### PR TITLE
Test: support of `#[kani::proof_for_contract]`

### DIFF
--- a/tests/proofs.rs
+++ b/tests/proofs.rs
@@ -16,6 +16,7 @@ fn test_proofs() -> eyre::Result<()> {
 
     expect![[r#"
         [
+            "tests/proofs/proofs_for_contract.rs",
             "tests/proofs/standard_proofs_with_contracts.rs",
             "tests/proofs/standard_proofs.rs",
             "tests/proofs/ad_hoc.rs",

--- a/tests/proofs/proofs_for_contract.rs
+++ b/tests/proofs/proofs_for_contract.rs
@@ -1,0 +1,32 @@
+#[cfg(kani)]
+mod verify {
+    #[kani::requires(a > 0)]
+    fn contract_requires(a: u8) {}
+
+    #[kani::proof_for_contract(contract_requires)]
+    fn single_contract_requires() {
+        contract_requires(0);
+    }
+
+    #[kani::ensures(|&ret| ret > 0)]
+    fn contract_ensures(a: u8) -> u8 {
+        a
+    }
+
+    #[kani::proof_for_contract(contract_ensures)]
+    fn single_with_contract_ensures() {
+        contract_ensures(0);
+    }
+
+    #[kani::requires(a > 0)]
+    #[kani::ensures(|&ret| ret > 0)]
+    fn contract(a: u8) -> u8 {
+        a
+    }
+
+    #[kani::proof_for_contract(contract)]
+    fn single_contract() {
+        let val = contract(1);
+        assert!(val > 0);
+    }
+}

--- a/tests/snapshots/proofs_for_contract.json
+++ b/tests/snapshots/proofs_for_contract.json
@@ -1,0 +1,3745 @@
+[
+  {
+    "hash": "1381134546671526262114770426830604814499",
+    "def_id": "DefId { id: 51, name: \"verify::single_contract\" }",
+    "file": "tests/proofs/proofs_for_contract.rs",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract\"]"
+    ],
+    "func": "fn single_contract() {\n        let val = contract(1);\n        assert!(val > 0);\n    }",
+    "callees": [
+      {
+        "def_id": "DefId { id: 270, name: \"kani::assert\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub const fn assert(cond: bool, msg: &'static str) {\n            let _ = cond;\n            let _ = msg;\n        }"
+      },
+      {
+        "def_id": "DefId { id: 52, name: \"kani::panic\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub const fn panic(message: &'static str) -> ! {\n            panic!(\"{}\", message)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub fn init_contracts() {}"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }",
+        "file": "library/core/src/array/mod.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::char_try_from_u32\" }",
+        "file": "library/core/src/char/convert.rs",
+        "func": "const fn char_try_from_u32(i: u32) -> Result<char, CharTryFromError> {\n    // This is an optimized version of the check\n    // (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF),\n    // which can also be written as\n    // i >= 0x110000 || (i >= 0xD800 && i < 0xE000).\n    //\n    // The XOR with 0xD800 permutes the ranges such that 0xD800..0xE000 is\n    // mapped to 0x0000..0x0800, while keeping all the high bits outside 0xFFFF the same.\n    // In particular, numbers >= 0x110000 stay in this range.\n    //\n    // Subtracting 0x800 causes 0x0000..0x0800 to wrap, meaning that a single\n    // unsigned comparison against 0x110000 - 0x800 will detect both the wrapped\n    // surrogate range as well as the numbers originally larger than 0x110000.\n    //\n    if (i ^ 0xD800).wrapping_sub(0x800) >= 0x110000 - 0x800 {\n        Err(CharTryFromError(()))\n    } else {\n        // SAFETY: checked that it's a legal unicode value\n        Ok(unsafe { transmute(i) })\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::char::convert::from_u32_unchecked\" }",
+        "file": "library/core/src/char/convert.rs",
+        "func": "pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {\n    // SAFETY: the caller must guarantee that `i` is a valid char value.\n    unsafe {\n        assert_unsafe_precondition!(\n            check_language_ub,\n            \"invalid value for `char`\",\n            (i: u32 = i) => char_try_from_u32(i).is_ok()\n        );\n        transmute(i)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }",
+        "file": "library/core/src/char/methods.rs",
+        "func": "pub const unsafe fn from_u32_unchecked(i: u32) -> char {\n        // SAFETY: the safety contract must be upheld by the caller.\n        unsafe { super::convert::from_u32_unchecked(i) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn lt(&self, other: &Self) -> bool { *self <  *other }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn lt(&self, other: &Self) -> bool { *self <  *other }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::cmp::Ord::min\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn min(self, other: Self) -> Self\n    where\n        Self: Sized,\n    {\n        if other < self { other } else { self }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"std::cmp::min\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "pub fn min<T: Ord>(v1: T, v2: T) -> T {\n    v1.min(v2)\n}"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"<T as std::convert::From<T>>::from\" }",
+        "file": "library/core/src/convert/mod.rs",
+        "func": "fn from(t: T) -> T {\n        t\n    }"
+      },
+      {
+        "def_id": "DefId { id: 75, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }",
+        "file": "library/core/src/convert/num.rs",
+        "func": "fn from(small: $Small) -> Self {\n                small as Self\n            }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"<str as std::fmt::Display>::fmt\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn fmt(&self, f: &mut Formatter<'_>) -> Result {\n        f.pad(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 63, name: \"<&T as std::fmt::Display>::fmt\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn fmt(&self, f: &mut Formatter<'_>) -> Result { $tr::fmt(&**self, f) }"
+      },
+      {
+        "def_id": "DefId { id: 115, name: \"core::fmt::PostPadding::new\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn new(fill: char, padding: u16) -> PostPadding {\n        PostPadding { fill, padding }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"std::fmt::FormattingOptions::get_align\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_align(&self) -> Option<Alignment> {\n        match self.flags & flags::ALIGN_BITS {\n            flags::ALIGN_LEFT => Some(Alignment::Left),\n            flags::ALIGN_RIGHT => Some(Alignment::Right),\n            flags::ALIGN_CENTER => Some(Alignment::Center),\n            _ => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::fmt::FormattingOptions::get_fill\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_fill(&self) -> char {\n        // SAFETY: We only ever put a valid `char` in the lower 21 bits of the flags field.\n        unsafe { char::from_u32_unchecked(self.flags & 0x1FFFFF) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::fmt::FormattingOptions::get_precision\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_precision(&self) -> Option<u16> {\n        if self.flags & flags::PRECISION_FLAG != 0 { Some(self.precision) } else { None }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"std::fmt::Arguments::<'a>::new_const\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn new_const<const N: usize>(pieces: &'a [&'static str; N]) -> Self {\n        const { assert!(N <= 1) };\n        Arguments { pieces, fmt: None, args: &[] }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"std::fmt::Arguments::<'a>::new_v1\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn new_v1<const P: usize, const A: usize>(\n        pieces: &'a [&'static str; P],\n        args: &'a [rt::Argument<'a>; A],\n    ) -> Arguments<'a> {\n        const { assert!(P >= A && P <= A + 1, \"invalid args\") }\n        Arguments { pieces, fmt: None, args }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 67, name: \"std::fmt::Formatter::<'a>::pad\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub fn pad(&mut self, s: &str) -> Result {\n        // Make sure there's a fast path up front.\n        if self.options.flags & (flags::WIDTH_FLAG | flags::PRECISION_FLAG) == 0 {\n            return self.buf.write_str(s);\n        }\n\n        // The `precision` field can be interpreted as a maximum width for the\n        // string being formatted.\n        let (s, char_count) = if let Some(max_char_count) = self.options.get_precision() {\n            let mut iter = s.char_indices();\n            let remaining = match iter.advance_by(usize::from(max_char_count)) {\n                Ok(()) => 0,\n                Err(remaining) => remaining.get(),\n            };\n            // SAFETY: The offset of `.char_indices()` is guaranteed to be\n            // in-bounds and between character boundaries.\n            let truncated = unsafe { s.get_unchecked(..iter.offset()) };\n            (truncated, usize::from(max_char_count) - remaining)\n        } else {\n            // Use the optimized char counting algorithm for the full string.\n            (s, s.chars().count())\n        };\n\n        // The `width` field is more of a minimum width parameter at this point.\n        if char_count < usize::from(self.options.width) {\n            // If we're under the minimum width, then fill up the minimum width\n            // with the specified string + some alignment.\n            let post_padding =\n                self.padding(self.options.width - char_count as u16, Alignment::Left)?;\n            self.buf.write_str(s)?;\n            post_padding.write(self)\n        } else {\n            // If we're over the minimum width or there is no minimum width, we\n            // can just emit the string.\n            self.buf.write_str(s)\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"std::fmt::Formatter::<'a>::padding\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub(crate) fn padding(\n        &mut self,\n        padding: u16,\n        default: Alignment,\n    ) -> result::Result<PostPadding, Error> {\n        let align = self.options.get_align().unwrap_or(default);\n        let fill = self.options.get_fill();\n\n        let padding_left = match align {\n            Alignment::Left => 0,\n            Alignment::Right => padding,\n            Alignment::Center => padding / 2,\n        };\n\n        for _ in 0..padding_left {\n            self.buf.write_char(fill)?;\n        }\n\n        Ok(PostPadding::new(fill, padding - padding_left))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::fmt::PostPadding::write\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub(crate) fn write(self, f: &mut Formatter<'_>) -> Result {\n        for _ in 0..self.padding {\n            f.buf.write_char(self.fill)?;\n        }\n        Ok(())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"core::fmt::rt::Argument::<'_>::new\" }",
+        "file": "library/core/src/fmt/rt.rs",
+        "func": "const fn new<'a, T>(x: &'a T, f: fn(&T, &mut Formatter<'_>) -> Result) -> Argument<'a> {\n        Argument {\n            // INVARIANT: this creates an `ArgumentType<'a>` from a `&'a T` and\n            // a `fn(&T, ...)`, so the invariant is maintained.\n            ty: ArgumentType::Placeholder {\n                value: NonNull::from_ref(x).cast(),\n                // SAFETY: function pointers always have the same layout.\n                formatter: unsafe { mem::transmute(f) },\n                _lifetime: PhantomData,\n            },\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"core::fmt::rt::Argument::<'_>::new_display\" }",
+        "file": "library/core/src/fmt/rt.rs",
+        "func": "pub fn new_display<T: Display>(x: &T) -> Argument<'_> {\n        Self::new(x, Display::fmt)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::hint::unreachable_unchecked\" }",
+        "file": "library/core/src/hint.rs",
+        "func": "pub const unsafe fn unreachable_unchecked() -> ! {\n    ub_checks::assert_unsafe_precondition!(\n        check_language_ub,\n        \"hint::unreachable_unchecked must never be reached\",\n        () => false\n    );\n    // SAFETY: the safety contract for `intrinsics::unreachable` must\n    // be upheld by the caller.\n    unsafe { intrinsics::unreachable() }\n}"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::intrinsics::cold_path\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "pub const fn cold_path() {}"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::intrinsics::unlikely\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "pub const fn unlikely(b: bool) -> bool {\n    if b {\n        cold_path();\n        true\n    } else {\n        false\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "fn count(self) -> usize {\n        #[inline]\n        fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {\n            move |x| predicate(&x) as usize\n        }\n\n        self.iter.map(to_usize(self.predicate)).sum()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {\n            move |x| predicate(&x) as usize\n        }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "move |x| predicate(&x) as usize"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"std::iter::Filter::<I, P>::new\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "pub(in crate::iter) fn new(iter: I, predicate: P) -> Filter<I, P> {\n        Filter { iter, predicate }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "fn fold<Acc, G>(self, init: Acc, g: G) -> Acc\n    where\n        G: FnMut(Acc, Self::Item) -> Acc,\n    {\n        self.iter.fold(init, map_fold(self.f, g))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"std::iter::adapters::map::map_fold\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "fn map_fold<T, B, Acc>(\n    mut f: impl FnMut(T) -> B,\n    mut g: impl FnMut(Acc, B) -> Acc,\n) -> impl FnMut(Acc, T) -> Acc {\n    move |acc, elt| g(acc, f(elt))\n}"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "move |acc, elt| g(acc, f(elt))"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"std::iter::Map::<I, F>::new\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "pub(in crate::iter) fn new(iter: I, f: F) -> Map<I, F> {\n        Map { iter, f }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn next(&mut self) -> Option<A> {\n        self.spec_next()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn next(&mut self) -> Option<A> {\n        self.spec_next()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn spec_next(&mut self) -> Option<T> {\n        if self.start < self.end {\n            let old = self.start;\n            // SAFETY: just checked precondition\n            self.start = unsafe { Step::forward_unchecked(old, 1) };\n            Some(old)\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn spec_next(&mut self) -> Option<T> {\n        if self.start < self.end {\n            let old = self.start;\n            // SAFETY: just checked precondition\n            self.start = unsafe { Step::forward_unchecked(old, 1) };\n            Some(old)\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"<u16 as std::iter::Step>::forward_unchecked\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "unsafe fn forward_unchecked(start: Self, n: usize) -> Self {\n            // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.\n            unsafe { start.unchecked_add(n as Self) }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"<usize as std::iter::Step>::forward_unchecked\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "unsafe fn forward_unchecked(start: Self, n: usize) -> Self {\n            // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.\n            unsafe { start.unchecked_add(n as Self) }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"<usize as std::iter::Sum>::sum\" }",
+        "file": "library/core/src/iter/traits/accum.rs",
+        "func": "fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {\n                iter.fold(\n                    $zero,\n                    #[rustc_inherit_overflow_checks]\n                    |a, b| a + b,\n                )\n            }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }",
+        "file": "library/core/src/iter/traits/accum.rs",
+        "func": "|a, b| a + b"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::iter::Iterator::advance_by\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {\n        for i in 0..n {\n            if self.next().is_none() {\n                // SAFETY: `i` is always less than `n`.\n                return Err(unsafe { NonZero::new_unchecked(n - i) });\n            }\n        }\n        Ok(())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::iter::Iterator::filter\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn filter<P>(self, predicate: P) -> Filter<Self, P>\n    where\n        Self: Sized,\n        P: FnMut(&Self::Item) -> bool,\n    {\n        Filter::new(self, predicate)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::iter::Iterator::map\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn map<B, F>(self, f: F) -> Map<Self, F>\n    where\n        Self: Sized,\n        F: FnMut(Self::Item) -> B,\n    {\n        Map::new(self, f)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::iter::Iterator::sum\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn sum<S>(self) -> S\n    where\n        Self: Sized,\n        S: Sum<Self::Item>,\n    {\n        Sum::sum(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 78, name: \"std::num::NonZero::<T>::get\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const fn get(self) -> T {\n        // Rustc can set range metadata only if it loads `self` from\n        // memory somewhere. If the value of `self` was from by-value argument\n        // of some not-inlined function, LLVM don't have range metadata\n        // to understand that the value cannot be zero.\n        //\n        // Using the transmute `assume`s the range at runtime.\n        //\n        // Even once LLVM supports `!range` metadata for function arguments\n        // (see <https://github.com/llvm/llvm-project/issues/76628>), this can't\n        // be `.0` because MCP#807 bans field-projecting into `scalar_valid_range`\n        // types, and it arguably wouldn't want to be anyway because if this is\n        // MIR-inlined, there's no opportunity to put that argument metadata anywhere.\n        //\n        // The good answer here will eventually be pattern types, which will hopefully\n        // allow it to go back to `.0`, maybe with a cast of some sort.\n        //\n        // SAFETY: `ZeroablePrimitive` guarantees that the size and bit validity\n        // of `.0` is such that this transmute is sound.\n        unsafe { intrinsics::transmute_unchecked(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"std::num::NonZero::<T>::new\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const fn new(n: T) -> Option<Self> {\n        // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has\n        //         the same layout and size as `T`, with `0` representing `None`.\n        unsafe { intrinsics::transmute_unchecked(n) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::num::NonZero::<T>::new_unchecked\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const unsafe fn new_unchecked(n: T) -> Self {\n        match Self::new(n) {\n            Some(n) => n,\n            None => {\n                // SAFETY: The caller guarantees that `n` is non-zero, so this is unreachable.\n                unsafe {\n                    ub_checks::assert_unsafe_precondition!(\n                        check_language_ub,\n                        \"NonZero::new_unchecked requires the argument to be non-zero\",\n                        () => false,\n                    );\n                    intrinsics::unreachable()\n                }\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::num::<impl usize>::count_ones\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn count_ones(self) -> u32 {\n            return intrinsics::ctpop(self);\n        }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"core::num::<impl usize>::is_power_of_two\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn is_power_of_two(self) -> bool {\n            self.count_ones() == 1\n        }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::overflowing_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"core::num::<impl usize>::overflowing_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::sub_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 214, name: \"core::num::<impl usize>::wrapping_mul\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn wrapping_mul(self, rhs: Self) -> Self {\n            intrinsics::wrapping_mul(self, rhs)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 132, name: \"core::num::<impl u32>::wrapping_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn wrapping_sub(self, rhs: Self) -> Self {\n            intrinsics::wrapping_sub(self, rhs)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"core::num::<impl u16>::unchecked_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_add cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_add(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_add(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::num::<impl usize>::unchecked_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_add cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_add(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_add(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"core::num::<impl usize>::unchecked_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_sub(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_sub cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_sub(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_sub(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/option.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Some(v) => ControlFlow::Continue(v),\n            None => ControlFlow::Break(None),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }",
+        "file": "library/core/src/option.rs",
+        "func": "fn from_residual(residual: Option<convert::Infallible>) -> Self {\n        match residual {\n            None => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::option::Option::<T>::is_none\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const fn is_none(&self) -> bool {\n        !self.is_some()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::option::Option::<T>::is_some\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const fn is_some(&self) -> bool {\n        matches!(*self, Some(_))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::option::Option::<T>::unwrap_unchecked\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const unsafe fn unwrap_unchecked(self) -> T {\n        match self {\n            Some(val) => val,\n            // SAFETY: the safety contract must be upheld by the caller.\n            None => unsafe { hint::unreachable_unchecked() },\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 254, name: \"std::option::Option::<T>::map\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub fn map<U, F>(self, f: F) -> Option<U>\n    where\n        F: FnOnce(T) -> U,\n    {\n        match self {\n            Some(x) => Some(f(x)),\n            None => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::option::Option::<T>::unwrap_or\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub fn unwrap_or(self, default: T) -> T {\n        match self {\n            Some(x) => x,\n            None => default,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"kani::panic::panic_cold_display\" }",
+        "file": "library/core/src/panic.rs",
+        "func": "const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {\n            $crate::panicking::panic_display(arg)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::panic::Location::<'a>::caller\" }",
+        "file": "library/core/src/panic/location.rs",
+        "func": "pub const fn caller() -> &'static Location<'static> {\n        crate::intrinsics::caller_location()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }",
+        "file": "library/core/src/panic/panic_info.rs",
+        "func": "pub(crate) fn new(\n        message: &'a fmt::Arguments<'a>,\n        location: &'a Location<'a>,\n        can_unwind: bool,\n        force_no_backtrace: bool,\n    ) -> Self {\n        PanicInfo { location, message, can_unwind, force_no_backtrace }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"core::panicking::panic\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic(expr: &'static str) -> ! {\n    // Use Arguments::new_const instead of format_args!(\"{expr}\") to potentially\n    // reduce size overhead. The format_args! macro uses str's Display trait to\n    // write expr, which calls Formatter::pad, which must accommodate string\n    // truncation and padding (even though none is used here). Using\n    // Arguments::new_const may allow the compiler to omit Formatter::pad from the\n    // output binary, saving up to a few kilobytes.\n    // However, this optimization only works for `'static` strings: `new_const` also makes this\n    // message return `Some` from `Arguments::as_str`, which means it can become part of the panic\n    // payload without any allocation or copying. Shorter-lived strings would become invalid as\n    // stack frames get popped during unwinding, and couldn't be directly referenced from the\n    // payload.\n    panic_fmt(fmt::Arguments::new_const(&[expr]));\n}"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"std::rt::panic_display\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_display<T: fmt::Display>(x: &T) -> ! {\n    panic_fmt(format_args!(\"{}\", *x));\n}"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::rt::panic_fmt\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {\n    if cfg!(feature = \"panic_immediate_abort\") {\n        super::intrinsics::abort()\n    }\n\n    // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call\n    // that gets resolved to the `#[panic_handler]` function.\n    unsafe extern \"Rust\" {\n        #[lang = \"panic_impl\"]\n        fn panic_impl(pi: &PanicInfo<'_>) -> !;\n    }\n\n    let pi = PanicInfo::new(\n        &fmt,\n        Location::caller(),\n        /* can_unwind */ true,\n        /* force_no_backtrace */ false,\n    );\n\n    // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.\n    unsafe { panic_impl(&pi) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"core::panicking::panic_nounwind\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_nounwind(expr: &'static str) -> ! {\n    panic_nounwind_fmt(fmt::Arguments::new_const(&[expr]), /* force_no_backtrace */ false);\n}"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"core::panicking::panic_nounwind_fmt\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: bool) -> ! {\n    const_eval_select!(\n        @capture { fmt: fmt::Arguments<'_>, force_no_backtrace: bool } -> !:\n        if const #[track_caller] {\n            // We don't unwind anyway at compile-time so we can call the regular `panic_fmt`.\n            panic_fmt(fmt)\n        } else #[track_caller] {\n            if cfg!(feature = \"panic_immediate_abort\") {\n                super::intrinsics::abort()\n            }\n\n            // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call\n            // that gets resolved to the `#[panic_handler]` function.\n            unsafe extern \"Rust\" {\n                #[lang = \"panic_impl\"]\n                fn panic_impl(pi: &PanicInfo<'_>) -> !;\n            }\n\n            // PanicInfo with the `can_unwind` flag set to false forces an abort.\n            let pi = PanicInfo::new(\n                &fmt,\n                Location::caller(),\n                /* can_unwind */ false,\n                force_no_backtrace,\n            );\n\n            // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.\n            unsafe { panic_impl(&pi) }\n        }\n    )\n}"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "const fn runtime_ptr_ge(this: *const (), origin: *const ()) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), origin: *const () } -> bool:\n                if const {\n                    true\n                } else {\n                    this >= origin\n                }\n            )\n        }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn as_ptr(self) -> *const T {\n        self as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn is_null(self) -> bool {\n        // Compare via a cast to a thin pointer, so fat pointers are only\n        // considering their \"data\" part for null-ness.\n        let ptr = self as *const u8;\n        const_eval_select!(\n            @capture { ptr: *const u8 } -> bool:\n            // This use of `const_raw_ptr_comparison` has been explicitly blessed by t-lang.\n            if const #[rustc_allow_const_fn_unstable(const_raw_ptr_comparison)] {\n                match (ptr).guaranteed_eq(null_mut()) {\n                    Some(res) => res,\n                    // To remain maximally convervative, we stop execution when we don't\n                    // know whether the pointer is null or not.\n                    // We can *not* return `false` here, that would be unsound in `NonNull::new`!\n                    None => panic!(\"null-ness of this pointer cannot be determined in const context\"),\n                }\n            } else {\n                ptr.addr() == 0\n            }\n        )\n    }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn len(self) -> usize {\n        metadata(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::add\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::add\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 188, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize\n    where\n        T: Sized,\n    {\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_ptr_ge(this: *const (), origin: *const ()) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), origin: *const () } -> bool:\n                if const {\n                    true\n                } else {\n                    this >= origin\n                }\n            )\n        }\n\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::offset_from_unsigned requires `self >= origin`\",\n            (\n                this: *const () = self as *const (),\n                origin: *const () = origin as *const (),\n            ) => runtime_ptr_ge(this, origin)\n        );\n\n        let pointee_size = size_of::<T>();\n        assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);\n        // SAFETY: the caller must uphold the safety contract for `ptr_offset_from_unsigned`.\n        unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn is_aligned_to(self, align: usize) -> bool {\n        if !align.is_power_of_two() {\n            panic!(\"is_aligned_to: align is not a power-of-two\");\n        }\n\n        self.addr() & (align - 1) == 0\n    }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {\n    ptr_metadata(ptr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::ptr::align_offset::mod_inv\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "const unsafe fn mod_inv(x: usize, m: usize) -> usize {\n        /// Multiplicative modular inverse table modulo 2⁴ = 16.\n        ///\n        /// Note, that this table does not contain values where inverse does not exist (i.e., for\n        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)\n        const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];\n        /// Modulo for which the `INV_TABLE_MOD_16` is intended.\n        const INV_TABLE_MOD: usize = 16;\n\n        // SAFETY: `m` is required to be a power-of-two, hence non-zero.\n        let m_minus_one = unsafe { unchecked_sub(m, 1) };\n        let mut inverse = INV_TABLE_MOD_16[(x & (INV_TABLE_MOD - 1)) >> 1] as usize;\n        let mut mod_gate = INV_TABLE_MOD;\n        // We iterate \"up\" using the following formula:\n        //\n        // $$ xy ≡ 1 (mod 2ⁿ) → xy (2 - xy) ≡ 1 (mod 2²ⁿ) $$\n        //\n        // This application needs to be applied at least until `2²ⁿ ≥ m`, at which point we can\n        // finally reduce the computation to our desired `m` by taking `inverse mod m`.\n        //\n        // This computation is `O(log log m)`, which is to say, that on 64-bit machines this loop\n        // will always finish in at most 4 iterations.\n        loop {\n            // y = y * (2 - xy) mod n\n            //\n            // Note, that we use wrapping operations here intentionally – the original formula\n            // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod\n            // usize::MAX` instead, because we take the result `mod n` at the end\n            // anyway.\n            if mod_gate >= m {\n                break;\n            }\n            inverse = wrapping_mul(inverse, wrapping_sub(2usize, wrapping_mul(x, inverse)));\n            let (new_gate, overflow) = mul_with_overflow(mod_gate, mod_gate);\n            if overflow {\n                break;\n            }\n            mod_gate = new_gate;\n        }\n        inverse & m_minus_one\n    }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"std::ptr::align_offset\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {\n    // FIXME(#75598): Direct use of these intrinsics improves codegen significantly at opt-level <=\n    // 1, where the method versions of these operations are not inlined.\n    use intrinsics::{\n        assume, cttz_nonzero, exact_div, mul_with_overflow, unchecked_rem, unchecked_shl,\n        unchecked_shr, unchecked_sub, wrapping_add, wrapping_mul, wrapping_sub,\n    };\n\n    /// Calculate multiplicative modular inverse of `x` modulo `m`.\n    ///\n    /// This implementation is tailored for `align_offset` and has following preconditions:\n    ///\n    /// * `m` is a power-of-two;\n    /// * `x < m`; (if `x ≥ m`, pass in `x % m` instead)\n    ///\n    /// Implementation of this function shall not panic. Ever.\n    #[inline]\n    const unsafe fn mod_inv(x: usize, m: usize) -> usize {\n        /// Multiplicative modular inverse table modulo 2⁴ = 16.\n        ///\n        /// Note, that this table does not contain values where inverse does not exist (i.e., for\n        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)\n        const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];\n        /// Modulo for which the `INV_TABLE_MOD_16` is intended.\n        const INV_TABLE_MOD: usize = 16;\n\n        // SAFETY: `m` is required to be a power-of-two, hence non-zero.\n        let m_minus_one = unsafe { unchecked_sub(m, 1) };\n        let mut inverse = INV_TABLE_MOD_16[(x & (INV_TABLE_MOD - 1)) >> 1] as usize;\n        let mut mod_gate = INV_TABLE_MOD;\n        // We iterate \"up\" using the following formula:\n        //\n        // $$ xy ≡ 1 (mod 2ⁿ) → xy (2 - xy) ≡ 1 (mod 2²ⁿ) $$\n        //\n        // This application needs to be applied at least until `2²ⁿ ≥ m`, at which point we can\n        // finally reduce the computation to our desired `m` by taking `inverse mod m`.\n        //\n        // This computation is `O(log log m)`, which is to say, that on 64-bit machines this loop\n        // will always finish in at most 4 iterations.\n        loop {\n            // y = y * (2 - xy) mod n\n            //\n            // Note, that we use wrapping operations here intentionally – the original formula\n            // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod\n            // usize::MAX` instead, because we take the result `mod n` at the end\n            // anyway.\n            if mod_gate >= m {\n                break;\n            }\n            inverse = wrapping_mul(inverse, wrapping_sub(2usize, wrapping_mul(x, inverse)));\n            let (new_gate, overflow) = mul_with_overflow(mod_gate, mod_gate);\n            if overflow {\n                break;\n            }\n            mod_gate = new_gate;\n        }\n        inverse & m_minus_one\n    }\n\n    let stride = size_of::<T>();\n\n    let addr: usize = p.addr();\n\n    // SAFETY: `a` is a power-of-two, therefore non-zero.\n    let a_minus_one = unsafe { unchecked_sub(a, 1) };\n\n    if stride == 0 {\n        // SPECIAL_CASE: handle 0-sized types. No matter how many times we step, the address will\n        // stay the same, so no offset will be able to align the pointer unless it is already\n        // aligned. This branch _will_ be optimized out as `stride` is known at compile-time.\n        let p_mod_a = addr & a_minus_one;\n        return if p_mod_a == 0 { 0 } else { usize::MAX };\n    }\n\n    // SAFETY: `stride == 0` case has been handled by the special case above.\n    let a_mod_stride = unsafe { unchecked_rem(a, stride) };\n    if a_mod_stride == 0 {\n        // SPECIAL_CASE: In cases where the `a` is divisible by `stride`, byte offset to align a\n        // pointer can be computed more simply through `-p (mod a)`. In the off-chance the byte\n        // offset is not a multiple of `stride`, the input pointer was misaligned and no pointer\n        // offset will be able to produce a `p` aligned to the specified `a`.\n        //\n        // The naive `-p (mod a)` equation inhibits LLVM's ability to select instructions\n        // like `lea`. We compute `(round_up_to_next_alignment(p, a) - p)` instead. This\n        // redistributes operations around the load-bearing, but pessimizing `and` instruction\n        // sufficiently for LLVM to be able to utilize the various optimizations it knows about.\n        //\n        // LLVM handles the branch here particularly nicely. If this branch needs to be evaluated\n        // at runtime, it will produce a mask `if addr_mod_stride == 0 { 0 } else { usize::MAX }`\n        // in a branch-free way and then bitwise-OR it with whatever result the `-p mod a`\n        // computation produces.\n\n        let aligned_address = wrapping_add(addr, a_minus_one) & wrapping_sub(0, a);\n        let byte_offset = wrapping_sub(aligned_address, addr);\n        // FIXME: Remove the assume after <https://github.com/llvm/llvm-project/issues/62502>\n        // SAFETY: Masking by `-a` can only affect the low bits, and thus cannot have reduced\n        // the value by more than `a-1`, so even though the intermediate values might have\n        // wrapped, the byte_offset is always in `[0, a)`.\n        unsafe { assume(byte_offset < a) };\n\n        // SAFETY: `stride == 0` case has been handled by the special case above.\n        let addr_mod_stride = unsafe { unchecked_rem(addr, stride) };\n\n        return if addr_mod_stride == 0 {\n            // SAFETY: `stride` is non-zero. This is guaranteed to divide exactly as well, because\n            // addr has been verified to be aligned to the original type’s alignment requirements.\n            unsafe { exact_div(byte_offset, stride) }\n        } else {\n            usize::MAX\n        };\n    }\n\n    // GENERAL_CASE: From here on we’re handling the very general case where `addr` may be\n    // misaligned, there isn’t an obvious relationship between `stride` and `a` that we can take an\n    // advantage of, etc. This case produces machine code that isn’t particularly high quality,\n    // compared to the special cases above. The code produced here is still within the realm of\n    // miracles, given the situations this case has to deal with.\n\n    // SAFETY: a is power-of-two hence non-zero. stride == 0 case is handled above.\n    // FIXME(const-hack) replace with min\n    let gcdpow = unsafe {\n        let x = cttz_nonzero(stride);\n        let y = cttz_nonzero(a);\n        if x < y { x } else { y }\n    };\n    // SAFETY: gcdpow has an upper-bound that’s at most the number of bits in a `usize`.\n    let gcd = unsafe { unchecked_shl(1usize, gcdpow) };\n    // SAFETY: gcd is always greater or equal to 1.\n    if addr & unsafe { unchecked_sub(gcd, 1) } == 0 {\n        // This branch solves for the following linear congruence equation:\n        //\n        // ` p + so = 0 mod a `\n        //\n        // `p` here is the pointer value, `s` - stride of `T`, `o` offset in `T`s, and `a` - the\n        // requested alignment.\n        //\n        // With `g = gcd(a, s)`, and the above condition asserting that `p` is also divisible by\n        // `g`, we can denote `a' = a/g`, `s' = s/g`, `p' = p/g`, then this becomes equivalent to:\n        //\n        // ` p' + s'o = 0 mod a' `\n        // ` o = (a' - (p' mod a')) * (s'^-1 mod a') `\n        //\n        // The first term is \"the relative alignment of `p` to `a`\" (divided by the `g`), the\n        // second term is \"how does incrementing `p` by `s` bytes change the relative alignment of\n        // `p`\" (again divided by `g`). Division by `g` is necessary to make the inverse well\n        // formed if `a` and `s` are not co-prime.\n        //\n        // Furthermore, the result produced by this solution is not \"minimal\", so it is necessary\n        // to take the result `o mod lcm(s, a)`. This `lcm(s, a)` is the same as `a'`.\n\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`.\n        let a2 = unsafe { unchecked_shr(a, gcdpow) };\n        // SAFETY: `a2` is non-zero. Shifting `a` by `gcdpow` cannot shift out any of the set bits\n        // in `a` (of which it has exactly one).\n        let a2minus1 = unsafe { unchecked_sub(a2, 1) };\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`.\n        let s2 = unsafe { unchecked_shr(stride & a_minus_one, gcdpow) };\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`. Furthermore, the subtraction cannot overflow, because `a2 = a >> gcdpow` will\n        // always be strictly greater than `(p % a) >> gcdpow`.\n        let minusp2 = unsafe { unchecked_sub(a2, unchecked_shr(addr & a_minus_one, gcdpow)) };\n        // SAFETY: `a2` is a power-of-two, as proven above. `s2` is strictly less than `a2`\n        // because `(s % a) >> gcdpow` is strictly less than `a >> gcdpow`.\n        return wrapping_mul(minusp2, unsafe { mod_inv(s2, a2) }) & a2minus1;\n    }\n\n    // Cannot be aligned at all.\n    usize::MAX\n}"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `sub_ptr`.\n        unsafe { (self as *const T).offset_from_unsigned(origin) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, subtracted: NonNull<T>) -> usize\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `sub_ptr`.\n        unsafe { self.as_ptr().offset_from_unsigned(subtracted.as_ptr()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Ok(v) => ControlFlow::Continue(v),\n            Err(e) => ControlFlow::Break(Err(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Ok(v) => ControlFlow::Continue(v),\n            Err(e) => ControlFlow::Break(Err(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn from_residual(residual: Result<convert::Infallible, E>) -> Self {\n        match residual {\n            Err(e) => Err(From::from(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn from_residual(residual: Result<convert::Infallible, E>) -> Self {\n        match residual {\n            Err(e) => Err(From::from(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::result::Result::<T, E>::is_ok\" }",
+        "file": "library/core/src/result.rs",
+        "func": "pub const fn is_ok(&self) -> bool {\n        matches!(*self, Ok(_))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn next(&mut self) -> Option<&'a [T]> {\n        if self.v.is_empty() {\n            None\n        } else {\n            let chunksz = cmp::min(self.v.len(), self.chunk_size);\n            let (fst, snd) = self.v.split_at(chunksz);\n            self.v = snd;\n            Some(fst)\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::Iter::<'a, T>::as_slice\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub fn as_slice(&self) -> &'a [T] {\n        self.make_slice()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::Chunks::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T], size: usize) -> Self {\n        Self { v: slice, chunk_size: size }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn fold<B, F>(self, init: B, mut f: F) -> B\n                where\n                    F: FnMut(B, Self::Item) -> B,\n            {\n                // this implementation consists of the following optimizations compared to the\n                // default implementation:\n                // - do-while loop, as is llvm's preferred loop shape,\n                //   see https://releases.llvm.org/16.0.0/docs/LoopTerminology.html#more-canonical-loops\n                // - bumps an index instead of a pointer since the latter case inhibits\n                //   some optimizations, see #111603\n                // - avoids Option wrapping/matching\n                if is_empty!(self) {\n                    return init;\n                }\n                let mut acc = init;\n                let mut i = 0;\n                let len = len!(self);\n                loop {\n                    // SAFETY: the loop iterates `i in 0..len`, which always is in bounds of\n                    // the slice allocation\n                    acc = f(acc, unsafe { & $( $mut_ )? *self.ptr.add(i).as_ptr() });\n                    // SAFETY: `i` can't overflow since it'll only reach usize::MAX if the\n                    // slice had that length, in which case we'll break out of the loop\n                    // after the increment\n                    i = unsafe { i.unchecked_add(1) };\n                    if i == len {\n                        break;\n                    }\n                }\n                acc\n            }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn len(&self) -> usize {\n                len!(self)\n            }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"std::slice::Iter::<'a, T>::make_slice\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn make_slice(&self) -> &'a [T] {\n                // SAFETY: the iterator was created from a slice with pointer\n                // `self.ptr` and length `len!(self)`. This guarantees that all\n                // the prerequisites for `from_raw_parts` are fulfilled.\n                unsafe { from_raw_parts(self.ptr.as_ptr(), len!(self)) }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 236, name: \"core::slice::<impl [T]>::align_to_offsets\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "fn align_to_offsets<U>(&self) -> (usize, usize) {\n        // What we gonna do about `rest` is figure out what multiple of `U`s we can put in a\n        // lowest number of `T`s. And how many `T`s we need for each such \"multiple\".\n        //\n        // Consider for example T=u8 U=u16. Then we can put 1 U in 2 Ts. Simple. Now, consider\n        // for example a case where size_of::<T> = 16, size_of::<U> = 24. We can put 2 Us in\n        // place of every 3 Ts in the `rest` slice. A bit more complicated.\n        //\n        // Formula to calculate this is:\n        //\n        // Us = lcm(size_of::<T>, size_of::<U>) / size_of::<U>\n        // Ts = lcm(size_of::<T>, size_of::<U>) / size_of::<T>\n        //\n        // Expanded and simplified:\n        //\n        // Us = size_of::<T> / gcd(size_of::<T>, size_of::<U>)\n        // Ts = size_of::<U> / gcd(size_of::<T>, size_of::<U>)\n        //\n        // Luckily since all this is constant-evaluated... performance here matters not!\n        const fn gcd(a: usize, b: usize) -> usize {\n            if b == 0 { a } else { gcd(b, a % b) }\n        }\n\n        // Explicitly wrap the function call in a const block so it gets\n        // constant-evaluated even in debug mode.\n        let gcd: usize = const { gcd(size_of::<T>(), size_of::<U>()) };\n        let ts: usize = size_of::<U>() / gcd;\n        let us: usize = size_of::<T>() / gcd;\n\n        // Armed with this knowledge, we can find how many `U`s we can fit!\n        let us_len = self.len() / ts * us;\n        // And how many `T`s will be in the trailing slice!\n        let ts_len = self.len() % ts;\n        (us_len, ts_len)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::slice::<impl [T]>::as_chunks\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_chunks<const N: usize>(&self) -> (&[[T; N]], &[T]) {\n        assert!(N != 0, \"chunk size must be non-zero\");\n        let len_rounded_down = self.len() / N * N;\n        // SAFETY: The rounded-down value is always the same or smaller than the\n        // original length, and thus must be in-bounds of the slice.\n        let (multiple_of_n, remainder) = unsafe { self.split_at_unchecked(len_rounded_down) };\n        // SAFETY: We already panicked for zero, and ensured by construction\n        // that the length of the subslice is a multiple of N.\n        let array_slice = unsafe { multiple_of_n.as_chunks_unchecked() };\n        (array_slice, remainder)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"core::slice::<impl [T]>::as_ptr\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_ptr(&self) -> *const T {\n        self as *const [T] as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"core::slice::<impl [T]>::as_ptr\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_ptr(&self) -> *const T {\n        self as *const [T] as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::chunks\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn chunks(&self, chunk_size: usize) -> Chunks<'_, T> {\n        assert!(chunk_size != 0, \"chunk size must be non-zero\");\n        Chunks::new(self, chunk_size)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"core::slice::<impl [T]>::is_empty\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn is_empty(&self) -> bool {\n        self.len() == 0\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"core::slice::<impl [T]>::split_at\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {\n        match self.split_at_checked(mid) {\n            Some(pair) => pair,\n            None => panic!(\"mid > len\"),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"core::slice::<impl [T]>::split_at\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {\n        match self.split_at_checked(mid) {\n            Some(pair) => pair,\n            None => panic!(\"mid > len\"),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"core::slice::<impl [T]>::split_at_checked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {\n        if mid <= self.len() {\n            // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which\n            // fulfills the requirements of `split_at_unchecked`.\n            Some(unsafe { self.split_at_unchecked(mid) })\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"core::slice::<impl [T]>::split_at_checked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {\n        if mid <= self.len() {\n            // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which\n            // fulfills the requirements of `split_at_unchecked`.\n            Some(unsafe { self.split_at_unchecked(mid) })\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {\n        assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks\",\n            (n: usize = N, len: usize = self.len()) => n != 0 && len % n == 0,\n        );\n        // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length\n        let new_len = unsafe { exact_div(self.len(), N) };\n        // SAFETY: We cast a slice of `new_len * N` elements into\n        // a slice of `new_len` many `N` elements chunks.\n        unsafe { from_raw_parts(self.as_ptr().cast(), new_len) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"core::slice::<impl [T]>::split_at_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {\n        // FIXME(const-hack): the const function `from_raw_parts` is used to make this\n        // function const; previously the implementation used\n        // `(self.get_unchecked(..mid), self.get_unchecked(mid..))`\n\n        let len = self.len();\n        let ptr = self.as_ptr();\n\n        assert_unsafe_precondition!(\n            check_library_ub,\n            \"slice::split_at_unchecked requires the index to be within the slice\",\n            (mid: usize = mid, len: usize = len) => mid <= len,\n        );\n\n        // SAFETY: Caller has to check that `0 <= mid <= self.len()`\n        unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"core::slice::<impl [T]>::split_at_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {\n        // FIXME(const-hack): the const function `from_raw_parts` is used to make this\n        // function const; previously the implementation used\n        // `(self.get_unchecked(..mid), self.get_unchecked(mid..))`\n\n        let len = self.len();\n        let ptr = self.as_ptr();\n\n        assert_unsafe_precondition!(\n            check_library_ub,\n            \"slice::split_at_unchecked requires the index to be within the slice\",\n            (mid: usize = mid, len: usize = len) => mid <= len,\n        );\n\n        // SAFETY: Caller has to check that `0 <= mid <= self.len()`\n        unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 197, name: \"core::slice::<impl [T]>::align_to\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub unsafe fn align_to<U>(&self) -> (&[T], &[U], &[T]) {\n        // Note that most of this function will be constant-evaluated,\n        if U::IS_ZST || T::IS_ZST {\n            // handle ZSTs specially, which is – don't handle them at all.\n            return (self, &[], &[]);\n        }\n\n        // First, find at what point do we split between the first and 2nd slice. Easy with\n        // ptr.align_offset.\n        let ptr = self.as_ptr();\n        // SAFETY: See the `align_to_mut` method for the detailed safety comment.\n        let offset = unsafe { crate::ptr::align_offset(ptr, align_of::<U>()) };\n        if offset > self.len() {\n            (self, &[], &[])\n        } else {\n            let (left, rest) = self.split_at(offset);\n            let (us_len, ts_len) = rest.align_to_offsets::<U>();\n            // Inform Miri that we want to consider the \"middle\" pointer to be suitably aligned.\n            #[cfg(miri)]\n            crate::intrinsics::miri_promise_symbolic_alignment(\n                rest.as_ptr().cast(),\n                align_of::<U>(),\n            );\n            // SAFETY: now `rest` is definitely aligned, so `from_raw_parts` below is okay,\n            // since the caller guarantees that we can transmute `T` to `U` safely.\n            unsafe {\n                (\n                    left,\n                    from_raw_parts(rest.as_ptr() as *const U, us_len),\n                    from_raw_parts(rest.as_ptr().add(rest.len() - ts_len), ts_len),\n                )\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"std::str::from_utf8_unchecked\" }",
+        "file": "library/core/src/str/converts.rs",
+        "func": "pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {\n    // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.\n    // Also relies on `&str` and `&[u8]` having the same layout.\n    unsafe { mem::transmute(v) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"core::str::count::char_count_general_case\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn char_count_general_case(s: &[u8]) -> usize {\n    s.iter().filter(|&&byte| !super::validations::utf8_is_cont_byte(byte)).count()\n}"
+      },
+      {
+        "def_id": "DefId { id: 207, name: \"core::str::count::contains_non_continuation_byte\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn contains_non_continuation_byte(w: usize) -> usize {\n    const LSB: usize = usize::repeat_u8(0x01);\n    ((!w >> 7) | (w >> 6)) & LSB\n}"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"core::str::count::do_count_chars\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn do_count_chars(s: &str) -> usize {\n    // For correctness, `CHUNK_SIZE` must be:\n    //\n    // - Less than or equal to 255, otherwise we'll overflow bytes in `counts`.\n    // - A multiple of `UNROLL_INNER`, otherwise our `break` inside the\n    //   `body.chunks(CHUNK_SIZE)` loop is incorrect.\n    //\n    // For performance, `CHUNK_SIZE` should be:\n    // - Relatively cheap to `/` against (so some simple sum of powers of two).\n    // - Large enough to avoid paying for the cost of the `sum_bytes_in_usize`\n    //   too often.\n    const CHUNK_SIZE: usize = 192;\n\n    // Check the properties of `CHUNK_SIZE` and `UNROLL_INNER` that are required\n    // for correctness.\n    const _: () = assert!(CHUNK_SIZE < 256);\n    const _: () = assert!(CHUNK_SIZE % UNROLL_INNER == 0);\n\n    // SAFETY: transmuting `[u8]` to `[usize]` is safe except for size\n    // differences which are handled by `align_to`.\n    let (head, body, tail) = unsafe { s.as_bytes().align_to::<usize>() };\n\n    // This should be quite rare, and basically exists to handle the degenerate\n    // cases where align_to fails (as well as miri under symbolic alignment\n    // mode).\n    //\n    // The `unlikely` helps discourage LLVM from inlining the body, which is\n    // nice, as we would rather not mark the `char_count_general_case` function\n    // as cold.\n    if unlikely(body.is_empty() || head.len() > USIZE_SIZE || tail.len() > USIZE_SIZE) {\n        return char_count_general_case(s.as_bytes());\n    }\n\n    let mut total = char_count_general_case(head) + char_count_general_case(tail);\n    // Split `body` into `CHUNK_SIZE` chunks to reduce the frequency with which\n    // we call `sum_bytes_in_usize`.\n    for chunk in body.chunks(CHUNK_SIZE) {\n        // We accumulate intermediate sums in `counts`, where each byte contains\n        // a subset of the sum of this chunk, like a `[u8; size_of::<usize>()]`.\n        let mut counts = 0;\n\n        let (unrolled_chunks, remainder) = chunk.as_chunks::<UNROLL_INNER>();\n        for unrolled in unrolled_chunks {\n            for &word in unrolled {\n                // Because `CHUNK_SIZE` is < 256, this addition can't cause the\n                // count in any of the bytes to overflow into a subsequent byte.\n                counts += contains_non_continuation_byte(word);\n            }\n        }\n\n        // Sum the values in `counts` (which, again, is conceptually a `[u8;\n        // size_of::<usize>()]`), and accumulate the result into `total`.\n        total += sum_bytes_in_usize(counts);\n\n        // If there's any data in `remainder`, then handle it. This will only\n        // happen for the last `chunk` in `body.chunks()` (because `CHUNK_SIZE`\n        // is divisible by `UNROLL_INNER`), so we explicitly break at the end\n        // (which seems to help LLVM out).\n        if !remainder.is_empty() {\n            // Accumulate all the data in the remainder.\n            let mut counts = 0;\n            for &word in remainder {\n                counts += contains_non_continuation_byte(word);\n            }\n            total += sum_bytes_in_usize(counts);\n            break;\n        }\n    }\n    total\n}"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"core::str::count::sum_bytes_in_usize\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn sum_bytes_in_usize(values: usize) -> usize {\n    const LSB_SHORTS: usize = usize::repeat_u16(0x0001);\n    const SKIP_BYTES: usize = usize::repeat_u16(0x00ff);\n\n    let pair_sum: usize = (values & SKIP_BYTES) + ((values >> 8) & SKIP_BYTES);\n    pair_sum.wrapping_mul(LSB_SHORTS) >> ((USIZE_SIZE - 2) * 8)\n}"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"core::str::count::count_chars\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "pub(super) fn count_chars(s: &str) -> usize {\n    if cfg!(feature = \"optimize_for_size\") || s.len() < USIZE_SIZE * UNROLL_INNER {\n        // Avoid entering the optimized implementation for strings where the\n        // difference is not likely to matter, or where it might even be slower.\n        // That said, a ton of thought was not spent on the particular threshold\n        // here, beyond \"this value seems to make sense\".\n        char_count_general_case(s.as_bytes())\n    } else {\n        do_count_chars(s)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::str::count::char_count_general_case::{closure#0}\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "|&&byte| !super::validations::utf8_is_cont_byte(byte)"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn count(self) -> usize {\n        super::count::count_chars(self.as_str())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn next(&mut self) -> Option<(usize, char)> {\n        let pre_len = self.iter.iter.len();\n        match self.iter.next() {\n            None => None,\n            Some(ch) => {\n                let index = self.front_offset;\n                let len = self.iter.iter.len();\n                self.front_offset += pre_len - len;\n                Some((index, ch))\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn next(&mut self) -> Option<char> {\n        // SAFETY: `str` invariant says `self.iter` is a valid UTF-8 string and\n        // the resulting `ch` is a valid Unicode Scalar Value.\n        unsafe { next_code_point(&mut self.iter).map(|ch| char::from_u32_unchecked(ch)) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::str::Chars::<'a>::as_str\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "pub fn as_str(&self) -> &'a str {\n        // SAFETY: `Chars` is only made from a str, which guarantees the iter is valid UTF-8.\n        unsafe { from_utf8_unchecked(self.iter.as_slice()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::str::CharIndices::<'a>::offset\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "pub fn offset(&self) -> usize {\n        self.front_offset\n    }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "|ch| char::from_u32_unchecked(ch)"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"core::str::<impl str>::as_bytes\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub const fn as_bytes(&self) -> &[u8] {\n        // SAFETY: const sound because we transmute two types with the same layout\n        unsafe { mem::transmute(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"core::str::<impl str>::len\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub const fn len(&self) -> usize {\n        self.as_bytes().len()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::char_indices\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub fn char_indices(&self) -> CharIndices<'_> {\n        CharIndices { front_offset: 0, iter: self.chars() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 81, name: \"core::str::<impl str>::chars\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub fn chars(&self) -> Chars<'_> {\n        Chars { iter: self.as_bytes().iter() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"core::str::<impl str>::get_unchecked\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub unsafe fn get_unchecked<I: SliceIndex<str>>(&self, i: I) -> &I::Output {\n        // SAFETY: the caller must uphold the safety contract for `get_unchecked`;\n        // the slice is dereferenceable because `self` is a safe reference.\n        // The returned pointer is safe because impls of `SliceIndex` have to guarantee that it is.\n        unsafe { &*i.get_unchecked(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 144, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }",
+        "file": "library/core/src/str/traits.rs",
+        "func": "unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {\n        // SAFETY: the caller has to uphold the safety contract for `get_unchecked`.\n        unsafe { (0..self.end).get_unchecked(slice) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }",
+        "file": "library/core/src/str/traits.rs",
+        "func": "unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {\n        let slice = slice as *const [u8];\n\n        assert_unsafe_precondition!(\n            // We'd like to check that the bounds are on char boundaries,\n            // but there's not really a way to do so without reading\n            // behind the pointer, which has aliasing implications.\n            // It's also not possible to move this check up to\n            // `str::get_unchecked` without adding a special function\n            // to `SliceIndex` just for this.\n            check_library_ub,\n            \"str::get_unchecked requires that the range is within the string slice\",\n            (\n                start: usize = self.start,\n                end: usize = self.end,\n                len: usize = slice.len()\n            ) => end >= start && end <= len,\n        );\n\n        // SAFETY: the caller guarantees that `self` is in bounds of `slice`\n        // which satisfies all the conditions for `add`.\n        unsafe {\n            let new_len = unchecked_sub(self.end, self.start);\n            ptr::slice_from_raw_parts(slice.as_ptr().add(self.start), new_len) as *const str\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"core::str::validations::utf8_acc_cont_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "const fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {\n    (ch << 6) | (byte & CONT_MASK) as u32\n}"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::str::validations::utf8_first_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "const fn utf8_first_byte(byte: u8, width: u32) -> u32 {\n    (byte & (0x7F >> width)) as u32\n}"
+      },
+      {
+        "def_id": "DefId { id: 253, name: \"core::str::validations::next_code_point\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "pub unsafe fn next_code_point<'a, I: Iterator<Item = &'a u8>>(bytes: &mut I) -> Option<u32> {\n    // Decode UTF-8\n    let x = *bytes.next()?;\n    if x < 128 {\n        return Some(x as u32);\n    }\n\n    // Multibyte case follows\n    // Decode from a byte combination out of: [[[x y] z] w]\n    // NOTE: Performance is sensitive to the exact formulation here\n    let init = utf8_first_byte(x, 2);\n    // SAFETY: `bytes` produces an UTF-8-like string,\n    // so the iterator must produce a value here.\n    let y = unsafe { *bytes.next().unwrap_unchecked() };\n    let mut ch = utf8_acc_cont_byte(init, y);\n    if x >= 0xE0 {\n        // [[x y z] w] case\n        // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid\n        // SAFETY: `bytes` produces an UTF-8-like string,\n        // so the iterator must produce a value here.\n        let z = unsafe { *bytes.next().unwrap_unchecked() };\n        let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);\n        ch = init << 12 | y_z;\n        if x >= 0xF0 {\n            // [x y z w] case\n            // use only the lower 3 bits of `init`\n            // SAFETY: `bytes` produces an UTF-8-like string,\n            // so the iterator must produce a value here.\n            let w = unsafe { *bytes.next().unwrap_unchecked() };\n            ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);\n        }\n    }\n\n    Some(ch)\n}"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"core::str::validations::utf8_is_cont_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "pub(super) const fn utf8_is_cont_byte(byte: u8) -> bool {\n    (byte as i8) < -64\n}"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"std::hint::unreachable_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"std::slice::from_raw_parts::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"core::ub_checks::check_language_ub\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn check_language_ub() -> bool {\n    // Only used for UB checks so we may const_eval_select.\n    intrinsics::ub_checks()\n        && const_eval_select!(\n            @capture { } -> bool:\n            if const {\n                // Always disable UB checks.\n                false\n            } else {\n                // Disable UB checks in Miri.\n                !cfg!(miri)\n            }\n        )\n}"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"core::ub_checks::is_valid_allocation_size\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn is_valid_allocation_size(size: usize, len: usize) -> bool {\n    let max_len = if size == 0 { usize::MAX } else { isize::MAX as usize / size };\n    len <= max_len\n}"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn maybe_is_aligned_and_not_null(\n    ptr: *const (),\n    align: usize,\n    is_zst: bool,\n) -> bool {\n    // This is just for safety checks so we can const_eval_select.\n    const_eval_select!(\n        @capture { ptr: *const (), align: usize, is_zst: bool } -> bool:\n        if const {\n            is_zst || !ptr.is_null()\n        } else {\n            ptr.is_aligned_to(align) && (is_zst || !ptr.is_null())\n        }\n    )\n}"
+      },
+      {
+        "def_id": "DefId { id: 33, name: \"verify::contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"verify::contract::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_contract_mode\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"verify::contract::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"verify::contract::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"verify::contract::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      }
+    ]
+  },
+  {
+    "hash": "1506927763362499646810711906139081353864",
+    "def_id": "DefId { id: 13, name: \"verify::single_contract_requires\" }",
+    "file": "tests/proofs/proofs_for_contract.rs",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract_requires\"]"
+    ],
+    "func": "fn single_contract_requires() {\n        contract_requires(0);\n    }",
+    "callees": [
+      {
+        "def_id": "DefId { id: 52, name: \"kani::panic\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub const fn panic(message: &'static str) -> ! {\n            panic!(\"{}\", message)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub fn init_contracts() {}"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }",
+        "file": "library/core/src/array/mod.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::char_try_from_u32\" }",
+        "file": "library/core/src/char/convert.rs",
+        "func": "const fn char_try_from_u32(i: u32) -> Result<char, CharTryFromError> {\n    // This is an optimized version of the check\n    // (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF),\n    // which can also be written as\n    // i >= 0x110000 || (i >= 0xD800 && i < 0xE000).\n    //\n    // The XOR with 0xD800 permutes the ranges such that 0xD800..0xE000 is\n    // mapped to 0x0000..0x0800, while keeping all the high bits outside 0xFFFF the same.\n    // In particular, numbers >= 0x110000 stay in this range.\n    //\n    // Subtracting 0x800 causes 0x0000..0x0800 to wrap, meaning that a single\n    // unsigned comparison against 0x110000 - 0x800 will detect both the wrapped\n    // surrogate range as well as the numbers originally larger than 0x110000.\n    //\n    if (i ^ 0xD800).wrapping_sub(0x800) >= 0x110000 - 0x800 {\n        Err(CharTryFromError(()))\n    } else {\n        // SAFETY: checked that it's a legal unicode value\n        Ok(unsafe { transmute(i) })\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::char::convert::from_u32_unchecked\" }",
+        "file": "library/core/src/char/convert.rs",
+        "func": "pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {\n    // SAFETY: the caller must guarantee that `i` is a valid char value.\n    unsafe {\n        assert_unsafe_precondition!(\n            check_language_ub,\n            \"invalid value for `char`\",\n            (i: u32 = i) => char_try_from_u32(i).is_ok()\n        );\n        transmute(i)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }",
+        "file": "library/core/src/char/methods.rs",
+        "func": "pub const unsafe fn from_u32_unchecked(i: u32) -> char {\n        // SAFETY: the safety contract must be upheld by the caller.\n        unsafe { super::convert::from_u32_unchecked(i) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn lt(&self, other: &Self) -> bool { *self <  *other }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn lt(&self, other: &Self) -> bool { *self <  *other }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::cmp::Ord::min\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn min(self, other: Self) -> Self\n    where\n        Self: Sized,\n    {\n        if other < self { other } else { self }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"std::cmp::min\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "pub fn min<T: Ord>(v1: T, v2: T) -> T {\n    v1.min(v2)\n}"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"<T as std::convert::From<T>>::from\" }",
+        "file": "library/core/src/convert/mod.rs",
+        "func": "fn from(t: T) -> T {\n        t\n    }"
+      },
+      {
+        "def_id": "DefId { id: 75, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }",
+        "file": "library/core/src/convert/num.rs",
+        "func": "fn from(small: $Small) -> Self {\n                small as Self\n            }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"<str as std::fmt::Display>::fmt\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn fmt(&self, f: &mut Formatter<'_>) -> Result {\n        f.pad(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 63, name: \"<&T as std::fmt::Display>::fmt\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn fmt(&self, f: &mut Formatter<'_>) -> Result { $tr::fmt(&**self, f) }"
+      },
+      {
+        "def_id": "DefId { id: 115, name: \"core::fmt::PostPadding::new\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn new(fill: char, padding: u16) -> PostPadding {\n        PostPadding { fill, padding }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"std::fmt::FormattingOptions::get_align\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_align(&self) -> Option<Alignment> {\n        match self.flags & flags::ALIGN_BITS {\n            flags::ALIGN_LEFT => Some(Alignment::Left),\n            flags::ALIGN_RIGHT => Some(Alignment::Right),\n            flags::ALIGN_CENTER => Some(Alignment::Center),\n            _ => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::fmt::FormattingOptions::get_fill\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_fill(&self) -> char {\n        // SAFETY: We only ever put a valid `char` in the lower 21 bits of the flags field.\n        unsafe { char::from_u32_unchecked(self.flags & 0x1FFFFF) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::fmt::FormattingOptions::get_precision\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_precision(&self) -> Option<u16> {\n        if self.flags & flags::PRECISION_FLAG != 0 { Some(self.precision) } else { None }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"std::fmt::Arguments::<'a>::new_const\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn new_const<const N: usize>(pieces: &'a [&'static str; N]) -> Self {\n        const { assert!(N <= 1) };\n        Arguments { pieces, fmt: None, args: &[] }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"std::fmt::Arguments::<'a>::new_v1\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn new_v1<const P: usize, const A: usize>(\n        pieces: &'a [&'static str; P],\n        args: &'a [rt::Argument<'a>; A],\n    ) -> Arguments<'a> {\n        const { assert!(P >= A && P <= A + 1, \"invalid args\") }\n        Arguments { pieces, fmt: None, args }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 67, name: \"std::fmt::Formatter::<'a>::pad\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub fn pad(&mut self, s: &str) -> Result {\n        // Make sure there's a fast path up front.\n        if self.options.flags & (flags::WIDTH_FLAG | flags::PRECISION_FLAG) == 0 {\n            return self.buf.write_str(s);\n        }\n\n        // The `precision` field can be interpreted as a maximum width for the\n        // string being formatted.\n        let (s, char_count) = if let Some(max_char_count) = self.options.get_precision() {\n            let mut iter = s.char_indices();\n            let remaining = match iter.advance_by(usize::from(max_char_count)) {\n                Ok(()) => 0,\n                Err(remaining) => remaining.get(),\n            };\n            // SAFETY: The offset of `.char_indices()` is guaranteed to be\n            // in-bounds and between character boundaries.\n            let truncated = unsafe { s.get_unchecked(..iter.offset()) };\n            (truncated, usize::from(max_char_count) - remaining)\n        } else {\n            // Use the optimized char counting algorithm for the full string.\n            (s, s.chars().count())\n        };\n\n        // The `width` field is more of a minimum width parameter at this point.\n        if char_count < usize::from(self.options.width) {\n            // If we're under the minimum width, then fill up the minimum width\n            // with the specified string + some alignment.\n            let post_padding =\n                self.padding(self.options.width - char_count as u16, Alignment::Left)?;\n            self.buf.write_str(s)?;\n            post_padding.write(self)\n        } else {\n            // If we're over the minimum width or there is no minimum width, we\n            // can just emit the string.\n            self.buf.write_str(s)\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"std::fmt::Formatter::<'a>::padding\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub(crate) fn padding(\n        &mut self,\n        padding: u16,\n        default: Alignment,\n    ) -> result::Result<PostPadding, Error> {\n        let align = self.options.get_align().unwrap_or(default);\n        let fill = self.options.get_fill();\n\n        let padding_left = match align {\n            Alignment::Left => 0,\n            Alignment::Right => padding,\n            Alignment::Center => padding / 2,\n        };\n\n        for _ in 0..padding_left {\n            self.buf.write_char(fill)?;\n        }\n\n        Ok(PostPadding::new(fill, padding - padding_left))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::fmt::PostPadding::write\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub(crate) fn write(self, f: &mut Formatter<'_>) -> Result {\n        for _ in 0..self.padding {\n            f.buf.write_char(self.fill)?;\n        }\n        Ok(())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"core::fmt::rt::Argument::<'_>::new\" }",
+        "file": "library/core/src/fmt/rt.rs",
+        "func": "const fn new<'a, T>(x: &'a T, f: fn(&T, &mut Formatter<'_>) -> Result) -> Argument<'a> {\n        Argument {\n            // INVARIANT: this creates an `ArgumentType<'a>` from a `&'a T` and\n            // a `fn(&T, ...)`, so the invariant is maintained.\n            ty: ArgumentType::Placeholder {\n                value: NonNull::from_ref(x).cast(),\n                // SAFETY: function pointers always have the same layout.\n                formatter: unsafe { mem::transmute(f) },\n                _lifetime: PhantomData,\n            },\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"core::fmt::rt::Argument::<'_>::new_display\" }",
+        "file": "library/core/src/fmt/rt.rs",
+        "func": "pub fn new_display<T: Display>(x: &T) -> Argument<'_> {\n        Self::new(x, Display::fmt)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::hint::unreachable_unchecked\" }",
+        "file": "library/core/src/hint.rs",
+        "func": "pub const unsafe fn unreachable_unchecked() -> ! {\n    ub_checks::assert_unsafe_precondition!(\n        check_language_ub,\n        \"hint::unreachable_unchecked must never be reached\",\n        () => false\n    );\n    // SAFETY: the safety contract for `intrinsics::unreachable` must\n    // be upheld by the caller.\n    unsafe { intrinsics::unreachable() }\n}"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::intrinsics::cold_path\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "pub const fn cold_path() {}"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::intrinsics::unlikely\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "pub const fn unlikely(b: bool) -> bool {\n    if b {\n        cold_path();\n        true\n    } else {\n        false\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "fn count(self) -> usize {\n        #[inline]\n        fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {\n            move |x| predicate(&x) as usize\n        }\n\n        self.iter.map(to_usize(self.predicate)).sum()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {\n            move |x| predicate(&x) as usize\n        }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "move |x| predicate(&x) as usize"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"std::iter::Filter::<I, P>::new\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "pub(in crate::iter) fn new(iter: I, predicate: P) -> Filter<I, P> {\n        Filter { iter, predicate }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "fn fold<Acc, G>(self, init: Acc, g: G) -> Acc\n    where\n        G: FnMut(Acc, Self::Item) -> Acc,\n    {\n        self.iter.fold(init, map_fold(self.f, g))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"std::iter::adapters::map::map_fold\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "fn map_fold<T, B, Acc>(\n    mut f: impl FnMut(T) -> B,\n    mut g: impl FnMut(Acc, B) -> Acc,\n) -> impl FnMut(Acc, T) -> Acc {\n    move |acc, elt| g(acc, f(elt))\n}"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "move |acc, elt| g(acc, f(elt))"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"std::iter::Map::<I, F>::new\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "pub(in crate::iter) fn new(iter: I, f: F) -> Map<I, F> {\n        Map { iter, f }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn next(&mut self) -> Option<A> {\n        self.spec_next()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn next(&mut self) -> Option<A> {\n        self.spec_next()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn spec_next(&mut self) -> Option<T> {\n        if self.start < self.end {\n            let old = self.start;\n            // SAFETY: just checked precondition\n            self.start = unsafe { Step::forward_unchecked(old, 1) };\n            Some(old)\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn spec_next(&mut self) -> Option<T> {\n        if self.start < self.end {\n            let old = self.start;\n            // SAFETY: just checked precondition\n            self.start = unsafe { Step::forward_unchecked(old, 1) };\n            Some(old)\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"<u16 as std::iter::Step>::forward_unchecked\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "unsafe fn forward_unchecked(start: Self, n: usize) -> Self {\n            // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.\n            unsafe { start.unchecked_add(n as Self) }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"<usize as std::iter::Step>::forward_unchecked\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "unsafe fn forward_unchecked(start: Self, n: usize) -> Self {\n            // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.\n            unsafe { start.unchecked_add(n as Self) }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"<usize as std::iter::Sum>::sum\" }",
+        "file": "library/core/src/iter/traits/accum.rs",
+        "func": "fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {\n                iter.fold(\n                    $zero,\n                    #[rustc_inherit_overflow_checks]\n                    |a, b| a + b,\n                )\n            }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }",
+        "file": "library/core/src/iter/traits/accum.rs",
+        "func": "|a, b| a + b"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::iter::Iterator::advance_by\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {\n        for i in 0..n {\n            if self.next().is_none() {\n                // SAFETY: `i` is always less than `n`.\n                return Err(unsafe { NonZero::new_unchecked(n - i) });\n            }\n        }\n        Ok(())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::iter::Iterator::filter\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn filter<P>(self, predicate: P) -> Filter<Self, P>\n    where\n        Self: Sized,\n        P: FnMut(&Self::Item) -> bool,\n    {\n        Filter::new(self, predicate)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::iter::Iterator::map\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn map<B, F>(self, f: F) -> Map<Self, F>\n    where\n        Self: Sized,\n        F: FnMut(Self::Item) -> B,\n    {\n        Map::new(self, f)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::iter::Iterator::sum\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn sum<S>(self) -> S\n    where\n        Self: Sized,\n        S: Sum<Self::Item>,\n    {\n        Sum::sum(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 78, name: \"std::num::NonZero::<T>::get\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const fn get(self) -> T {\n        // Rustc can set range metadata only if it loads `self` from\n        // memory somewhere. If the value of `self` was from by-value argument\n        // of some not-inlined function, LLVM don't have range metadata\n        // to understand that the value cannot be zero.\n        //\n        // Using the transmute `assume`s the range at runtime.\n        //\n        // Even once LLVM supports `!range` metadata for function arguments\n        // (see <https://github.com/llvm/llvm-project/issues/76628>), this can't\n        // be `.0` because MCP#807 bans field-projecting into `scalar_valid_range`\n        // types, and it arguably wouldn't want to be anyway because if this is\n        // MIR-inlined, there's no opportunity to put that argument metadata anywhere.\n        //\n        // The good answer here will eventually be pattern types, which will hopefully\n        // allow it to go back to `.0`, maybe with a cast of some sort.\n        //\n        // SAFETY: `ZeroablePrimitive` guarantees that the size and bit validity\n        // of `.0` is such that this transmute is sound.\n        unsafe { intrinsics::transmute_unchecked(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"std::num::NonZero::<T>::new\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const fn new(n: T) -> Option<Self> {\n        // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has\n        //         the same layout and size as `T`, with `0` representing `None`.\n        unsafe { intrinsics::transmute_unchecked(n) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::num::NonZero::<T>::new_unchecked\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const unsafe fn new_unchecked(n: T) -> Self {\n        match Self::new(n) {\n            Some(n) => n,\n            None => {\n                // SAFETY: The caller guarantees that `n` is non-zero, so this is unreachable.\n                unsafe {\n                    ub_checks::assert_unsafe_precondition!(\n                        check_language_ub,\n                        \"NonZero::new_unchecked requires the argument to be non-zero\",\n                        () => false,\n                    );\n                    intrinsics::unreachable()\n                }\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::num::<impl usize>::count_ones\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn count_ones(self) -> u32 {\n            return intrinsics::ctpop(self);\n        }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"core::num::<impl usize>::is_power_of_two\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn is_power_of_two(self) -> bool {\n            self.count_ones() == 1\n        }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::overflowing_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"core::num::<impl usize>::overflowing_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::sub_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 214, name: \"core::num::<impl usize>::wrapping_mul\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn wrapping_mul(self, rhs: Self) -> Self {\n            intrinsics::wrapping_mul(self, rhs)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 132, name: \"core::num::<impl u32>::wrapping_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn wrapping_sub(self, rhs: Self) -> Self {\n            intrinsics::wrapping_sub(self, rhs)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"core::num::<impl u16>::unchecked_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_add cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_add(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_add(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::num::<impl usize>::unchecked_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_add cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_add(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_add(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"core::num::<impl usize>::unchecked_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_sub(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_sub cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_sub(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_sub(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/option.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Some(v) => ControlFlow::Continue(v),\n            None => ControlFlow::Break(None),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }",
+        "file": "library/core/src/option.rs",
+        "func": "fn from_residual(residual: Option<convert::Infallible>) -> Self {\n        match residual {\n            None => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::option::Option::<T>::is_none\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const fn is_none(&self) -> bool {\n        !self.is_some()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::option::Option::<T>::is_some\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const fn is_some(&self) -> bool {\n        matches!(*self, Some(_))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::option::Option::<T>::unwrap_unchecked\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const unsafe fn unwrap_unchecked(self) -> T {\n        match self {\n            Some(val) => val,\n            // SAFETY: the safety contract must be upheld by the caller.\n            None => unsafe { hint::unreachable_unchecked() },\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 254, name: \"std::option::Option::<T>::map\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub fn map<U, F>(self, f: F) -> Option<U>\n    where\n        F: FnOnce(T) -> U,\n    {\n        match self {\n            Some(x) => Some(f(x)),\n            None => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::option::Option::<T>::unwrap_or\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub fn unwrap_or(self, default: T) -> T {\n        match self {\n            Some(x) => x,\n            None => default,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"kani::panic::panic_cold_display\" }",
+        "file": "library/core/src/panic.rs",
+        "func": "const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {\n            $crate::panicking::panic_display(arg)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::panic::Location::<'a>::caller\" }",
+        "file": "library/core/src/panic/location.rs",
+        "func": "pub const fn caller() -> &'static Location<'static> {\n        crate::intrinsics::caller_location()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }",
+        "file": "library/core/src/panic/panic_info.rs",
+        "func": "pub(crate) fn new(\n        message: &'a fmt::Arguments<'a>,\n        location: &'a Location<'a>,\n        can_unwind: bool,\n        force_no_backtrace: bool,\n    ) -> Self {\n        PanicInfo { location, message, can_unwind, force_no_backtrace }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"core::panicking::panic\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic(expr: &'static str) -> ! {\n    // Use Arguments::new_const instead of format_args!(\"{expr}\") to potentially\n    // reduce size overhead. The format_args! macro uses str's Display trait to\n    // write expr, which calls Formatter::pad, which must accommodate string\n    // truncation and padding (even though none is used here). Using\n    // Arguments::new_const may allow the compiler to omit Formatter::pad from the\n    // output binary, saving up to a few kilobytes.\n    // However, this optimization only works for `'static` strings: `new_const` also makes this\n    // message return `Some` from `Arguments::as_str`, which means it can become part of the panic\n    // payload without any allocation or copying. Shorter-lived strings would become invalid as\n    // stack frames get popped during unwinding, and couldn't be directly referenced from the\n    // payload.\n    panic_fmt(fmt::Arguments::new_const(&[expr]));\n}"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"std::rt::panic_display\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_display<T: fmt::Display>(x: &T) -> ! {\n    panic_fmt(format_args!(\"{}\", *x));\n}"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::rt::panic_fmt\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {\n    if cfg!(feature = \"panic_immediate_abort\") {\n        super::intrinsics::abort()\n    }\n\n    // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call\n    // that gets resolved to the `#[panic_handler]` function.\n    unsafe extern \"Rust\" {\n        #[lang = \"panic_impl\"]\n        fn panic_impl(pi: &PanicInfo<'_>) -> !;\n    }\n\n    let pi = PanicInfo::new(\n        &fmt,\n        Location::caller(),\n        /* can_unwind */ true,\n        /* force_no_backtrace */ false,\n    );\n\n    // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.\n    unsafe { panic_impl(&pi) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"core::panicking::panic_nounwind\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_nounwind(expr: &'static str) -> ! {\n    panic_nounwind_fmt(fmt::Arguments::new_const(&[expr]), /* force_no_backtrace */ false);\n}"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"core::panicking::panic_nounwind_fmt\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: bool) -> ! {\n    const_eval_select!(\n        @capture { fmt: fmt::Arguments<'_>, force_no_backtrace: bool } -> !:\n        if const #[track_caller] {\n            // We don't unwind anyway at compile-time so we can call the regular `panic_fmt`.\n            panic_fmt(fmt)\n        } else #[track_caller] {\n            if cfg!(feature = \"panic_immediate_abort\") {\n                super::intrinsics::abort()\n            }\n\n            // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call\n            // that gets resolved to the `#[panic_handler]` function.\n            unsafe extern \"Rust\" {\n                #[lang = \"panic_impl\"]\n                fn panic_impl(pi: &PanicInfo<'_>) -> !;\n            }\n\n            // PanicInfo with the `can_unwind` flag set to false forces an abort.\n            let pi = PanicInfo::new(\n                &fmt,\n                Location::caller(),\n                /* can_unwind */ false,\n                force_no_backtrace,\n            );\n\n            // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.\n            unsafe { panic_impl(&pi) }\n        }\n    )\n}"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "const fn runtime_ptr_ge(this: *const (), origin: *const ()) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), origin: *const () } -> bool:\n                if const {\n                    true\n                } else {\n                    this >= origin\n                }\n            )\n        }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn as_ptr(self) -> *const T {\n        self as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn is_null(self) -> bool {\n        // Compare via a cast to a thin pointer, so fat pointers are only\n        // considering their \"data\" part for null-ness.\n        let ptr = self as *const u8;\n        const_eval_select!(\n            @capture { ptr: *const u8 } -> bool:\n            // This use of `const_raw_ptr_comparison` has been explicitly blessed by t-lang.\n            if const #[rustc_allow_const_fn_unstable(const_raw_ptr_comparison)] {\n                match (ptr).guaranteed_eq(null_mut()) {\n                    Some(res) => res,\n                    // To remain maximally convervative, we stop execution when we don't\n                    // know whether the pointer is null or not.\n                    // We can *not* return `false` here, that would be unsound in `NonNull::new`!\n                    None => panic!(\"null-ness of this pointer cannot be determined in const context\"),\n                }\n            } else {\n                ptr.addr() == 0\n            }\n        )\n    }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn len(self) -> usize {\n        metadata(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::add\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::add\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 188, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize\n    where\n        T: Sized,\n    {\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_ptr_ge(this: *const (), origin: *const ()) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), origin: *const () } -> bool:\n                if const {\n                    true\n                } else {\n                    this >= origin\n                }\n            )\n        }\n\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::offset_from_unsigned requires `self >= origin`\",\n            (\n                this: *const () = self as *const (),\n                origin: *const () = origin as *const (),\n            ) => runtime_ptr_ge(this, origin)\n        );\n\n        let pointee_size = size_of::<T>();\n        assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);\n        // SAFETY: the caller must uphold the safety contract for `ptr_offset_from_unsigned`.\n        unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn is_aligned_to(self, align: usize) -> bool {\n        if !align.is_power_of_two() {\n            panic!(\"is_aligned_to: align is not a power-of-two\");\n        }\n\n        self.addr() & (align - 1) == 0\n    }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {\n    ptr_metadata(ptr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::ptr::align_offset::mod_inv\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "const unsafe fn mod_inv(x: usize, m: usize) -> usize {\n        /// Multiplicative modular inverse table modulo 2⁴ = 16.\n        ///\n        /// Note, that this table does not contain values where inverse does not exist (i.e., for\n        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)\n        const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];\n        /// Modulo for which the `INV_TABLE_MOD_16` is intended.\n        const INV_TABLE_MOD: usize = 16;\n\n        // SAFETY: `m` is required to be a power-of-two, hence non-zero.\n        let m_minus_one = unsafe { unchecked_sub(m, 1) };\n        let mut inverse = INV_TABLE_MOD_16[(x & (INV_TABLE_MOD - 1)) >> 1] as usize;\n        let mut mod_gate = INV_TABLE_MOD;\n        // We iterate \"up\" using the following formula:\n        //\n        // $$ xy ≡ 1 (mod 2ⁿ) → xy (2 - xy) ≡ 1 (mod 2²ⁿ) $$\n        //\n        // This application needs to be applied at least until `2²ⁿ ≥ m`, at which point we can\n        // finally reduce the computation to our desired `m` by taking `inverse mod m`.\n        //\n        // This computation is `O(log log m)`, which is to say, that on 64-bit machines this loop\n        // will always finish in at most 4 iterations.\n        loop {\n            // y = y * (2 - xy) mod n\n            //\n            // Note, that we use wrapping operations here intentionally – the original formula\n            // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod\n            // usize::MAX` instead, because we take the result `mod n` at the end\n            // anyway.\n            if mod_gate >= m {\n                break;\n            }\n            inverse = wrapping_mul(inverse, wrapping_sub(2usize, wrapping_mul(x, inverse)));\n            let (new_gate, overflow) = mul_with_overflow(mod_gate, mod_gate);\n            if overflow {\n                break;\n            }\n            mod_gate = new_gate;\n        }\n        inverse & m_minus_one\n    }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"std::ptr::align_offset\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {\n    // FIXME(#75598): Direct use of these intrinsics improves codegen significantly at opt-level <=\n    // 1, where the method versions of these operations are not inlined.\n    use intrinsics::{\n        assume, cttz_nonzero, exact_div, mul_with_overflow, unchecked_rem, unchecked_shl,\n        unchecked_shr, unchecked_sub, wrapping_add, wrapping_mul, wrapping_sub,\n    };\n\n    /// Calculate multiplicative modular inverse of `x` modulo `m`.\n    ///\n    /// This implementation is tailored for `align_offset` and has following preconditions:\n    ///\n    /// * `m` is a power-of-two;\n    /// * `x < m`; (if `x ≥ m`, pass in `x % m` instead)\n    ///\n    /// Implementation of this function shall not panic. Ever.\n    #[inline]\n    const unsafe fn mod_inv(x: usize, m: usize) -> usize {\n        /// Multiplicative modular inverse table modulo 2⁴ = 16.\n        ///\n        /// Note, that this table does not contain values where inverse does not exist (i.e., for\n        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)\n        const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];\n        /// Modulo for which the `INV_TABLE_MOD_16` is intended.\n        const INV_TABLE_MOD: usize = 16;\n\n        // SAFETY: `m` is required to be a power-of-two, hence non-zero.\n        let m_minus_one = unsafe { unchecked_sub(m, 1) };\n        let mut inverse = INV_TABLE_MOD_16[(x & (INV_TABLE_MOD - 1)) >> 1] as usize;\n        let mut mod_gate = INV_TABLE_MOD;\n        // We iterate \"up\" using the following formula:\n        //\n        // $$ xy ≡ 1 (mod 2ⁿ) → xy (2 - xy) ≡ 1 (mod 2²ⁿ) $$\n        //\n        // This application needs to be applied at least until `2²ⁿ ≥ m`, at which point we can\n        // finally reduce the computation to our desired `m` by taking `inverse mod m`.\n        //\n        // This computation is `O(log log m)`, which is to say, that on 64-bit machines this loop\n        // will always finish in at most 4 iterations.\n        loop {\n            // y = y * (2 - xy) mod n\n            //\n            // Note, that we use wrapping operations here intentionally – the original formula\n            // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod\n            // usize::MAX` instead, because we take the result `mod n` at the end\n            // anyway.\n            if mod_gate >= m {\n                break;\n            }\n            inverse = wrapping_mul(inverse, wrapping_sub(2usize, wrapping_mul(x, inverse)));\n            let (new_gate, overflow) = mul_with_overflow(mod_gate, mod_gate);\n            if overflow {\n                break;\n            }\n            mod_gate = new_gate;\n        }\n        inverse & m_minus_one\n    }\n\n    let stride = size_of::<T>();\n\n    let addr: usize = p.addr();\n\n    // SAFETY: `a` is a power-of-two, therefore non-zero.\n    let a_minus_one = unsafe { unchecked_sub(a, 1) };\n\n    if stride == 0 {\n        // SPECIAL_CASE: handle 0-sized types. No matter how many times we step, the address will\n        // stay the same, so no offset will be able to align the pointer unless it is already\n        // aligned. This branch _will_ be optimized out as `stride` is known at compile-time.\n        let p_mod_a = addr & a_minus_one;\n        return if p_mod_a == 0 { 0 } else { usize::MAX };\n    }\n\n    // SAFETY: `stride == 0` case has been handled by the special case above.\n    let a_mod_stride = unsafe { unchecked_rem(a, stride) };\n    if a_mod_stride == 0 {\n        // SPECIAL_CASE: In cases where the `a` is divisible by `stride`, byte offset to align a\n        // pointer can be computed more simply through `-p (mod a)`. In the off-chance the byte\n        // offset is not a multiple of `stride`, the input pointer was misaligned and no pointer\n        // offset will be able to produce a `p` aligned to the specified `a`.\n        //\n        // The naive `-p (mod a)` equation inhibits LLVM's ability to select instructions\n        // like `lea`. We compute `(round_up_to_next_alignment(p, a) - p)` instead. This\n        // redistributes operations around the load-bearing, but pessimizing `and` instruction\n        // sufficiently for LLVM to be able to utilize the various optimizations it knows about.\n        //\n        // LLVM handles the branch here particularly nicely. If this branch needs to be evaluated\n        // at runtime, it will produce a mask `if addr_mod_stride == 0 { 0 } else { usize::MAX }`\n        // in a branch-free way and then bitwise-OR it with whatever result the `-p mod a`\n        // computation produces.\n\n        let aligned_address = wrapping_add(addr, a_minus_one) & wrapping_sub(0, a);\n        let byte_offset = wrapping_sub(aligned_address, addr);\n        // FIXME: Remove the assume after <https://github.com/llvm/llvm-project/issues/62502>\n        // SAFETY: Masking by `-a` can only affect the low bits, and thus cannot have reduced\n        // the value by more than `a-1`, so even though the intermediate values might have\n        // wrapped, the byte_offset is always in `[0, a)`.\n        unsafe { assume(byte_offset < a) };\n\n        // SAFETY: `stride == 0` case has been handled by the special case above.\n        let addr_mod_stride = unsafe { unchecked_rem(addr, stride) };\n\n        return if addr_mod_stride == 0 {\n            // SAFETY: `stride` is non-zero. This is guaranteed to divide exactly as well, because\n            // addr has been verified to be aligned to the original type’s alignment requirements.\n            unsafe { exact_div(byte_offset, stride) }\n        } else {\n            usize::MAX\n        };\n    }\n\n    // GENERAL_CASE: From here on we’re handling the very general case where `addr` may be\n    // misaligned, there isn’t an obvious relationship between `stride` and `a` that we can take an\n    // advantage of, etc. This case produces machine code that isn’t particularly high quality,\n    // compared to the special cases above. The code produced here is still within the realm of\n    // miracles, given the situations this case has to deal with.\n\n    // SAFETY: a is power-of-two hence non-zero. stride == 0 case is handled above.\n    // FIXME(const-hack) replace with min\n    let gcdpow = unsafe {\n        let x = cttz_nonzero(stride);\n        let y = cttz_nonzero(a);\n        if x < y { x } else { y }\n    };\n    // SAFETY: gcdpow has an upper-bound that’s at most the number of bits in a `usize`.\n    let gcd = unsafe { unchecked_shl(1usize, gcdpow) };\n    // SAFETY: gcd is always greater or equal to 1.\n    if addr & unsafe { unchecked_sub(gcd, 1) } == 0 {\n        // This branch solves for the following linear congruence equation:\n        //\n        // ` p + so = 0 mod a `\n        //\n        // `p` here is the pointer value, `s` - stride of `T`, `o` offset in `T`s, and `a` - the\n        // requested alignment.\n        //\n        // With `g = gcd(a, s)`, and the above condition asserting that `p` is also divisible by\n        // `g`, we can denote `a' = a/g`, `s' = s/g`, `p' = p/g`, then this becomes equivalent to:\n        //\n        // ` p' + s'o = 0 mod a' `\n        // ` o = (a' - (p' mod a')) * (s'^-1 mod a') `\n        //\n        // The first term is \"the relative alignment of `p` to `a`\" (divided by the `g`), the\n        // second term is \"how does incrementing `p` by `s` bytes change the relative alignment of\n        // `p`\" (again divided by `g`). Division by `g` is necessary to make the inverse well\n        // formed if `a` and `s` are not co-prime.\n        //\n        // Furthermore, the result produced by this solution is not \"minimal\", so it is necessary\n        // to take the result `o mod lcm(s, a)`. This `lcm(s, a)` is the same as `a'`.\n\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`.\n        let a2 = unsafe { unchecked_shr(a, gcdpow) };\n        // SAFETY: `a2` is non-zero. Shifting `a` by `gcdpow` cannot shift out any of the set bits\n        // in `a` (of which it has exactly one).\n        let a2minus1 = unsafe { unchecked_sub(a2, 1) };\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`.\n        let s2 = unsafe { unchecked_shr(stride & a_minus_one, gcdpow) };\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`. Furthermore, the subtraction cannot overflow, because `a2 = a >> gcdpow` will\n        // always be strictly greater than `(p % a) >> gcdpow`.\n        let minusp2 = unsafe { unchecked_sub(a2, unchecked_shr(addr & a_minus_one, gcdpow)) };\n        // SAFETY: `a2` is a power-of-two, as proven above. `s2` is strictly less than `a2`\n        // because `(s % a) >> gcdpow` is strictly less than `a >> gcdpow`.\n        return wrapping_mul(minusp2, unsafe { mod_inv(s2, a2) }) & a2minus1;\n    }\n\n    // Cannot be aligned at all.\n    usize::MAX\n}"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `sub_ptr`.\n        unsafe { (self as *const T).offset_from_unsigned(origin) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, subtracted: NonNull<T>) -> usize\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `sub_ptr`.\n        unsafe { self.as_ptr().offset_from_unsigned(subtracted.as_ptr()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Ok(v) => ControlFlow::Continue(v),\n            Err(e) => ControlFlow::Break(Err(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Ok(v) => ControlFlow::Continue(v),\n            Err(e) => ControlFlow::Break(Err(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn from_residual(residual: Result<convert::Infallible, E>) -> Self {\n        match residual {\n            Err(e) => Err(From::from(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn from_residual(residual: Result<convert::Infallible, E>) -> Self {\n        match residual {\n            Err(e) => Err(From::from(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::result::Result::<T, E>::is_ok\" }",
+        "file": "library/core/src/result.rs",
+        "func": "pub const fn is_ok(&self) -> bool {\n        matches!(*self, Ok(_))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn next(&mut self) -> Option<&'a [T]> {\n        if self.v.is_empty() {\n            None\n        } else {\n            let chunksz = cmp::min(self.v.len(), self.chunk_size);\n            let (fst, snd) = self.v.split_at(chunksz);\n            self.v = snd;\n            Some(fst)\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::Iter::<'a, T>::as_slice\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub fn as_slice(&self) -> &'a [T] {\n        self.make_slice()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::Chunks::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T], size: usize) -> Self {\n        Self { v: slice, chunk_size: size }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn fold<B, F>(self, init: B, mut f: F) -> B\n                where\n                    F: FnMut(B, Self::Item) -> B,\n            {\n                // this implementation consists of the following optimizations compared to the\n                // default implementation:\n                // - do-while loop, as is llvm's preferred loop shape,\n                //   see https://releases.llvm.org/16.0.0/docs/LoopTerminology.html#more-canonical-loops\n                // - bumps an index instead of a pointer since the latter case inhibits\n                //   some optimizations, see #111603\n                // - avoids Option wrapping/matching\n                if is_empty!(self) {\n                    return init;\n                }\n                let mut acc = init;\n                let mut i = 0;\n                let len = len!(self);\n                loop {\n                    // SAFETY: the loop iterates `i in 0..len`, which always is in bounds of\n                    // the slice allocation\n                    acc = f(acc, unsafe { & $( $mut_ )? *self.ptr.add(i).as_ptr() });\n                    // SAFETY: `i` can't overflow since it'll only reach usize::MAX if the\n                    // slice had that length, in which case we'll break out of the loop\n                    // after the increment\n                    i = unsafe { i.unchecked_add(1) };\n                    if i == len {\n                        break;\n                    }\n                }\n                acc\n            }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn len(&self) -> usize {\n                len!(self)\n            }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"std::slice::Iter::<'a, T>::make_slice\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn make_slice(&self) -> &'a [T] {\n                // SAFETY: the iterator was created from a slice with pointer\n                // `self.ptr` and length `len!(self)`. This guarantees that all\n                // the prerequisites for `from_raw_parts` are fulfilled.\n                unsafe { from_raw_parts(self.ptr.as_ptr(), len!(self)) }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 236, name: \"core::slice::<impl [T]>::align_to_offsets\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "fn align_to_offsets<U>(&self) -> (usize, usize) {\n        // What we gonna do about `rest` is figure out what multiple of `U`s we can put in a\n        // lowest number of `T`s. And how many `T`s we need for each such \"multiple\".\n        //\n        // Consider for example T=u8 U=u16. Then we can put 1 U in 2 Ts. Simple. Now, consider\n        // for example a case where size_of::<T> = 16, size_of::<U> = 24. We can put 2 Us in\n        // place of every 3 Ts in the `rest` slice. A bit more complicated.\n        //\n        // Formula to calculate this is:\n        //\n        // Us = lcm(size_of::<T>, size_of::<U>) / size_of::<U>\n        // Ts = lcm(size_of::<T>, size_of::<U>) / size_of::<T>\n        //\n        // Expanded and simplified:\n        //\n        // Us = size_of::<T> / gcd(size_of::<T>, size_of::<U>)\n        // Ts = size_of::<U> / gcd(size_of::<T>, size_of::<U>)\n        //\n        // Luckily since all this is constant-evaluated... performance here matters not!\n        const fn gcd(a: usize, b: usize) -> usize {\n            if b == 0 { a } else { gcd(b, a % b) }\n        }\n\n        // Explicitly wrap the function call in a const block so it gets\n        // constant-evaluated even in debug mode.\n        let gcd: usize = const { gcd(size_of::<T>(), size_of::<U>()) };\n        let ts: usize = size_of::<U>() / gcd;\n        let us: usize = size_of::<T>() / gcd;\n\n        // Armed with this knowledge, we can find how many `U`s we can fit!\n        let us_len = self.len() / ts * us;\n        // And how many `T`s will be in the trailing slice!\n        let ts_len = self.len() % ts;\n        (us_len, ts_len)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::slice::<impl [T]>::as_chunks\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_chunks<const N: usize>(&self) -> (&[[T; N]], &[T]) {\n        assert!(N != 0, \"chunk size must be non-zero\");\n        let len_rounded_down = self.len() / N * N;\n        // SAFETY: The rounded-down value is always the same or smaller than the\n        // original length, and thus must be in-bounds of the slice.\n        let (multiple_of_n, remainder) = unsafe { self.split_at_unchecked(len_rounded_down) };\n        // SAFETY: We already panicked for zero, and ensured by construction\n        // that the length of the subslice is a multiple of N.\n        let array_slice = unsafe { multiple_of_n.as_chunks_unchecked() };\n        (array_slice, remainder)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"core::slice::<impl [T]>::as_ptr\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_ptr(&self) -> *const T {\n        self as *const [T] as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"core::slice::<impl [T]>::as_ptr\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_ptr(&self) -> *const T {\n        self as *const [T] as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::chunks\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn chunks(&self, chunk_size: usize) -> Chunks<'_, T> {\n        assert!(chunk_size != 0, \"chunk size must be non-zero\");\n        Chunks::new(self, chunk_size)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"core::slice::<impl [T]>::is_empty\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn is_empty(&self) -> bool {\n        self.len() == 0\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"core::slice::<impl [T]>::split_at\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {\n        match self.split_at_checked(mid) {\n            Some(pair) => pair,\n            None => panic!(\"mid > len\"),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"core::slice::<impl [T]>::split_at\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {\n        match self.split_at_checked(mid) {\n            Some(pair) => pair,\n            None => panic!(\"mid > len\"),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"core::slice::<impl [T]>::split_at_checked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {\n        if mid <= self.len() {\n            // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which\n            // fulfills the requirements of `split_at_unchecked`.\n            Some(unsafe { self.split_at_unchecked(mid) })\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"core::slice::<impl [T]>::split_at_checked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {\n        if mid <= self.len() {\n            // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which\n            // fulfills the requirements of `split_at_unchecked`.\n            Some(unsafe { self.split_at_unchecked(mid) })\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {\n        assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks\",\n            (n: usize = N, len: usize = self.len()) => n != 0 && len % n == 0,\n        );\n        // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length\n        let new_len = unsafe { exact_div(self.len(), N) };\n        // SAFETY: We cast a slice of `new_len * N` elements into\n        // a slice of `new_len` many `N` elements chunks.\n        unsafe { from_raw_parts(self.as_ptr().cast(), new_len) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"core::slice::<impl [T]>::split_at_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {\n        // FIXME(const-hack): the const function `from_raw_parts` is used to make this\n        // function const; previously the implementation used\n        // `(self.get_unchecked(..mid), self.get_unchecked(mid..))`\n\n        let len = self.len();\n        let ptr = self.as_ptr();\n\n        assert_unsafe_precondition!(\n            check_library_ub,\n            \"slice::split_at_unchecked requires the index to be within the slice\",\n            (mid: usize = mid, len: usize = len) => mid <= len,\n        );\n\n        // SAFETY: Caller has to check that `0 <= mid <= self.len()`\n        unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"core::slice::<impl [T]>::split_at_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {\n        // FIXME(const-hack): the const function `from_raw_parts` is used to make this\n        // function const; previously the implementation used\n        // `(self.get_unchecked(..mid), self.get_unchecked(mid..))`\n\n        let len = self.len();\n        let ptr = self.as_ptr();\n\n        assert_unsafe_precondition!(\n            check_library_ub,\n            \"slice::split_at_unchecked requires the index to be within the slice\",\n            (mid: usize = mid, len: usize = len) => mid <= len,\n        );\n\n        // SAFETY: Caller has to check that `0 <= mid <= self.len()`\n        unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 197, name: \"core::slice::<impl [T]>::align_to\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub unsafe fn align_to<U>(&self) -> (&[T], &[U], &[T]) {\n        // Note that most of this function will be constant-evaluated,\n        if U::IS_ZST || T::IS_ZST {\n            // handle ZSTs specially, which is – don't handle them at all.\n            return (self, &[], &[]);\n        }\n\n        // First, find at what point do we split between the first and 2nd slice. Easy with\n        // ptr.align_offset.\n        let ptr = self.as_ptr();\n        // SAFETY: See the `align_to_mut` method for the detailed safety comment.\n        let offset = unsafe { crate::ptr::align_offset(ptr, align_of::<U>()) };\n        if offset > self.len() {\n            (self, &[], &[])\n        } else {\n            let (left, rest) = self.split_at(offset);\n            let (us_len, ts_len) = rest.align_to_offsets::<U>();\n            // Inform Miri that we want to consider the \"middle\" pointer to be suitably aligned.\n            #[cfg(miri)]\n            crate::intrinsics::miri_promise_symbolic_alignment(\n                rest.as_ptr().cast(),\n                align_of::<U>(),\n            );\n            // SAFETY: now `rest` is definitely aligned, so `from_raw_parts` below is okay,\n            // since the caller guarantees that we can transmute `T` to `U` safely.\n            unsafe {\n                (\n                    left,\n                    from_raw_parts(rest.as_ptr() as *const U, us_len),\n                    from_raw_parts(rest.as_ptr().add(rest.len() - ts_len), ts_len),\n                )\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"std::str::from_utf8_unchecked\" }",
+        "file": "library/core/src/str/converts.rs",
+        "func": "pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {\n    // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.\n    // Also relies on `&str` and `&[u8]` having the same layout.\n    unsafe { mem::transmute(v) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"core::str::count::char_count_general_case\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn char_count_general_case(s: &[u8]) -> usize {\n    s.iter().filter(|&&byte| !super::validations::utf8_is_cont_byte(byte)).count()\n}"
+      },
+      {
+        "def_id": "DefId { id: 207, name: \"core::str::count::contains_non_continuation_byte\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn contains_non_continuation_byte(w: usize) -> usize {\n    const LSB: usize = usize::repeat_u8(0x01);\n    ((!w >> 7) | (w >> 6)) & LSB\n}"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"core::str::count::do_count_chars\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn do_count_chars(s: &str) -> usize {\n    // For correctness, `CHUNK_SIZE` must be:\n    //\n    // - Less than or equal to 255, otherwise we'll overflow bytes in `counts`.\n    // - A multiple of `UNROLL_INNER`, otherwise our `break` inside the\n    //   `body.chunks(CHUNK_SIZE)` loop is incorrect.\n    //\n    // For performance, `CHUNK_SIZE` should be:\n    // - Relatively cheap to `/` against (so some simple sum of powers of two).\n    // - Large enough to avoid paying for the cost of the `sum_bytes_in_usize`\n    //   too often.\n    const CHUNK_SIZE: usize = 192;\n\n    // Check the properties of `CHUNK_SIZE` and `UNROLL_INNER` that are required\n    // for correctness.\n    const _: () = assert!(CHUNK_SIZE < 256);\n    const _: () = assert!(CHUNK_SIZE % UNROLL_INNER == 0);\n\n    // SAFETY: transmuting `[u8]` to `[usize]` is safe except for size\n    // differences which are handled by `align_to`.\n    let (head, body, tail) = unsafe { s.as_bytes().align_to::<usize>() };\n\n    // This should be quite rare, and basically exists to handle the degenerate\n    // cases where align_to fails (as well as miri under symbolic alignment\n    // mode).\n    //\n    // The `unlikely` helps discourage LLVM from inlining the body, which is\n    // nice, as we would rather not mark the `char_count_general_case` function\n    // as cold.\n    if unlikely(body.is_empty() || head.len() > USIZE_SIZE || tail.len() > USIZE_SIZE) {\n        return char_count_general_case(s.as_bytes());\n    }\n\n    let mut total = char_count_general_case(head) + char_count_general_case(tail);\n    // Split `body` into `CHUNK_SIZE` chunks to reduce the frequency with which\n    // we call `sum_bytes_in_usize`.\n    for chunk in body.chunks(CHUNK_SIZE) {\n        // We accumulate intermediate sums in `counts`, where each byte contains\n        // a subset of the sum of this chunk, like a `[u8; size_of::<usize>()]`.\n        let mut counts = 0;\n\n        let (unrolled_chunks, remainder) = chunk.as_chunks::<UNROLL_INNER>();\n        for unrolled in unrolled_chunks {\n            for &word in unrolled {\n                // Because `CHUNK_SIZE` is < 256, this addition can't cause the\n                // count in any of the bytes to overflow into a subsequent byte.\n                counts += contains_non_continuation_byte(word);\n            }\n        }\n\n        // Sum the values in `counts` (which, again, is conceptually a `[u8;\n        // size_of::<usize>()]`), and accumulate the result into `total`.\n        total += sum_bytes_in_usize(counts);\n\n        // If there's any data in `remainder`, then handle it. This will only\n        // happen for the last `chunk` in `body.chunks()` (because `CHUNK_SIZE`\n        // is divisible by `UNROLL_INNER`), so we explicitly break at the end\n        // (which seems to help LLVM out).\n        if !remainder.is_empty() {\n            // Accumulate all the data in the remainder.\n            let mut counts = 0;\n            for &word in remainder {\n                counts += contains_non_continuation_byte(word);\n            }\n            total += sum_bytes_in_usize(counts);\n            break;\n        }\n    }\n    total\n}"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"core::str::count::sum_bytes_in_usize\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn sum_bytes_in_usize(values: usize) -> usize {\n    const LSB_SHORTS: usize = usize::repeat_u16(0x0001);\n    const SKIP_BYTES: usize = usize::repeat_u16(0x00ff);\n\n    let pair_sum: usize = (values & SKIP_BYTES) + ((values >> 8) & SKIP_BYTES);\n    pair_sum.wrapping_mul(LSB_SHORTS) >> ((USIZE_SIZE - 2) * 8)\n}"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"core::str::count::count_chars\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "pub(super) fn count_chars(s: &str) -> usize {\n    if cfg!(feature = \"optimize_for_size\") || s.len() < USIZE_SIZE * UNROLL_INNER {\n        // Avoid entering the optimized implementation for strings where the\n        // difference is not likely to matter, or where it might even be slower.\n        // That said, a ton of thought was not spent on the particular threshold\n        // here, beyond \"this value seems to make sense\".\n        char_count_general_case(s.as_bytes())\n    } else {\n        do_count_chars(s)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::str::count::char_count_general_case::{closure#0}\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "|&&byte| !super::validations::utf8_is_cont_byte(byte)"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn count(self) -> usize {\n        super::count::count_chars(self.as_str())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn next(&mut self) -> Option<(usize, char)> {\n        let pre_len = self.iter.iter.len();\n        match self.iter.next() {\n            None => None,\n            Some(ch) => {\n                let index = self.front_offset;\n                let len = self.iter.iter.len();\n                self.front_offset += pre_len - len;\n                Some((index, ch))\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn next(&mut self) -> Option<char> {\n        // SAFETY: `str` invariant says `self.iter` is a valid UTF-8 string and\n        // the resulting `ch` is a valid Unicode Scalar Value.\n        unsafe { next_code_point(&mut self.iter).map(|ch| char::from_u32_unchecked(ch)) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::str::Chars::<'a>::as_str\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "pub fn as_str(&self) -> &'a str {\n        // SAFETY: `Chars` is only made from a str, which guarantees the iter is valid UTF-8.\n        unsafe { from_utf8_unchecked(self.iter.as_slice()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::str::CharIndices::<'a>::offset\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "pub fn offset(&self) -> usize {\n        self.front_offset\n    }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "|ch| char::from_u32_unchecked(ch)"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"core::str::<impl str>::as_bytes\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub const fn as_bytes(&self) -> &[u8] {\n        // SAFETY: const sound because we transmute two types with the same layout\n        unsafe { mem::transmute(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"core::str::<impl str>::len\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub const fn len(&self) -> usize {\n        self.as_bytes().len()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::char_indices\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub fn char_indices(&self) -> CharIndices<'_> {\n        CharIndices { front_offset: 0, iter: self.chars() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 81, name: \"core::str::<impl str>::chars\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub fn chars(&self) -> Chars<'_> {\n        Chars { iter: self.as_bytes().iter() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"core::str::<impl str>::get_unchecked\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub unsafe fn get_unchecked<I: SliceIndex<str>>(&self, i: I) -> &I::Output {\n        // SAFETY: the caller must uphold the safety contract for `get_unchecked`;\n        // the slice is dereferenceable because `self` is a safe reference.\n        // The returned pointer is safe because impls of `SliceIndex` have to guarantee that it is.\n        unsafe { &*i.get_unchecked(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 144, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }",
+        "file": "library/core/src/str/traits.rs",
+        "func": "unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {\n        // SAFETY: the caller has to uphold the safety contract for `get_unchecked`.\n        unsafe { (0..self.end).get_unchecked(slice) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }",
+        "file": "library/core/src/str/traits.rs",
+        "func": "unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {\n        let slice = slice as *const [u8];\n\n        assert_unsafe_precondition!(\n            // We'd like to check that the bounds are on char boundaries,\n            // but there's not really a way to do so without reading\n            // behind the pointer, which has aliasing implications.\n            // It's also not possible to move this check up to\n            // `str::get_unchecked` without adding a special function\n            // to `SliceIndex` just for this.\n            check_library_ub,\n            \"str::get_unchecked requires that the range is within the string slice\",\n            (\n                start: usize = self.start,\n                end: usize = self.end,\n                len: usize = slice.len()\n            ) => end >= start && end <= len,\n        );\n\n        // SAFETY: the caller guarantees that `self` is in bounds of `slice`\n        // which satisfies all the conditions for `add`.\n        unsafe {\n            let new_len = unchecked_sub(self.end, self.start);\n            ptr::slice_from_raw_parts(slice.as_ptr().add(self.start), new_len) as *const str\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"core::str::validations::utf8_acc_cont_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "const fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {\n    (ch << 6) | (byte & CONT_MASK) as u32\n}"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::str::validations::utf8_first_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "const fn utf8_first_byte(byte: u8, width: u32) -> u32 {\n    (byte & (0x7F >> width)) as u32\n}"
+      },
+      {
+        "def_id": "DefId { id: 253, name: \"core::str::validations::next_code_point\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "pub unsafe fn next_code_point<'a, I: Iterator<Item = &'a u8>>(bytes: &mut I) -> Option<u32> {\n    // Decode UTF-8\n    let x = *bytes.next()?;\n    if x < 128 {\n        return Some(x as u32);\n    }\n\n    // Multibyte case follows\n    // Decode from a byte combination out of: [[[x y] z] w]\n    // NOTE: Performance is sensitive to the exact formulation here\n    let init = utf8_first_byte(x, 2);\n    // SAFETY: `bytes` produces an UTF-8-like string,\n    // so the iterator must produce a value here.\n    let y = unsafe { *bytes.next().unwrap_unchecked() };\n    let mut ch = utf8_acc_cont_byte(init, y);\n    if x >= 0xE0 {\n        // [[x y z] w] case\n        // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid\n        // SAFETY: `bytes` produces an UTF-8-like string,\n        // so the iterator must produce a value here.\n        let z = unsafe { *bytes.next().unwrap_unchecked() };\n        let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);\n        ch = init << 12 | y_z;\n        if x >= 0xF0 {\n            // [x y z w] case\n            // use only the lower 3 bits of `init`\n            // SAFETY: `bytes` produces an UTF-8-like string,\n            // so the iterator must produce a value here.\n            let w = unsafe { *bytes.next().unwrap_unchecked() };\n            ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);\n        }\n    }\n\n    Some(ch)\n}"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"core::str::validations::utf8_is_cont_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "pub(super) const fn utf8_is_cont_byte(byte: u8) -> bool {\n    (byte as i8) < -64\n}"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"std::hint::unreachable_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"std::slice::from_raw_parts::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"core::ub_checks::check_language_ub\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn check_language_ub() -> bool {\n    // Only used for UB checks so we may const_eval_select.\n    intrinsics::ub_checks()\n        && const_eval_select!(\n            @capture { } -> bool:\n            if const {\n                // Always disable UB checks.\n                false\n            } else {\n                // Disable UB checks in Miri.\n                !cfg!(miri)\n            }\n        )\n}"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"core::ub_checks::is_valid_allocation_size\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn is_valid_allocation_size(size: usize, len: usize) -> bool {\n    let max_len = if size == 0 { usize::MAX } else { isize::MAX as usize / size };\n    len <= max_len\n}"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn maybe_is_aligned_and_not_null(\n    ptr: *const (),\n    align: usize,\n    is_zst: bool,\n) -> bool {\n    // This is just for safety checks so we can const_eval_select.\n    const_eval_select!(\n        @capture { ptr: *const (), align: usize, is_zst: bool } -> bool:\n        if const {\n            is_zst || !ptr.is_null()\n        } else {\n            ptr.is_aligned_to(align) && (is_zst || !ptr.is_null())\n        }\n    )\n}"
+      },
+      {
+        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::requires(a > 0)]"
+      }
+    ]
+  },
+  {
+    "hash": "179332162935062096483091042922467261693",
+    "def_id": "DefId { id: 32, name: \"verify::single_with_contract_ensures\" }",
+    "file": "tests/proofs/proofs_for_contract.rs",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract_ensures\"]"
+    ],
+    "func": "fn single_with_contract_ensures() {\n        contract_ensures(0);\n    }",
+    "callees": [
+      {
+        "def_id": "DefId { id: 52, name: \"kani::panic\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub const fn panic(message: &'static str) -> ! {\n            panic!(\"{}\", message)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }",
+        "file": "kani/library/kani_core/src/lib.rs",
+        "func": "pub fn init_contracts() {}"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }",
+        "file": "library/core/src/array/mod.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::char_try_from_u32\" }",
+        "file": "library/core/src/char/convert.rs",
+        "func": "const fn char_try_from_u32(i: u32) -> Result<char, CharTryFromError> {\n    // This is an optimized version of the check\n    // (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF),\n    // which can also be written as\n    // i >= 0x110000 || (i >= 0xD800 && i < 0xE000).\n    //\n    // The XOR with 0xD800 permutes the ranges such that 0xD800..0xE000 is\n    // mapped to 0x0000..0x0800, while keeping all the high bits outside 0xFFFF the same.\n    // In particular, numbers >= 0x110000 stay in this range.\n    //\n    // Subtracting 0x800 causes 0x0000..0x0800 to wrap, meaning that a single\n    // unsigned comparison against 0x110000 - 0x800 will detect both the wrapped\n    // surrogate range as well as the numbers originally larger than 0x110000.\n    //\n    if (i ^ 0xD800).wrapping_sub(0x800) >= 0x110000 - 0x800 {\n        Err(CharTryFromError(()))\n    } else {\n        // SAFETY: checked that it's a legal unicode value\n        Ok(unsafe { transmute(i) })\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::char::convert::from_u32_unchecked\" }",
+        "file": "library/core/src/char/convert.rs",
+        "func": "pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {\n    // SAFETY: the caller must guarantee that `i` is a valid char value.\n    unsafe {\n        assert_unsafe_precondition!(\n            check_language_ub,\n            \"invalid value for `char`\",\n            (i: u32 = i) => char_try_from_u32(i).is_ok()\n        );\n        transmute(i)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }",
+        "file": "library/core/src/char/methods.rs",
+        "func": "pub const unsafe fn from_u32_unchecked(i: u32) -> char {\n        // SAFETY: the safety contract must be upheld by the caller.\n        unsafe { super::convert::from_u32_unchecked(i) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn lt(&self, other: &Self) -> bool { *self <  *other }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn lt(&self, other: &Self) -> bool { *self <  *other }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::cmp::Ord::min\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "fn min(self, other: Self) -> Self\n    where\n        Self: Sized,\n    {\n        if other < self { other } else { self }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"std::cmp::min\" }",
+        "file": "library/core/src/cmp.rs",
+        "func": "pub fn min<T: Ord>(v1: T, v2: T) -> T {\n    v1.min(v2)\n}"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"<T as std::convert::From<T>>::from\" }",
+        "file": "library/core/src/convert/mod.rs",
+        "func": "fn from(t: T) -> T {\n        t\n    }"
+      },
+      {
+        "def_id": "DefId { id: 75, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }",
+        "file": "library/core/src/convert/num.rs",
+        "func": "fn from(small: $Small) -> Self {\n                small as Self\n            }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"<str as std::fmt::Display>::fmt\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn fmt(&self, f: &mut Formatter<'_>) -> Result {\n        f.pad(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 63, name: \"<&T as std::fmt::Display>::fmt\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn fmt(&self, f: &mut Formatter<'_>) -> Result { $tr::fmt(&**self, f) }"
+      },
+      {
+        "def_id": "DefId { id: 115, name: \"core::fmt::PostPadding::new\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "fn new(fill: char, padding: u16) -> PostPadding {\n        PostPadding { fill, padding }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"std::fmt::FormattingOptions::get_align\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_align(&self) -> Option<Alignment> {\n        match self.flags & flags::ALIGN_BITS {\n            flags::ALIGN_LEFT => Some(Alignment::Left),\n            flags::ALIGN_RIGHT => Some(Alignment::Right),\n            flags::ALIGN_CENTER => Some(Alignment::Center),\n            _ => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::fmt::FormattingOptions::get_fill\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_fill(&self) -> char {\n        // SAFETY: We only ever put a valid `char` in the lower 21 bits of the flags field.\n        unsafe { char::from_u32_unchecked(self.flags & 0x1FFFFF) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::fmt::FormattingOptions::get_precision\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn get_precision(&self) -> Option<u16> {\n        if self.flags & flags::PRECISION_FLAG != 0 { Some(self.precision) } else { None }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"std::fmt::Arguments::<'a>::new_const\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn new_const<const N: usize>(pieces: &'a [&'static str; N]) -> Self {\n        const { assert!(N <= 1) };\n        Arguments { pieces, fmt: None, args: &[] }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"std::fmt::Arguments::<'a>::new_v1\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub const fn new_v1<const P: usize, const A: usize>(\n        pieces: &'a [&'static str; P],\n        args: &'a [rt::Argument<'a>; A],\n    ) -> Arguments<'a> {\n        const { assert!(P >= A && P <= A + 1, \"invalid args\") }\n        Arguments { pieces, fmt: None, args }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 67, name: \"std::fmt::Formatter::<'a>::pad\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub fn pad(&mut self, s: &str) -> Result {\n        // Make sure there's a fast path up front.\n        if self.options.flags & (flags::WIDTH_FLAG | flags::PRECISION_FLAG) == 0 {\n            return self.buf.write_str(s);\n        }\n\n        // The `precision` field can be interpreted as a maximum width for the\n        // string being formatted.\n        let (s, char_count) = if let Some(max_char_count) = self.options.get_precision() {\n            let mut iter = s.char_indices();\n            let remaining = match iter.advance_by(usize::from(max_char_count)) {\n                Ok(()) => 0,\n                Err(remaining) => remaining.get(),\n            };\n            // SAFETY: The offset of `.char_indices()` is guaranteed to be\n            // in-bounds and between character boundaries.\n            let truncated = unsafe { s.get_unchecked(..iter.offset()) };\n            (truncated, usize::from(max_char_count) - remaining)\n        } else {\n            // Use the optimized char counting algorithm for the full string.\n            (s, s.chars().count())\n        };\n\n        // The `width` field is more of a minimum width parameter at this point.\n        if char_count < usize::from(self.options.width) {\n            // If we're under the minimum width, then fill up the minimum width\n            // with the specified string + some alignment.\n            let post_padding =\n                self.padding(self.options.width - char_count as u16, Alignment::Left)?;\n            self.buf.write_str(s)?;\n            post_padding.write(self)\n        } else {\n            // If we're over the minimum width or there is no minimum width, we\n            // can just emit the string.\n            self.buf.write_str(s)\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"std::fmt::Formatter::<'a>::padding\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub(crate) fn padding(\n        &mut self,\n        padding: u16,\n        default: Alignment,\n    ) -> result::Result<PostPadding, Error> {\n        let align = self.options.get_align().unwrap_or(default);\n        let fill = self.options.get_fill();\n\n        let padding_left = match align {\n            Alignment::Left => 0,\n            Alignment::Right => padding,\n            Alignment::Center => padding / 2,\n        };\n\n        for _ in 0..padding_left {\n            self.buf.write_char(fill)?;\n        }\n\n        Ok(PostPadding::new(fill, padding - padding_left))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::fmt::PostPadding::write\" }",
+        "file": "library/core/src/fmt/mod.rs",
+        "func": "pub(crate) fn write(self, f: &mut Formatter<'_>) -> Result {\n        for _ in 0..self.padding {\n            f.buf.write_char(self.fill)?;\n        }\n        Ok(())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"core::fmt::rt::Argument::<'_>::new\" }",
+        "file": "library/core/src/fmt/rt.rs",
+        "func": "const fn new<'a, T>(x: &'a T, f: fn(&T, &mut Formatter<'_>) -> Result) -> Argument<'a> {\n        Argument {\n            // INVARIANT: this creates an `ArgumentType<'a>` from a `&'a T` and\n            // a `fn(&T, ...)`, so the invariant is maintained.\n            ty: ArgumentType::Placeholder {\n                value: NonNull::from_ref(x).cast(),\n                // SAFETY: function pointers always have the same layout.\n                formatter: unsafe { mem::transmute(f) },\n                _lifetime: PhantomData,\n            },\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"core::fmt::rt::Argument::<'_>::new_display\" }",
+        "file": "library/core/src/fmt/rt.rs",
+        "func": "pub fn new_display<T: Display>(x: &T) -> Argument<'_> {\n        Self::new(x, Display::fmt)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::hint::unreachable_unchecked\" }",
+        "file": "library/core/src/hint.rs",
+        "func": "pub const unsafe fn unreachable_unchecked() -> ! {\n    ub_checks::assert_unsafe_precondition!(\n        check_language_ub,\n        \"hint::unreachable_unchecked must never be reached\",\n        () => false\n    );\n    // SAFETY: the safety contract for `intrinsics::unreachable` must\n    // be upheld by the caller.\n    unsafe { intrinsics::unreachable() }\n}"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "fn runtime$(<$($binders)*>)?($($arg: $ty),*) $( -> $ret )? {\n            $runtime\n        }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::intrinsics::cold_path\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "pub const fn cold_path() {}"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::intrinsics::unlikely\" }",
+        "file": "library/core/src/intrinsics/mod.rs",
+        "func": "pub const fn unlikely(b: bool) -> bool {\n    if b {\n        cold_path();\n        true\n    } else {\n        false\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "fn count(self) -> usize {\n        #[inline]\n        fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {\n            move |x| predicate(&x) as usize\n        }\n\n        self.iter.map(to_usize(self.predicate)).sum()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {\n            move |x| predicate(&x) as usize\n        }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "move |x| predicate(&x) as usize"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"std::iter::Filter::<I, P>::new\" }",
+        "file": "library/core/src/iter/adapters/filter.rs",
+        "func": "pub(in crate::iter) fn new(iter: I, predicate: P) -> Filter<I, P> {\n        Filter { iter, predicate }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "fn fold<Acc, G>(self, init: Acc, g: G) -> Acc\n    where\n        G: FnMut(Acc, Self::Item) -> Acc,\n    {\n        self.iter.fold(init, map_fold(self.f, g))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"std::iter::adapters::map::map_fold\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "fn map_fold<T, B, Acc>(\n    mut f: impl FnMut(T) -> B,\n    mut g: impl FnMut(Acc, B) -> Acc,\n) -> impl FnMut(Acc, T) -> Acc {\n    move |acc, elt| g(acc, f(elt))\n}"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "move |acc, elt| g(acc, f(elt))"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"std::iter::Map::<I, F>::new\" }",
+        "file": "library/core/src/iter/adapters/map.rs",
+        "func": "pub(in crate::iter) fn new(iter: I, f: F) -> Map<I, F> {\n        Map { iter, f }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn next(&mut self) -> Option<A> {\n        self.spec_next()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn next(&mut self) -> Option<A> {\n        self.spec_next()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn spec_next(&mut self) -> Option<T> {\n        if self.start < self.end {\n            let old = self.start;\n            // SAFETY: just checked precondition\n            self.start = unsafe { Step::forward_unchecked(old, 1) };\n            Some(old)\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "fn spec_next(&mut self) -> Option<T> {\n        if self.start < self.end {\n            let old = self.start;\n            // SAFETY: just checked precondition\n            self.start = unsafe { Step::forward_unchecked(old, 1) };\n            Some(old)\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"<u16 as std::iter::Step>::forward_unchecked\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "unsafe fn forward_unchecked(start: Self, n: usize) -> Self {\n            // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.\n            unsafe { start.unchecked_add(n as Self) }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"<usize as std::iter::Step>::forward_unchecked\" }",
+        "file": "library/core/src/iter/range.rs",
+        "func": "unsafe fn forward_unchecked(start: Self, n: usize) -> Self {\n            // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.\n            unsafe { start.unchecked_add(n as Self) }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"<usize as std::iter::Sum>::sum\" }",
+        "file": "library/core/src/iter/traits/accum.rs",
+        "func": "fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {\n                iter.fold(\n                    $zero,\n                    #[rustc_inherit_overflow_checks]\n                    |a, b| a + b,\n                )\n            }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }",
+        "file": "library/core/src/iter/traits/accum.rs",
+        "func": "|a, b| a + b"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"<I as std::iter::IntoIterator>::into_iter\" }",
+        "file": "library/core/src/iter/traits/collect.rs",
+        "func": "fn into_iter(self) -> I {\n        self\n    }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::iter::Iterator::advance_by\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {\n        for i in 0..n {\n            if self.next().is_none() {\n                // SAFETY: `i` is always less than `n`.\n                return Err(unsafe { NonZero::new_unchecked(n - i) });\n            }\n        }\n        Ok(())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::iter::Iterator::filter\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn filter<P>(self, predicate: P) -> Filter<Self, P>\n    where\n        Self: Sized,\n        P: FnMut(&Self::Item) -> bool,\n    {\n        Filter::new(self, predicate)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::iter::Iterator::map\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn map<B, F>(self, f: F) -> Map<Self, F>\n    where\n        Self: Sized,\n        F: FnMut(Self::Item) -> B,\n    {\n        Map::new(self, f)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::iter::Iterator::sum\" }",
+        "file": "library/core/src/iter/traits/iterator.rs",
+        "func": "fn sum<S>(self) -> S\n    where\n        Self: Sized,\n        S: Sum<Self::Item>,\n    {\n        Sum::sum(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"std::mem::align_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn align_of<T>() -> usize {\n    intrinsics::min_align_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::mem::size_of\" }",
+        "file": "library/core/src/mem/mod.rs",
+        "func": "pub const fn size_of<T>() -> usize {\n    intrinsics::size_of::<T>()\n}"
+      },
+      {
+        "def_id": "DefId { id: 78, name: \"std::num::NonZero::<T>::get\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const fn get(self) -> T {\n        // Rustc can set range metadata only if it loads `self` from\n        // memory somewhere. If the value of `self` was from by-value argument\n        // of some not-inlined function, LLVM don't have range metadata\n        // to understand that the value cannot be zero.\n        //\n        // Using the transmute `assume`s the range at runtime.\n        //\n        // Even once LLVM supports `!range` metadata for function arguments\n        // (see <https://github.com/llvm/llvm-project/issues/76628>), this can't\n        // be `.0` because MCP#807 bans field-projecting into `scalar_valid_range`\n        // types, and it arguably wouldn't want to be anyway because if this is\n        // MIR-inlined, there's no opportunity to put that argument metadata anywhere.\n        //\n        // The good answer here will eventually be pattern types, which will hopefully\n        // allow it to go back to `.0`, maybe with a cast of some sort.\n        //\n        // SAFETY: `ZeroablePrimitive` guarantees that the size and bit validity\n        // of `.0` is such that this transmute is sound.\n        unsafe { intrinsics::transmute_unchecked(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"std::num::NonZero::<T>::new\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const fn new(n: T) -> Option<Self> {\n        // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has\n        //         the same layout and size as `T`, with `0` representing `None`.\n        unsafe { intrinsics::transmute_unchecked(n) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::num::NonZero::<T>::new_unchecked\" }",
+        "file": "library/core/src/num/nonzero.rs",
+        "func": "pub const unsafe fn new_unchecked(n: T) -> Self {\n        match Self::new(n) {\n            Some(n) => n,\n            None => {\n                // SAFETY: The caller guarantees that `n` is non-zero, so this is unreachable.\n                unsafe {\n                    ub_checks::assert_unsafe_precondition!(\n                        check_language_ub,\n                        \"NonZero::new_unchecked requires the argument to be non-zero\",\n                        () => false,\n                    );\n                    intrinsics::unreachable()\n                }\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::num::<impl usize>::count_ones\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn count_ones(self) -> u32 {\n            return intrinsics::ctpop(self);\n        }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"core::num::<impl usize>::is_power_of_two\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn is_power_of_two(self) -> bool {\n            self.count_ones() == 1\n        }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::overflowing_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"core::num::<impl usize>::overflowing_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {\n            let (a, b) = intrinsics::sub_with_overflow(self as $ActualT, rhs as $ActualT);\n            (a as Self, b)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 214, name: \"core::num::<impl usize>::wrapping_mul\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn wrapping_mul(self, rhs: Self) -> Self {\n            intrinsics::wrapping_mul(self, rhs)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 132, name: \"core::num::<impl u32>::wrapping_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const fn wrapping_sub(self, rhs: Self) -> Self {\n            intrinsics::wrapping_sub(self, rhs)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"core::num::<impl u16>::unchecked_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_add cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_add(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_add(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::num::<impl usize>::unchecked_add\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_add(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_add cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_add(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_add(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"core::num::<impl usize>::unchecked_sub\" }",
+        "file": "library/core/src/num/uint_macros.rs",
+        "func": "pub const unsafe fn unchecked_sub(self, rhs: Self) -> Self {\n            assert_unsafe_precondition!(\n                check_language_ub,\n                concat!(stringify!($SelfT), \"::unchecked_sub cannot overflow\"),\n                (\n                    lhs: $SelfT = self,\n                    rhs: $SelfT = rhs,\n                ) => !lhs.overflowing_sub(rhs).1,\n            );\n\n            // SAFETY: this is guaranteed to be safe by the caller.\n            unsafe {\n                intrinsics::unchecked_sub(self, rhs)\n            }\n        }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/option.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Some(v) => ControlFlow::Continue(v),\n            None => ControlFlow::Break(None),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }",
+        "file": "library/core/src/option.rs",
+        "func": "fn from_residual(residual: Option<convert::Infallible>) -> Self {\n        match residual {\n            None => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::option::Option::<T>::is_none\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const fn is_none(&self) -> bool {\n        !self.is_some()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::option::Option::<T>::is_some\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const fn is_some(&self) -> bool {\n        matches!(*self, Some(_))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::option::Option::<T>::unwrap_unchecked\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub const unsafe fn unwrap_unchecked(self) -> T {\n        match self {\n            Some(val) => val,\n            // SAFETY: the safety contract must be upheld by the caller.\n            None => unsafe { hint::unreachable_unchecked() },\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 254, name: \"std::option::Option::<T>::map\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub fn map<U, F>(self, f: F) -> Option<U>\n    where\n        F: FnOnce(T) -> U,\n    {\n        match self {\n            Some(x) => Some(f(x)),\n            None => None,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::option::Option::<T>::unwrap_or\" }",
+        "file": "library/core/src/option.rs",
+        "func": "pub fn unwrap_or(self, default: T) -> T {\n        match self {\n            Some(x) => x,\n            None => default,\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"kani::panic::panic_cold_display\" }",
+        "file": "library/core/src/panic.rs",
+        "func": "const fn panic_cold_display<T: $crate::fmt::Display>(arg: &T) -> ! {\n            $crate::panicking::panic_display(arg)\n        }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::panic::Location::<'a>::caller\" }",
+        "file": "library/core/src/panic/location.rs",
+        "func": "pub const fn caller() -> &'static Location<'static> {\n        crate::intrinsics::caller_location()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }",
+        "file": "library/core/src/panic/panic_info.rs",
+        "func": "pub(crate) fn new(\n        message: &'a fmt::Arguments<'a>,\n        location: &'a Location<'a>,\n        can_unwind: bool,\n        force_no_backtrace: bool,\n    ) -> Self {\n        PanicInfo { location, message, can_unwind, force_no_backtrace }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"core::panicking::panic\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic(expr: &'static str) -> ! {\n    // Use Arguments::new_const instead of format_args!(\"{expr}\") to potentially\n    // reduce size overhead. The format_args! macro uses str's Display trait to\n    // write expr, which calls Formatter::pad, which must accommodate string\n    // truncation and padding (even though none is used here). Using\n    // Arguments::new_const may allow the compiler to omit Formatter::pad from the\n    // output binary, saving up to a few kilobytes.\n    // However, this optimization only works for `'static` strings: `new_const` also makes this\n    // message return `Some` from `Arguments::as_str`, which means it can become part of the panic\n    // payload without any allocation or copying. Shorter-lived strings would become invalid as\n    // stack frames get popped during unwinding, and couldn't be directly referenced from the\n    // payload.\n    panic_fmt(fmt::Arguments::new_const(&[expr]));\n}"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"std::rt::panic_display\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_display<T: fmt::Display>(x: &T) -> ! {\n    panic_fmt(format_args!(\"{}\", *x));\n}"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::rt::panic_fmt\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {\n    if cfg!(feature = \"panic_immediate_abort\") {\n        super::intrinsics::abort()\n    }\n\n    // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call\n    // that gets resolved to the `#[panic_handler]` function.\n    unsafe extern \"Rust\" {\n        #[lang = \"panic_impl\"]\n        fn panic_impl(pi: &PanicInfo<'_>) -> !;\n    }\n\n    let pi = PanicInfo::new(\n        &fmt,\n        Location::caller(),\n        /* can_unwind */ true,\n        /* force_no_backtrace */ false,\n    );\n\n    // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.\n    unsafe { panic_impl(&pi) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"core::panicking::panic_nounwind\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_nounwind(expr: &'static str) -> ! {\n    panic_nounwind_fmt(fmt::Arguments::new_const(&[expr]), /* force_no_backtrace */ false);\n}"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"core::panicking::panic_nounwind_fmt\" }",
+        "file": "library/core/src/panicking.rs",
+        "func": "pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: bool) -> ! {\n    const_eval_select!(\n        @capture { fmt: fmt::Arguments<'_>, force_no_backtrace: bool } -> !:\n        if const #[track_caller] {\n            // We don't unwind anyway at compile-time so we can call the regular `panic_fmt`.\n            panic_fmt(fmt)\n        } else #[track_caller] {\n            if cfg!(feature = \"panic_immediate_abort\") {\n                super::intrinsics::abort()\n            }\n\n            // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call\n            // that gets resolved to the `#[panic_handler]` function.\n            unsafe extern \"Rust\" {\n                #[lang = \"panic_impl\"]\n                fn panic_impl(pi: &PanicInfo<'_>) -> !;\n            }\n\n            // PanicInfo with the `can_unwind` flag set to false forces an abort.\n            let pi = PanicInfo::new(\n                &fmt,\n                Location::caller(),\n                /* can_unwind */ false,\n                force_no_backtrace,\n            );\n\n            // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.\n            unsafe { panic_impl(&pi) }\n        }\n    )\n}"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "const fn runtime_ptr_ge(this: *const (), origin: *const ()) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), origin: *const () } -> bool:\n                if const {\n                    true\n                } else {\n                    this >= origin\n                }\n            )\n        }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn as_ptr(self) -> *const T {\n        self as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn cast<U>(self) -> *const U {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn is_null(self) -> bool {\n        // Compare via a cast to a thin pointer, so fat pointers are only\n        // considering their \"data\" part for null-ness.\n        let ptr = self as *const u8;\n        const_eval_select!(\n            @capture { ptr: *const u8 } -> bool:\n            // This use of `const_raw_ptr_comparison` has been explicitly blessed by t-lang.\n            if const #[rustc_allow_const_fn_unstable(const_raw_ptr_comparison)] {\n                match (ptr).guaranteed_eq(null_mut()) {\n                    Some(res) => res,\n                    // To remain maximally convervative, we stop execution when we don't\n                    // know whether the pointer is null or not.\n                    // We can *not* return `false` here, that would be unsound in `NonNull::new`!\n                    None => panic!(\"null-ness of this pointer cannot be determined in const context\"),\n                }\n            } else {\n                ptr.addr() == 0\n            }\n        )\n    }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const fn len(self) -> usize {\n        metadata(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::add\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::add\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 188, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize\n    where\n        T: Sized,\n    {\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_ptr_ge(this: *const (), origin: *const ()) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), origin: *const () } -> bool:\n                if const {\n                    true\n                } else {\n                    this >= origin\n                }\n            )\n        }\n\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::offset_from_unsigned requires `self >= origin`\",\n            (\n                this: *const () = self as *const (),\n                origin: *const () = origin as *const (),\n            ) => runtime_ptr_ge(this, origin)\n        );\n\n        let pointee_size = size_of::<T>();\n        assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);\n        // SAFETY: the caller must uphold the safety contract for `ptr_offset_from_unsigned`.\n        unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn addr(self) -> usize {\n        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the\n        // address without exposing the provenance. Note that this is *not* a stable guarantee about\n        // transmute semantics, it relies on sysroot crates having special status.\n        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the\n        // provenance).\n        unsafe { mem::transmute(self.cast::<()>()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }",
+        "file": "library/core/src/ptr/const_ptr.rs",
+        "func": "pub fn is_aligned_to(self, align: usize) -> bool {\n        if !align.is_power_of_two() {\n            panic!(\"is_aligned_to: align is not a power-of-two\");\n        }\n\n        self.addr() & (align - 1) == 0\n    }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::from_raw_parts\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn from_raw_parts<T: ?Sized>(\n    data_pointer: *const impl Thin,\n    metadata: <T as Pointee>::Metadata,\n) -> *const T {\n    aggregate_raw_ptr(data_pointer, metadata)\n}"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }",
+        "file": "library/core/src/ptr/metadata.rs",
+        "func": "pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {\n    ptr_metadata(ptr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::ptr::align_offset::mod_inv\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "const unsafe fn mod_inv(x: usize, m: usize) -> usize {\n        /// Multiplicative modular inverse table modulo 2⁴ = 16.\n        ///\n        /// Note, that this table does not contain values where inverse does not exist (i.e., for\n        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)\n        const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];\n        /// Modulo for which the `INV_TABLE_MOD_16` is intended.\n        const INV_TABLE_MOD: usize = 16;\n\n        // SAFETY: `m` is required to be a power-of-two, hence non-zero.\n        let m_minus_one = unsafe { unchecked_sub(m, 1) };\n        let mut inverse = INV_TABLE_MOD_16[(x & (INV_TABLE_MOD - 1)) >> 1] as usize;\n        let mut mod_gate = INV_TABLE_MOD;\n        // We iterate \"up\" using the following formula:\n        //\n        // $$ xy ≡ 1 (mod 2ⁿ) → xy (2 - xy) ≡ 1 (mod 2²ⁿ) $$\n        //\n        // This application needs to be applied at least until `2²ⁿ ≥ m`, at which point we can\n        // finally reduce the computation to our desired `m` by taking `inverse mod m`.\n        //\n        // This computation is `O(log log m)`, which is to say, that on 64-bit machines this loop\n        // will always finish in at most 4 iterations.\n        loop {\n            // y = y * (2 - xy) mod n\n            //\n            // Note, that we use wrapping operations here intentionally – the original formula\n            // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod\n            // usize::MAX` instead, because we take the result `mod n` at the end\n            // anyway.\n            if mod_gate >= m {\n                break;\n            }\n            inverse = wrapping_mul(inverse, wrapping_sub(2usize, wrapping_mul(x, inverse)));\n            let (new_gate, overflow) = mul_with_overflow(mod_gate, mod_gate);\n            if overflow {\n                break;\n            }\n            mod_gate = new_gate;\n        }\n        inverse & m_minus_one\n    }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::slice_from_raw_parts\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {\n    from_raw_parts(data, len)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::without_provenance\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance<T>(addr: usize) -> *const T {\n    without_provenance_mut(addr)\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::without_provenance_mut\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {\n    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a\n    // pointer without provenance. Note that this is *not* a stable guarantee about transmute\n    // semantics, it relies on sysroot crates having special status.\n    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that\n    // pointer).\n    unsafe { mem::transmute(addr) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::drop_in_place\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T)"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"std::ptr::align_offset\" }",
+        "file": "library/core/src/ptr/mod.rs",
+        "func": "pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {\n    // FIXME(#75598): Direct use of these intrinsics improves codegen significantly at opt-level <=\n    // 1, where the method versions of these operations are not inlined.\n    use intrinsics::{\n        assume, cttz_nonzero, exact_div, mul_with_overflow, unchecked_rem, unchecked_shl,\n        unchecked_shr, unchecked_sub, wrapping_add, wrapping_mul, wrapping_sub,\n    };\n\n    /// Calculate multiplicative modular inverse of `x` modulo `m`.\n    ///\n    /// This implementation is tailored for `align_offset` and has following preconditions:\n    ///\n    /// * `m` is a power-of-two;\n    /// * `x < m`; (if `x ≥ m`, pass in `x % m` instead)\n    ///\n    /// Implementation of this function shall not panic. Ever.\n    #[inline]\n    const unsafe fn mod_inv(x: usize, m: usize) -> usize {\n        /// Multiplicative modular inverse table modulo 2⁴ = 16.\n        ///\n        /// Note, that this table does not contain values where inverse does not exist (i.e., for\n        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)\n        const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];\n        /// Modulo for which the `INV_TABLE_MOD_16` is intended.\n        const INV_TABLE_MOD: usize = 16;\n\n        // SAFETY: `m` is required to be a power-of-two, hence non-zero.\n        let m_minus_one = unsafe { unchecked_sub(m, 1) };\n        let mut inverse = INV_TABLE_MOD_16[(x & (INV_TABLE_MOD - 1)) >> 1] as usize;\n        let mut mod_gate = INV_TABLE_MOD;\n        // We iterate \"up\" using the following formula:\n        //\n        // $$ xy ≡ 1 (mod 2ⁿ) → xy (2 - xy) ≡ 1 (mod 2²ⁿ) $$\n        //\n        // This application needs to be applied at least until `2²ⁿ ≥ m`, at which point we can\n        // finally reduce the computation to our desired `m` by taking `inverse mod m`.\n        //\n        // This computation is `O(log log m)`, which is to say, that on 64-bit machines this loop\n        // will always finish in at most 4 iterations.\n        loop {\n            // y = y * (2 - xy) mod n\n            //\n            // Note, that we use wrapping operations here intentionally – the original formula\n            // uses e.g., subtraction `mod n`. It is entirely fine to do them `mod\n            // usize::MAX` instead, because we take the result `mod n` at the end\n            // anyway.\n            if mod_gate >= m {\n                break;\n            }\n            inverse = wrapping_mul(inverse, wrapping_sub(2usize, wrapping_mul(x, inverse)));\n            let (new_gate, overflow) = mul_with_overflow(mod_gate, mod_gate);\n            if overflow {\n                break;\n            }\n            mod_gate = new_gate;\n        }\n        inverse & m_minus_one\n    }\n\n    let stride = size_of::<T>();\n\n    let addr: usize = p.addr();\n\n    // SAFETY: `a` is a power-of-two, therefore non-zero.\n    let a_minus_one = unsafe { unchecked_sub(a, 1) };\n\n    if stride == 0 {\n        // SPECIAL_CASE: handle 0-sized types. No matter how many times we step, the address will\n        // stay the same, so no offset will be able to align the pointer unless it is already\n        // aligned. This branch _will_ be optimized out as `stride` is known at compile-time.\n        let p_mod_a = addr & a_minus_one;\n        return if p_mod_a == 0 { 0 } else { usize::MAX };\n    }\n\n    // SAFETY: `stride == 0` case has been handled by the special case above.\n    let a_mod_stride = unsafe { unchecked_rem(a, stride) };\n    if a_mod_stride == 0 {\n        // SPECIAL_CASE: In cases where the `a` is divisible by `stride`, byte offset to align a\n        // pointer can be computed more simply through `-p (mod a)`. In the off-chance the byte\n        // offset is not a multiple of `stride`, the input pointer was misaligned and no pointer\n        // offset will be able to produce a `p` aligned to the specified `a`.\n        //\n        // The naive `-p (mod a)` equation inhibits LLVM's ability to select instructions\n        // like `lea`. We compute `(round_up_to_next_alignment(p, a) - p)` instead. This\n        // redistributes operations around the load-bearing, but pessimizing `and` instruction\n        // sufficiently for LLVM to be able to utilize the various optimizations it knows about.\n        //\n        // LLVM handles the branch here particularly nicely. If this branch needs to be evaluated\n        // at runtime, it will produce a mask `if addr_mod_stride == 0 { 0 } else { usize::MAX }`\n        // in a branch-free way and then bitwise-OR it with whatever result the `-p mod a`\n        // computation produces.\n\n        let aligned_address = wrapping_add(addr, a_minus_one) & wrapping_sub(0, a);\n        let byte_offset = wrapping_sub(aligned_address, addr);\n        // FIXME: Remove the assume after <https://github.com/llvm/llvm-project/issues/62502>\n        // SAFETY: Masking by `-a` can only affect the low bits, and thus cannot have reduced\n        // the value by more than `a-1`, so even though the intermediate values might have\n        // wrapped, the byte_offset is always in `[0, a)`.\n        unsafe { assume(byte_offset < a) };\n\n        // SAFETY: `stride == 0` case has been handled by the special case above.\n        let addr_mod_stride = unsafe { unchecked_rem(addr, stride) };\n\n        return if addr_mod_stride == 0 {\n            // SAFETY: `stride` is non-zero. This is guaranteed to divide exactly as well, because\n            // addr has been verified to be aligned to the original type’s alignment requirements.\n            unsafe { exact_div(byte_offset, stride) }\n        } else {\n            usize::MAX\n        };\n    }\n\n    // GENERAL_CASE: From here on we’re handling the very general case where `addr` may be\n    // misaligned, there isn’t an obvious relationship between `stride` and `a` that we can take an\n    // advantage of, etc. This case produces machine code that isn’t particularly high quality,\n    // compared to the special cases above. The code produced here is still within the realm of\n    // miracles, given the situations this case has to deal with.\n\n    // SAFETY: a is power-of-two hence non-zero. stride == 0 case is handled above.\n    // FIXME(const-hack) replace with min\n    let gcdpow = unsafe {\n        let x = cttz_nonzero(stride);\n        let y = cttz_nonzero(a);\n        if x < y { x } else { y }\n    };\n    // SAFETY: gcdpow has an upper-bound that’s at most the number of bits in a `usize`.\n    let gcd = unsafe { unchecked_shl(1usize, gcdpow) };\n    // SAFETY: gcd is always greater or equal to 1.\n    if addr & unsafe { unchecked_sub(gcd, 1) } == 0 {\n        // This branch solves for the following linear congruence equation:\n        //\n        // ` p + so = 0 mod a `\n        //\n        // `p` here is the pointer value, `s` - stride of `T`, `o` offset in `T`s, and `a` - the\n        // requested alignment.\n        //\n        // With `g = gcd(a, s)`, and the above condition asserting that `p` is also divisible by\n        // `g`, we can denote `a' = a/g`, `s' = s/g`, `p' = p/g`, then this becomes equivalent to:\n        //\n        // ` p' + s'o = 0 mod a' `\n        // ` o = (a' - (p' mod a')) * (s'^-1 mod a') `\n        //\n        // The first term is \"the relative alignment of `p` to `a`\" (divided by the `g`), the\n        // second term is \"how does incrementing `p` by `s` bytes change the relative alignment of\n        // `p`\" (again divided by `g`). Division by `g` is necessary to make the inverse well\n        // formed if `a` and `s` are not co-prime.\n        //\n        // Furthermore, the result produced by this solution is not \"minimal\", so it is necessary\n        // to take the result `o mod lcm(s, a)`. This `lcm(s, a)` is the same as `a'`.\n\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`.\n        let a2 = unsafe { unchecked_shr(a, gcdpow) };\n        // SAFETY: `a2` is non-zero. Shifting `a` by `gcdpow` cannot shift out any of the set bits\n        // in `a` (of which it has exactly one).\n        let a2minus1 = unsafe { unchecked_sub(a2, 1) };\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`.\n        let s2 = unsafe { unchecked_shr(stride & a_minus_one, gcdpow) };\n        // SAFETY: `gcdpow` has an upper-bound not greater than the number of trailing 0-bits in\n        // `a`. Furthermore, the subtraction cannot overflow, because `a2 = a >> gcdpow` will\n        // always be strictly greater than `(p % a) >> gcdpow`.\n        let minusp2 = unsafe { unchecked_sub(a2, unchecked_shr(addr & a_minus_one, gcdpow)) };\n        // SAFETY: `a2` is a power-of-two, as proven above. `s2` is strictly less than `a2`\n        // because `(s % a) >> gcdpow` is strictly less than `a >> gcdpow`.\n        return wrapping_mul(minusp2, unsafe { mod_inv(s2, a2) }) & a2minus1;\n    }\n\n    // Cannot be aligned at all.\n    usize::MAX\n}"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const fn cast_const(self) -> *const T {\n        self as _\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        #[cfg(debug_assertions)]\n        #[inline]\n        #[rustc_allow_const_fn_unstable(const_eval_select)]\n        const fn runtime_add_nowrap(this: *const (), count: usize, size: usize) -> bool {\n            const_eval_select!(\n                @capture { this: *const (), count: usize, size: usize } -> bool:\n                if const {\n                    true\n                } else {\n                    let Some(byte_offset) = count.checked_mul(size) else {\n                        return false;\n                    };\n                    let (_, overflow) = this.addr().overflowing_add(byte_offset);\n                    byte_offset <= (isize::MAX as usize) && !overflow\n                }\n            )\n        }\n\n        #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"ptr::add requires that the address calculation does not overflow\",\n            (\n                this: *const () = self as *const (),\n                count: usize = count,\n                size: usize = size_of::<T>(),\n            ) => runtime_add_nowrap(this, count, size)\n        );\n\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        unsafe { intrinsics::offset(self, count) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/mut_ptr.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `sub_ptr`.\n        unsafe { (self as *const T).offset_from_unsigned(origin) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "fn eq(&self, other: &Self) -> bool {\n        self.as_ptr() == other.as_ptr()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::ptr::NonNull::<T>::as_ptr\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn as_ptr(self) -> *mut T {\n        // This is a transmute for the same reasons as `NonZero::get`.\n\n        // SAFETY: `NonNull` is `transparent` over a `*const T`, and `*const T`\n        // and `*mut T` have the same layout, so transitively we can transmute\n        // our `NonNull` to a `*mut T` directly.\n        unsafe { mem::transmute::<Self, *mut T>(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::cast\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn cast<U>(self) -> NonNull<U> {\n        // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null\n        unsafe { NonNull { pointer: self.as_ptr() as *mut U } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"std::ptr::NonNull::<T>::from_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const fn from_ref(r: &T) -> Self {\n        // SAFETY: A reference cannot be null.\n        unsafe { NonNull { pointer: r as *const T } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"std::ptr::NonNull::<T>::add\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn add(self, count: usize) -> Self\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `offset`.\n        // Additionally safety contract of `offset` guarantees that the resulting pointer is\n        // pointing to an allocation, there can't be an allocation at null, thus it's safe to\n        // construct `NonNull`.\n        unsafe { NonNull { pointer: intrinsics::offset(self.as_ptr(), count) } }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::NonNull::<T>::as_ref\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn as_ref<'a>(&self) -> &'a T {\n        // SAFETY: the caller must guarantee that `self` meets all the\n        // requirements for a reference.\n        // `cast_const` avoids a mutable raw pointer deref.\n        unsafe { &*self.as_ptr().cast_const() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }",
+        "file": "library/core/src/ptr/non_null.rs",
+        "func": "pub const unsafe fn offset_from_unsigned(self, subtracted: NonNull<T>) -> usize\n    where\n        T: Sized,\n    {\n        // SAFETY: the caller must uphold the safety contract for `sub_ptr`.\n        unsafe { self.as_ptr().offset_from_unsigned(subtracted.as_ptr()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Ok(v) => ControlFlow::Continue(v),\n            Err(e) => ControlFlow::Break(Err(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {\n        match self {\n            Ok(v) => ControlFlow::Continue(v),\n            Err(e) => ControlFlow::Break(Err(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn from_residual(residual: Result<convert::Infallible, E>) -> Self {\n        match residual {\n            Err(e) => Err(From::from(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }",
+        "file": "library/core/src/result.rs",
+        "func": "fn from_residual(residual: Result<convert::Infallible, E>) -> Self {\n        match residual {\n            Err(e) => Err(From::from(e)),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::result::Result::<T, E>::is_ok\" }",
+        "file": "library/core/src/result.rs",
+        "func": "pub const fn is_ok(&self) -> bool {\n        matches!(*self, Ok(_))\n    }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn into_iter(self) -> Iter<'a, T> {\n        self.iter()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "fn next(&mut self) -> Option<&'a [T]> {\n        if self.v.is_empty() {\n            None\n        } else {\n            let chunksz = cmp::min(self.v.len(), self.chunk_size);\n            let (fst, snd) = self.v.split_at(chunksz);\n            self.v = snd;\n            Some(fst)\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::Iter::<'a, T>::as_slice\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub fn as_slice(&self) -> &'a [T] {\n        self.make_slice()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::slice::Iter::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T]) -> Self {\n        let len = slice.len();\n        let ptr: NonNull<T> = NonNull::from_ref(slice).cast();\n        // SAFETY: Similar to `IterMut::new`.\n        unsafe {\n            let end_or_len =\n                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };\n\n            Self { ptr, end_or_len, _marker: PhantomData }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::Chunks::<'a, T>::new\" }",
+        "file": "library/core/src/slice/iter.rs",
+        "func": "pub(super) const fn new(slice: &'a [T], size: usize) -> Self {\n        Self { v: slice, chunk_size: size }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn fold<B, F>(self, init: B, mut f: F) -> B\n                where\n                    F: FnMut(B, Self::Item) -> B,\n            {\n                // this implementation consists of the following optimizations compared to the\n                // default implementation:\n                // - do-while loop, as is llvm's preferred loop shape,\n                //   see https://releases.llvm.org/16.0.0/docs/LoopTerminology.html#more-canonical-loops\n                // - bumps an index instead of a pointer since the latter case inhibits\n                //   some optimizations, see #111603\n                // - avoids Option wrapping/matching\n                if is_empty!(self) {\n                    return init;\n                }\n                let mut acc = init;\n                let mut i = 0;\n                let len = len!(self);\n                loop {\n                    // SAFETY: the loop iterates `i in 0..len`, which always is in bounds of\n                    // the slice allocation\n                    acc = f(acc, unsafe { & $( $mut_ )? *self.ptr.add(i).as_ptr() });\n                    // SAFETY: `i` can't overflow since it'll only reach usize::MAX if the\n                    // slice had that length, in which case we'll break out of the loop\n                    // after the increment\n                    i = unsafe { i.unchecked_add(1) };\n                    if i == len {\n                        break;\n                    }\n                }\n                acc\n            }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn len(&self) -> usize {\n                len!(self)\n            }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"std::slice::Iter::<'a, T>::make_slice\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn make_slice(&self) -> &'a [T] {\n                // SAFETY: the iterator was created from a slice with pointer\n                // `self.ptr` and length `len!(self)`. This guarantees that all\n                // the prerequisites for `from_raw_parts` are fulfilled.\n                unsafe { from_raw_parts(self.ptr.as_ptr(), len!(self)) }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/slice/iter/macros.rs",
+        "func": "fn next(&mut self) -> Option<$elem> {\n                // intentionally not using the helpers because this is\n                // one of the most mono'd things in the library.\n\n                let ptr = self.ptr;\n                let end_or_len = self.end_or_len;\n                // SAFETY: See inner comments. (For some reason having multiple\n                // block breaks inlining this -- if you can fix that please do!)\n                unsafe {\n                    if T::IS_ZST {\n                        let len = end_or_len.addr();\n                        if len == 0 {\n                            return None;\n                        }\n                        // SAFETY: just checked that it's not zero, so subtracting one\n                        // cannot wrap.  (Ideally this would be `checked_sub`, which\n                        // does the same thing internally, but as of 2025-02 that\n                        // doesn't optimize quite as small in MIR.)\n                        self.end_or_len = without_provenance_mut(len.unchecked_sub(1));\n                    } else {\n                        // SAFETY: by type invariant, the `end_or_len` field is always\n                        // non-null for a non-ZST pointee.  (This transmute ensures we\n                        // get `!nonnull` metadata on the load of the field.)\n                        if ptr == crate::intrinsics::transmute::<$ptr, NonNull<T>>(end_or_len) {\n                            return None;\n                        }\n                        // SAFETY: since it's not empty, per the check above, moving\n                        // forward one keeps us inside the slice, and this is valid.\n                        self.ptr = ptr.add(1);\n                    }\n                    // SAFETY: Now that we know it wasn't empty and we've moved past\n                    // the first one (to avoid giving a duplicate `&mut` next time),\n                    // we can give out a reference to it.\n                    Some({ptr}.$into_ref())\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 236, name: \"core::slice::<impl [T]>::align_to_offsets\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "fn align_to_offsets<U>(&self) -> (usize, usize) {\n        // What we gonna do about `rest` is figure out what multiple of `U`s we can put in a\n        // lowest number of `T`s. And how many `T`s we need for each such \"multiple\".\n        //\n        // Consider for example T=u8 U=u16. Then we can put 1 U in 2 Ts. Simple. Now, consider\n        // for example a case where size_of::<T> = 16, size_of::<U> = 24. We can put 2 Us in\n        // place of every 3 Ts in the `rest` slice. A bit more complicated.\n        //\n        // Formula to calculate this is:\n        //\n        // Us = lcm(size_of::<T>, size_of::<U>) / size_of::<U>\n        // Ts = lcm(size_of::<T>, size_of::<U>) / size_of::<T>\n        //\n        // Expanded and simplified:\n        //\n        // Us = size_of::<T> / gcd(size_of::<T>, size_of::<U>)\n        // Ts = size_of::<U> / gcd(size_of::<T>, size_of::<U>)\n        //\n        // Luckily since all this is constant-evaluated... performance here matters not!\n        const fn gcd(a: usize, b: usize) -> usize {\n            if b == 0 { a } else { gcd(b, a % b) }\n        }\n\n        // Explicitly wrap the function call in a const block so it gets\n        // constant-evaluated even in debug mode.\n        let gcd: usize = const { gcd(size_of::<T>(), size_of::<U>()) };\n        let ts: usize = size_of::<U>() / gcd;\n        let us: usize = size_of::<T>() / gcd;\n\n        // Armed with this knowledge, we can find how many `U`s we can fit!\n        let us_len = self.len() / ts * us;\n        // And how many `T`s will be in the trailing slice!\n        let ts_len = self.len() % ts;\n        (us_len, ts_len)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::slice::<impl [T]>::as_chunks\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_chunks<const N: usize>(&self) -> (&[[T; N]], &[T]) {\n        assert!(N != 0, \"chunk size must be non-zero\");\n        let len_rounded_down = self.len() / N * N;\n        // SAFETY: The rounded-down value is always the same or smaller than the\n        // original length, and thus must be in-bounds of the slice.\n        let (multiple_of_n, remainder) = unsafe { self.split_at_unchecked(len_rounded_down) };\n        // SAFETY: We already panicked for zero, and ensured by construction\n        // that the length of the subslice is a multiple of N.\n        let array_slice = unsafe { multiple_of_n.as_chunks_unchecked() };\n        (array_slice, remainder)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"core::slice::<impl [T]>::as_ptr\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_ptr(&self) -> *const T {\n        self as *const [T] as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"core::slice::<impl [T]>::as_ptr\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn as_ptr(&self) -> *const T {\n        self as *const [T] as *const T\n    }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::chunks\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn chunks(&self, chunk_size: usize) -> Chunks<'_, T> {\n        assert!(chunk_size != 0, \"chunk size must be non-zero\");\n        Chunks::new(self, chunk_size)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"core::slice::<impl [T]>::is_empty\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn is_empty(&self) -> bool {\n        self.len() == 0\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"core::slice::<impl [T]>::iter\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn iter(&self) -> Iter<'_, T> {\n        Iter::new(self)\n    }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"core::slice::<impl [T]>::split_at\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {\n        match self.split_at_checked(mid) {\n            Some(pair) => pair,\n            None => panic!(\"mid > len\"),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"core::slice::<impl [T]>::split_at\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {\n        match self.split_at_checked(mid) {\n            Some(pair) => pair,\n            None => panic!(\"mid > len\"),\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"core::slice::<impl [T]>::split_at_checked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {\n        if mid <= self.len() {\n            // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which\n            // fulfills the requirements of `split_at_unchecked`.\n            Some(unsafe { self.split_at_unchecked(mid) })\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"core::slice::<impl [T]>::split_at_checked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {\n        if mid <= self.len() {\n            // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which\n            // fulfills the requirements of `split_at_unchecked`.\n            Some(unsafe { self.split_at_unchecked(mid) })\n        } else {\n            None\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {\n        assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks\",\n            (n: usize = N, len: usize = self.len()) => n != 0 && len % n == 0,\n        );\n        // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length\n        let new_len = unsafe { exact_div(self.len(), N) };\n        // SAFETY: We cast a slice of `new_len * N` elements into\n        // a slice of `new_len` many `N` elements chunks.\n        unsafe { from_raw_parts(self.as_ptr().cast(), new_len) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"core::slice::<impl [T]>::split_at_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {\n        // FIXME(const-hack): the const function `from_raw_parts` is used to make this\n        // function const; previously the implementation used\n        // `(self.get_unchecked(..mid), self.get_unchecked(mid..))`\n\n        let len = self.len();\n        let ptr = self.as_ptr();\n\n        assert_unsafe_precondition!(\n            check_library_ub,\n            \"slice::split_at_unchecked requires the index to be within the slice\",\n            (mid: usize = mid, len: usize = len) => mid <= len,\n        );\n\n        // SAFETY: Caller has to check that `0 <= mid <= self.len()`\n        unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"core::slice::<impl [T]>::split_at_unchecked\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {\n        // FIXME(const-hack): the const function `from_raw_parts` is used to make this\n        // function const; previously the implementation used\n        // `(self.get_unchecked(..mid), self.get_unchecked(mid..))`\n\n        let len = self.len();\n        let ptr = self.as_ptr();\n\n        assert_unsafe_precondition!(\n            check_library_ub,\n            \"slice::split_at_unchecked requires the index to be within the slice\",\n            (mid: usize = mid, len: usize = len) => mid <= len,\n        );\n\n        // SAFETY: Caller has to check that `0 <= mid <= self.len()`\n        unsafe { (from_raw_parts(ptr, mid), from_raw_parts(ptr.add(mid), unchecked_sub(len, mid))) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 197, name: \"core::slice::<impl [T]>::align_to\" }",
+        "file": "library/core/src/slice/mod.rs",
+        "func": "pub unsafe fn align_to<U>(&self) -> (&[T], &[U], &[T]) {\n        // Note that most of this function will be constant-evaluated,\n        if U::IS_ZST || T::IS_ZST {\n            // handle ZSTs specially, which is – don't handle them at all.\n            return (self, &[], &[]);\n        }\n\n        // First, find at what point do we split between the first and 2nd slice. Easy with\n        // ptr.align_offset.\n        let ptr = self.as_ptr();\n        // SAFETY: See the `align_to_mut` method for the detailed safety comment.\n        let offset = unsafe { crate::ptr::align_offset(ptr, align_of::<U>()) };\n        if offset > self.len() {\n            (self, &[], &[])\n        } else {\n            let (left, rest) = self.split_at(offset);\n            let (us_len, ts_len) = rest.align_to_offsets::<U>();\n            // Inform Miri that we want to consider the \"middle\" pointer to be suitably aligned.\n            #[cfg(miri)]\n            crate::intrinsics::miri_promise_symbolic_alignment(\n                rest.as_ptr().cast(),\n                align_of::<U>(),\n            );\n            // SAFETY: now `rest` is definitely aligned, so `from_raw_parts` below is okay,\n            // since the caller guarantees that we can transmute `T` to `U` safely.\n            unsafe {\n                (\n                    left,\n                    from_raw_parts(rest.as_ptr() as *const U, us_len),\n                    from_raw_parts(rest.as_ptr().add(rest.len() - ts_len), ts_len),\n                )\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::slice::from_raw_parts\" }",
+        "file": "library/core/src/slice/raw.rs",
+        "func": "pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {\n    // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.\n    unsafe {\n        ub_checks::assert_unsafe_precondition!(\n            check_language_ub,\n            \"slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`\",\n            (\n                data: *mut () = data as *mut (),\n                size: usize = size_of::<T>(),\n                align: usize = align_of::<T>(),\n                len: usize = len,\n            ) =>\n            ub_checks::maybe_is_aligned_and_not_null(data, align, false)\n                && ub_checks::is_valid_allocation_size(size, len)\n        );\n        &*ptr::slice_from_raw_parts(data, len)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"std::str::from_utf8_unchecked\" }",
+        "file": "library/core/src/str/converts.rs",
+        "func": "pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {\n    // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.\n    // Also relies on `&str` and `&[u8]` having the same layout.\n    unsafe { mem::transmute(v) }\n}"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"core::str::count::char_count_general_case\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn char_count_general_case(s: &[u8]) -> usize {\n    s.iter().filter(|&&byte| !super::validations::utf8_is_cont_byte(byte)).count()\n}"
+      },
+      {
+        "def_id": "DefId { id: 207, name: \"core::str::count::contains_non_continuation_byte\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn contains_non_continuation_byte(w: usize) -> usize {\n    const LSB: usize = usize::repeat_u8(0x01);\n    ((!w >> 7) | (w >> 6)) & LSB\n}"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"core::str::count::do_count_chars\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn do_count_chars(s: &str) -> usize {\n    // For correctness, `CHUNK_SIZE` must be:\n    //\n    // - Less than or equal to 255, otherwise we'll overflow bytes in `counts`.\n    // - A multiple of `UNROLL_INNER`, otherwise our `break` inside the\n    //   `body.chunks(CHUNK_SIZE)` loop is incorrect.\n    //\n    // For performance, `CHUNK_SIZE` should be:\n    // - Relatively cheap to `/` against (so some simple sum of powers of two).\n    // - Large enough to avoid paying for the cost of the `sum_bytes_in_usize`\n    //   too often.\n    const CHUNK_SIZE: usize = 192;\n\n    // Check the properties of `CHUNK_SIZE` and `UNROLL_INNER` that are required\n    // for correctness.\n    const _: () = assert!(CHUNK_SIZE < 256);\n    const _: () = assert!(CHUNK_SIZE % UNROLL_INNER == 0);\n\n    // SAFETY: transmuting `[u8]` to `[usize]` is safe except for size\n    // differences which are handled by `align_to`.\n    let (head, body, tail) = unsafe { s.as_bytes().align_to::<usize>() };\n\n    // This should be quite rare, and basically exists to handle the degenerate\n    // cases where align_to fails (as well as miri under symbolic alignment\n    // mode).\n    //\n    // The `unlikely` helps discourage LLVM from inlining the body, which is\n    // nice, as we would rather not mark the `char_count_general_case` function\n    // as cold.\n    if unlikely(body.is_empty() || head.len() > USIZE_SIZE || tail.len() > USIZE_SIZE) {\n        return char_count_general_case(s.as_bytes());\n    }\n\n    let mut total = char_count_general_case(head) + char_count_general_case(tail);\n    // Split `body` into `CHUNK_SIZE` chunks to reduce the frequency with which\n    // we call `sum_bytes_in_usize`.\n    for chunk in body.chunks(CHUNK_SIZE) {\n        // We accumulate intermediate sums in `counts`, where each byte contains\n        // a subset of the sum of this chunk, like a `[u8; size_of::<usize>()]`.\n        let mut counts = 0;\n\n        let (unrolled_chunks, remainder) = chunk.as_chunks::<UNROLL_INNER>();\n        for unrolled in unrolled_chunks {\n            for &word in unrolled {\n                // Because `CHUNK_SIZE` is < 256, this addition can't cause the\n                // count in any of the bytes to overflow into a subsequent byte.\n                counts += contains_non_continuation_byte(word);\n            }\n        }\n\n        // Sum the values in `counts` (which, again, is conceptually a `[u8;\n        // size_of::<usize>()]`), and accumulate the result into `total`.\n        total += sum_bytes_in_usize(counts);\n\n        // If there's any data in `remainder`, then handle it. This will only\n        // happen for the last `chunk` in `body.chunks()` (because `CHUNK_SIZE`\n        // is divisible by `UNROLL_INNER`), so we explicitly break at the end\n        // (which seems to help LLVM out).\n        if !remainder.is_empty() {\n            // Accumulate all the data in the remainder.\n            let mut counts = 0;\n            for &word in remainder {\n                counts += contains_non_continuation_byte(word);\n            }\n            total += sum_bytes_in_usize(counts);\n            break;\n        }\n    }\n    total\n}"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"core::str::count::sum_bytes_in_usize\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "fn sum_bytes_in_usize(values: usize) -> usize {\n    const LSB_SHORTS: usize = usize::repeat_u16(0x0001);\n    const SKIP_BYTES: usize = usize::repeat_u16(0x00ff);\n\n    let pair_sum: usize = (values & SKIP_BYTES) + ((values >> 8) & SKIP_BYTES);\n    pair_sum.wrapping_mul(LSB_SHORTS) >> ((USIZE_SIZE - 2) * 8)\n}"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"core::str::count::count_chars\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "pub(super) fn count_chars(s: &str) -> usize {\n    if cfg!(feature = \"optimize_for_size\") || s.len() < USIZE_SIZE * UNROLL_INNER {\n        // Avoid entering the optimized implementation for strings where the\n        // difference is not likely to matter, or where it might even be slower.\n        // That said, a ton of thought was not spent on the particular threshold\n        // here, beyond \"this value seems to make sense\".\n        char_count_general_case(s.as_bytes())\n    } else {\n        do_count_chars(s)\n    }\n}"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::str::count::char_count_general_case::{closure#0}\" }",
+        "file": "library/core/src/str/count.rs",
+        "func": "|&&byte| !super::validations::utf8_is_cont_byte(byte)"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn count(self) -> usize {\n        super::count::count_chars(self.as_str())\n    }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn next(&mut self) -> Option<(usize, char)> {\n        let pre_len = self.iter.iter.len();\n        match self.iter.next() {\n            None => None,\n            Some(ch) => {\n                let index = self.front_offset;\n                let len = self.iter.iter.len();\n                self.front_offset += pre_len - len;\n                Some((index, ch))\n            }\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "fn next(&mut self) -> Option<char> {\n        // SAFETY: `str` invariant says `self.iter` is a valid UTF-8 string and\n        // the resulting `ch` is a valid Unicode Scalar Value.\n        unsafe { next_code_point(&mut self.iter).map(|ch| char::from_u32_unchecked(ch)) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::str::Chars::<'a>::as_str\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "pub fn as_str(&self) -> &'a str {\n        // SAFETY: `Chars` is only made from a str, which guarantees the iter is valid UTF-8.\n        unsafe { from_utf8_unchecked(self.iter.as_slice()) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::str::CharIndices::<'a>::offset\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "pub fn offset(&self) -> usize {\n        self.front_offset\n    }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }",
+        "file": "library/core/src/str/iter.rs",
+        "func": "|ch| char::from_u32_unchecked(ch)"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"core::str::<impl str>::as_bytes\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub const fn as_bytes(&self) -> &[u8] {\n        // SAFETY: const sound because we transmute two types with the same layout\n        unsafe { mem::transmute(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"core::str::<impl str>::len\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub const fn len(&self) -> usize {\n        self.as_bytes().len()\n    }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::char_indices\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub fn char_indices(&self) -> CharIndices<'_> {\n        CharIndices { front_offset: 0, iter: self.chars() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 81, name: \"core::str::<impl str>::chars\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub fn chars(&self) -> Chars<'_> {\n        Chars { iter: self.as_bytes().iter() }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"core::str::<impl str>::get_unchecked\" }",
+        "file": "library/core/src/str/mod.rs",
+        "func": "pub unsafe fn get_unchecked<I: SliceIndex<str>>(&self, i: I) -> &I::Output {\n        // SAFETY: the caller must uphold the safety contract for `get_unchecked`;\n        // the slice is dereferenceable because `self` is a safe reference.\n        // The returned pointer is safe because impls of `SliceIndex` have to guarantee that it is.\n        unsafe { &*i.get_unchecked(self) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 144, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }",
+        "file": "library/core/src/str/traits.rs",
+        "func": "unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {\n        // SAFETY: the caller has to uphold the safety contract for `get_unchecked`.\n        unsafe { (0..self.end).get_unchecked(slice) }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }",
+        "file": "library/core/src/str/traits.rs",
+        "func": "unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {\n        let slice = slice as *const [u8];\n\n        assert_unsafe_precondition!(\n            // We'd like to check that the bounds are on char boundaries,\n            // but there's not really a way to do so without reading\n            // behind the pointer, which has aliasing implications.\n            // It's also not possible to move this check up to\n            // `str::get_unchecked` without adding a special function\n            // to `SliceIndex` just for this.\n            check_library_ub,\n            \"str::get_unchecked requires that the range is within the string slice\",\n            (\n                start: usize = self.start,\n                end: usize = self.end,\n                len: usize = slice.len()\n            ) => end >= start && end <= len,\n        );\n\n        // SAFETY: the caller guarantees that `self` is in bounds of `slice`\n        // which satisfies all the conditions for `add`.\n        unsafe {\n            let new_len = unchecked_sub(self.end, self.start);\n            ptr::slice_from_raw_parts(slice.as_ptr().add(self.start), new_len) as *const str\n        }\n    }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"core::str::validations::utf8_acc_cont_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "const fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {\n    (ch << 6) | (byte & CONT_MASK) as u32\n}"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::str::validations::utf8_first_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "const fn utf8_first_byte(byte: u8, width: u32) -> u32 {\n    (byte & (0x7F >> width)) as u32\n}"
+      },
+      {
+        "def_id": "DefId { id: 253, name: \"core::str::validations::next_code_point\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "pub unsafe fn next_code_point<'a, I: Iterator<Item = &'a u8>>(bytes: &mut I) -> Option<u32> {\n    // Decode UTF-8\n    let x = *bytes.next()?;\n    if x < 128 {\n        return Some(x as u32);\n    }\n\n    // Multibyte case follows\n    // Decode from a byte combination out of: [[[x y] z] w]\n    // NOTE: Performance is sensitive to the exact formulation here\n    let init = utf8_first_byte(x, 2);\n    // SAFETY: `bytes` produces an UTF-8-like string,\n    // so the iterator must produce a value here.\n    let y = unsafe { *bytes.next().unwrap_unchecked() };\n    let mut ch = utf8_acc_cont_byte(init, y);\n    if x >= 0xE0 {\n        // [[x y z] w] case\n        // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid\n        // SAFETY: `bytes` produces an UTF-8-like string,\n        // so the iterator must produce a value here.\n        let z = unsafe { *bytes.next().unwrap_unchecked() };\n        let y_z = utf8_acc_cont_byte((y & CONT_MASK) as u32, z);\n        ch = init << 12 | y_z;\n        if x >= 0xF0 {\n            // [x y z w] case\n            // use only the lower 3 bits of `init`\n            // SAFETY: `bytes` produces an UTF-8-like string,\n            // so the iterator must produce a value here.\n            let w = unsafe { *bytes.next().unwrap_unchecked() };\n            ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);\n        }\n    }\n\n    Some(ch)\n}"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"core::str::validations::utf8_is_cont_byte\" }",
+        "file": "library/core/src/str/validations.rs",
+        "func": "pub(super) const fn utf8_is_cont_byte(byte: u8) -> bool {\n    (byte as i8) < -64\n}"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"std::hint::unreachable_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"std::slice::from_raw_parts::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "const fn precondition_check($($name:$ty),*) {\n                if !$e {\n                    ::core::panicking::panic_nounwind(concat!(\"unsafe precondition(s) violated: \", $message,\n                        \"\\n\\nThis indicates a bug in the program. \\\n                        This Undefined Behavior check is optional, and cannot be relied on for safety.\"));\n                }\n            }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"core::ub_checks::check_language_ub\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn check_language_ub() -> bool {\n    // Only used for UB checks so we may const_eval_select.\n    intrinsics::ub_checks()\n        && const_eval_select!(\n            @capture { } -> bool:\n            if const {\n                // Always disable UB checks.\n                false\n            } else {\n                // Disable UB checks in Miri.\n                !cfg!(miri)\n            }\n        )\n}"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"core::ub_checks::is_valid_allocation_size\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn is_valid_allocation_size(size: usize, len: usize) -> bool {\n    let max_len = if size == 0 { usize::MAX } else { isize::MAX as usize / size };\n    len <= max_len\n}"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }",
+        "file": "library/core/src/ub_checks.rs",
+        "func": "pub(crate) const fn maybe_is_aligned_and_not_null(\n    ptr: *const (),\n    align: usize,\n    is_zst: bool,\n) -> bool {\n    // This is just for safety checks so we can const_eval_select.\n    const_eval_select!(\n        @capture { ptr: *const (), align: usize, is_zst: bool } -> bool:\n        if const {\n            is_zst || !ptr.is_null()\n        } else {\n            ptr.is_aligned_to(align) && (is_zst || !ptr.is_null())\n        }\n    )\n}"
+      },
+      {
+        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::ensures(|&ret| ret > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::ensures(|&ret| ret > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::ensures(|&ret| ret > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::ensures(|&ret| ret > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::ensures(|&ret| ret > 0)]"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }",
+        "file": "tests/proofs/proofs_for_contract.rs",
+        "func": "#[kani::ensures(|&ret| ret > 0)]"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Only need to test one contract for each `#[kani::proof_for_contract]` proof:
* cc https://github.com/os-checker/distributed-verification/discussions/28
* cc https://github.com/os-checker/distributed-verification/issues/16

