### PR TITLE
Feat: add `--simplify-json` to generate smaller JSON

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,7 @@ jobs:
           cat ${{ env.CORE_JSON }}
 
       - name: Print core.json
-        run: ls -alh core.json && head -n 5000 core.json # core.json is large
+        run: |
+          ls -alh core.json
+          # head -n 5000 core.json
+          cat core.json

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,5 @@
-use crate::functions::SourceCode;
 use clap::Parser;
 use distributed_verification::kani_path;
-use std::sync::{LazyLock, Mutex};
 
 /// Parse cli arguments.
 pub fn parse() -> Run {
@@ -70,30 +68,18 @@ impl Args {
         };
         args.extend(self.rustc_args);
 
-        // set SIMPLIFY_JSON
-        STATE.lock().unwrap().simplify_json = self.simplify_json;
-
-        Run { json: self.json, check_kani_list: self.check_kani_list, rustc_args: args }
+        Run {
+            json: self.json,
+            check_kani_list: self.check_kani_list,
+            simplify_json: self.simplify_json,
+            rustc_args: args,
+        }
     }
 }
 
 pub struct Run {
     pub json: Option<String>,
     pub check_kani_list: bool,
+    pub simplify_json: bool,
     pub rustc_args: Vec<String>,
-}
-
-static STATE: LazyLock<Mutex<GlobalState>> =
-    LazyLock::new(|| Mutex::new(GlobalState { simplify_json: false }));
-
-struct GlobalState {
-    simplify_json: bool,
-}
-
-/// simplify_json = false => don't skip
-/// simplify_json = true => skip
-pub fn skip_serialize_callee_souce_code(_: &SourceCode) -> bool {
-    // NOTE: Stable MIR is run on another thread, which is not the same as main thread.
-    // So this function need a synchronous global state.
-    STATE.lock().unwrap().simplify_json
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -13,7 +13,7 @@ pub use cache::{clear_rustc_ctx, set_rustc_ctx};
 mod kani;
 
 mod utils;
-pub use utils::vec_convertion;
+pub use utils::{SourceCode, vec_convertion};
 
 mod serialization;
 pub use serialization::SerFunction;

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -13,7 +13,7 @@ pub use cache::{clear_rustc_ctx, set_rustc_ctx};
 mod kani;
 
 mod utils;
-pub use utils::{SourceCode, vec_convertion};
+pub use utils::vec_convertion;
 
 mod serialization;
 pub use serialization::SerFunction;

--- a/src/functions/serialization.rs
+++ b/src/functions/serialization.rs
@@ -1,5 +1,4 @@
 use super::{cache, utils::SourceCode};
-use crate::cli::skip_serialize_callee_souce_code;
 use rustc_stable_hash::{FromStableHash, SipHasher128Hash, StableHasher, hashers::SipHasher128};
 use serde::Serialize;
 use stable_mir::{CrateDef, mir::mono::Instance};
@@ -72,7 +71,6 @@ fn format_def_id(inst: &Instance) -> String {
 #[derive(Debug, Serialize)]
 pub struct Callee {
     def_id: String,
-    #[serde(skip_serializing_if = "skip_serialize_callee_souce_code")]
     func: SourceCode,
 }
 
@@ -160,6 +158,19 @@ mod conversion {
     impl From<MacroBacktrace> for lib::MacroBacktrace {
         fn from(MacroBacktrace { callsite, defsite }: MacroBacktrace) -> Self {
             Self { callsite, defsite }
+        }
+    }
+
+    impl From<&SerFunction> for lib::SimplifiedSerFunction {
+        fn from(val: &SerFunction) -> Self {
+            Self {
+                hash: val.hash.clone(),
+                attrs: val.attrs.clone(),
+                name: val.func.name.clone(),
+                file: val.func.file.clone(),
+                callees_len: val.callees_len,
+                callees: val.callees.iter().map(|c| c.func.name.clone()).collect(),
+            }
         }
     }
 }

--- a/src/functions/serialization.rs
+++ b/src/functions/serialization.rs
@@ -1,4 +1,5 @@
 use super::{cache, utils::SourceCode};
+use crate::cli::skip_serialize_callee_souce_code;
 use rustc_stable_hash::{FromStableHash, SipHasher128Hash, StableHasher, hashers::SipHasher128};
 use serde::Serialize;
 use stable_mir::{CrateDef, mir::mono::Instance};
@@ -71,6 +72,7 @@ fn format_def_id(inst: &Instance) -> String {
 #[derive(Debug, Serialize)]
 pub struct Callee {
     def_id: String,
+    #[serde(skip_serializing_if = "skip_serialize_callee_souce_code")]
     func: SourceCode,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub enum Kind {
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Callee {
     pub def_id: String,
+    #[serde(default)]
     pub func: SourceCode,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub enum Kind {
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Callee {
     pub def_id: String,
-    #[serde(default)]
     pub func: SourceCode,
 }
 
@@ -97,4 +96,27 @@ pub fn kani_path() -> String {
     };
     assert!(std::fs::exists(&path).unwrap());
     path
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct SimplifiedSerFunction {
+    pub hash: String,
+    pub attrs: Vec<String>,
+    pub name: String,
+    pub file: String,
+    pub callees_len: usize,
+    pub callees: Vec<String>,
+}
+
+impl From<&SerFunction> for SimplifiedSerFunction {
+    fn from(val: &SerFunction) -> Self {
+        SimplifiedSerFunction {
+            hash: val.hash.clone(),
+            attrs: val.attrs.clone(),
+            name: val.func.name.clone(),
+            file: val.func.file.clone(),
+            callees_len: val.callees_len,
+            callees: val.callees.iter().map(|c| c.func.name.clone()).collect(),
+        }
+    }
 }

--- a/tests/dummy-crate/examples/verify_rust_std.rs
+++ b/tests/dummy-crate/examples/verify_rust_std.rs
@@ -140,8 +140,14 @@ fn build_core(args: Vec<String>) {
     let mut new_args = Vec::with_capacity(args.len() + 2);
     let core_json = var("CORE_JSON");
     new_args.extend(
-        ["--no-kani-args", "--json", core_json.as_deref().unwrap_or(CORE_JSON), "--"]
-            .map(String::from),
+        [
+            "--no-kani-args",
+            "--simplify-json",
+            "--json",
+            core_json.as_deref().unwrap_or(CORE_JSON),
+            "--",
+        ]
+        .map(String::from),
     );
     new_args.extend(args);
     run("distributed-verification", &new_args, &[]);

--- a/tests/kani_list.rs
+++ b/tests/kani_list.rs
@@ -17,7 +17,7 @@ fn validate_kani_list_json() -> Result<()> {
         let kani_list = get_kani_list(path);
         expect_file![list_path].assert_debug_eq(&kani_list);
 
-        // run `distributed_verification`
+        // run `distributed-verification`
         let text = cmd(&[path]);
         let v_ser_function: Vec<SerFunction> = serde_json::from_str(&text).unwrap();
         check_proofs(&kani_list, &v_ser_function);

--- a/tests/simplified/ad_hoc.json
+++ b/tests/simplified/ad_hoc.json
@@ -1,0 +1,92 @@
+[
+  {
+    "hash": "231371728546000426415569688603538432620",
+    "def_id": "DefId { id: 0, name: \"adhoc::callee_defined_in_proof\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "adhoc::callee_defined_in_proof",
+      "mangled_name": "_ZN6ad_hoc5adhoc23callee_defined_in_proof17h04faf672d1be046dE",
+      "kind": "Item",
+      "file": "tests/proofs/ad_hoc.rs",
+      "src": "fn callee_defined_in_proof() {\n        fn f() -> u8 {\n            1\n        }\n        assert!(f() == 1);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 2,
+    "callees": [
+      {
+        "def_id": "DefId { id: 1, name: \"adhoc::callee_defined_in_proof::f\" }"
+      },
+      {
+        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
+      }
+    ]
+  },
+  {
+    "hash": "61932375823549408104071622445676960413",
+    "def_id": "DefId { id: 2, name: \"adhoc::closure_in_proof\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "adhoc::closure_in_proof",
+      "mangled_name": "_ZN6ad_hoc5adhoc16closure_in_proof17hc3a9b3580daf319eE",
+      "kind": "Item",
+      "file": "tests/proofs/ad_hoc.rs",
+      "src": "fn closure_in_proof() {\n        let f = || 1;\n        assert!(f() == 1);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 2,
+    "callees": [
+      {
+        "def_id": "DefId { id: 3, name: \"adhoc::closure_in_proof::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
+      }
+    ]
+  },
+  {
+    "hash": "6925603377655101244643534194235942800",
+    "def_id": "DefId { id: 5, name: \"adhoc::proof_in_fn_item::proof\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "adhoc::proof_in_fn_item::proof",
+      "mangled_name": "_ZN6ad_hoc5adhoc16proof_in_fn_item5proof17h81a8c21d61ba53baE",
+      "kind": "Item",
+      "file": "tests/proofs/ad_hoc.rs",
+      "src": "fn proof() {\n            assert!(kani::any::<u8>() == 1);\n        }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 10, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 12, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 11, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 13, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  }
+]

--- a/tests/simplified/ad_hoc.json
+++ b/tests/simplified/ad_hoc.json
@@ -1,92 +1,45 @@
 [
   {
     "hash": "231371728546000426415569688603538432620",
-    "def_id": "DefId { id: 0, name: \"adhoc::callee_defined_in_proof\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "adhoc::callee_defined_in_proof",
-      "mangled_name": "_ZN6ad_hoc5adhoc23callee_defined_in_proof17h04faf672d1be046dE",
-      "kind": "Item",
-      "file": "tests/proofs/ad_hoc.rs",
-      "src": "fn callee_defined_in_proof() {\n        fn f() -> u8 {\n            1\n        }\n        assert!(f() == 1);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "adhoc::callee_defined_in_proof",
+    "file": "tests/proofs/ad_hoc.rs",
     "callees_len": 2,
     "callees": [
-      {
-        "def_id": "DefId { id: 1, name: \"adhoc::callee_defined_in_proof::f\" }"
-      },
-      {
-        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
-      }
+      "adhoc::callee_defined_in_proof::f",
+      "kani::assert"
     ]
   },
   {
     "hash": "61932375823549408104071622445676960413",
-    "def_id": "DefId { id: 2, name: \"adhoc::closure_in_proof\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "adhoc::closure_in_proof",
-      "mangled_name": "_ZN6ad_hoc5adhoc16closure_in_proof17hc3a9b3580daf319eE",
-      "kind": "Item",
-      "file": "tests/proofs/ad_hoc.rs",
-      "src": "fn closure_in_proof() {\n        let f = || 1;\n        assert!(f() == 1);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "adhoc::closure_in_proof",
+    "file": "tests/proofs/ad_hoc.rs",
     "callees_len": 2,
     "callees": [
-      {
-        "def_id": "DefId { id: 3, name: \"adhoc::closure_in_proof::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
-      }
+      "adhoc::closure_in_proof::{closure#0}",
+      "kani::assert"
     ]
   },
   {
     "hash": "6925603377655101244643534194235942800",
-    "def_id": "DefId { id: 5, name: \"adhoc::proof_in_fn_item::proof\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "adhoc::proof_in_fn_item::proof",
-      "mangled_name": "_ZN6ad_hoc5adhoc16proof_in_fn_item5proof17h81a8c21d61ba53baE",
-      "kind": "Item",
-      "file": "tests/proofs/ad_hoc.rs",
-      "src": "fn proof() {\n            assert!(kani::any::<u8>() == 1);\n        }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "adhoc::proof_in_fn_item::proof",
+    "file": "tests/proofs/ad_hoc.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 10, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 12, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 11, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 13, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   }
 ]

--- a/tests/simplified/gen_contracts_by_macros.json
+++ b/tests/simplified/gen_contracts_by_macros.json
@@ -1,2336 +1,788 @@
 [
   {
     "hash": "1689096496237791355510770873012758110496",
-    "def_id": "DefId { id: 13, name: \"verify::proof1\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract1\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::proof1",
-      "mangled_name": "_ZN23gen_contracts_by_macros6verify6proof117he3754be12d716b06E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_contracts_by_macros.rs",
-      "src": "fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }",
-      "macro_backtrace_len": 1,
-      "macro_backtrace": [
-        {
-          "callsite": "gen! { proof1: contract1(arg), arg > 0}",
-          "defsite": "macro_rules! gen {\n    ($proof:ident: $contract_name:ident($arg:ident), $e:expr) => {\n        #[kani::requires($e)]\n        fn $contract_name($arg: u8) -> u8 { $arg }\n\n        #[kani::proof_for_contract($contract_name)]\n        fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }\n    }\n}"
-        }
-      ]
-    },
+    "name": "verify::proof1",
+    "file": "tests/proofs/gen_contracts_by_macros.rs",
     "callees_len": 251,
     "callees": [
-      {
-        "def_id": "DefId { id: 56, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 130, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 222, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 132, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 137, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 46, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 253, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 107, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 207, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 89, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 66, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 74, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 98, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 188, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"kani::kani_intrinsic\" }"
-      },
-      {
-        "def_id": "DefId { id: 42, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 44, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 236, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 68, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 47, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 60, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 254, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 165, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 135, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 255, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 111, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 101, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 45, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 48, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 214, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 216, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 72, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 0, name: \"verify::contract1\" }"
-      },
-      {
-        "def_id": "DefId { id: 2, name: \"verify::contract1::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<u8 as kani::Arbitrary>::any",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::internal::init_contracts",
+      "kani::kani_intrinsic::<u8>",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract1",
+      "verify::contract1::kani_contract_mode",
+      "verify::contract1::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract1::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract1::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract1::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>"
     ]
   },
   {
     "hash": "68469033701256472383683903298250524375",
-    "def_id": "DefId { id: 27, name: \"verify::proof2\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract2\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::proof2",
-      "mangled_name": "_ZN23gen_contracts_by_macros6verify6proof217hedb9389a247d4c11E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_contracts_by_macros.rs",
-      "src": "fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }",
-      "macro_backtrace_len": 1,
-      "macro_backtrace": [
-        {
-          "callsite": "gen! { proof2: contract2(arg), arg != 0}",
-          "defsite": "macro_rules! gen {\n    ($proof:ident: $contract_name:ident($arg:ident), $e:expr) => {\n        #[kani::requires($e)]\n        fn $contract_name($arg: u8) -> u8 { $arg }\n\n        #[kani::proof_for_contract($contract_name)]\n        fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }\n    }\n}"
-        }
-      ]
-    },
+    "name": "verify::proof2",
+    "file": "tests/proofs/gen_contracts_by_macros.rs",
     "callees_len": 251,
     "callees": [
-      {
-        "def_id": "DefId { id: 56, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 130, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 222, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 132, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 137, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 46, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 253, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 107, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 207, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 89, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 66, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 74, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 98, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 188, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"kani::kani_intrinsic\" }"
-      },
-      {
-        "def_id": "DefId { id: 42, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 44, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 236, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 68, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 47, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 60, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 254, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 165, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 135, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 255, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 111, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 101, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 45, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 48, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 214, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 216, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 72, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 14, name: \"verify::contract2\" }"
-      },
-      {
-        "def_id": "DefId { id: 16, name: \"verify::contract2::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<u8 as kani::Arbitrary>::any",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::internal::init_contracts",
+      "kani::kani_intrinsic::<u8>",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract2",
+      "verify::contract2::kani_contract_mode",
+      "verify::contract2::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract2::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract2::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract2::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>"
     ]
   },
   {
     "hash": "541738454925646440912281930290055954593",
-    "def_id": "DefId { id: 41, name: \"verify::proof3\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract3\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::proof3",
-      "mangled_name": "_ZN23gen_contracts_by_macros6verify6proof317hae65fadbc9bef89cE",
-      "kind": "Item",
-      "file": "tests/proofs/gen_contracts_by_macros.rs",
-      "src": "fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }",
-      "macro_backtrace_len": 1,
-      "macro_backtrace": [
-        {
-          "callsite": "gen! { proof3: contract3(arg), arg < 10}",
-          "defsite": "macro_rules! gen {\n    ($proof:ident: $contract_name:ident($arg:ident), $e:expr) => {\n        #[kani::requires($e)]\n        fn $contract_name($arg: u8) -> u8 { $arg }\n\n        #[kani::proof_for_contract($contract_name)]\n        fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }\n    }\n}"
-        }
-      ]
-    },
+    "name": "verify::proof3",
+    "file": "tests/proofs/gen_contracts_by_macros.rs",
     "callees_len": 251,
     "callees": [
-      {
-        "def_id": "DefId { id: 56, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 130, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 222, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 132, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 137, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 46, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 253, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 107, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 207, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 89, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 66, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 74, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 98, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 188, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"kani::kani_intrinsic\" }"
-      },
-      {
-        "def_id": "DefId { id: 42, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 44, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 236, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 68, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 47, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 60, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 254, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 165, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 135, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 255, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 111, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 101, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 45, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 48, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 214, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 216, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 72, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 28, name: \"verify::contract3\" }"
-      },
-      {
-        "def_id": "DefId { id: 30, name: \"verify::contract3::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<u8 as kani::Arbitrary>::any",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::internal::init_contracts",
+      "kani::kani_intrinsic::<u8>",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract3",
+      "verify::contract3::kani_contract_mode",
+      "verify::contract3::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract3::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract3::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>",
+      "verify::contract3::kani_register_contract::<u8, {closure@tests/proofs/gen_contracts_by_macros.rs:3:9: 3:30}>"
     ]
   }
 ]

--- a/tests/simplified/gen_contracts_by_macros.json
+++ b/tests/simplified/gen_contracts_by_macros.json
@@ -1,0 +1,2336 @@
+[
+  {
+    "hash": "1689096496237791355510770873012758110496",
+    "def_id": "DefId { id: 13, name: \"verify::proof1\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract1\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::proof1",
+      "mangled_name": "_ZN23gen_contracts_by_macros6verify6proof117he3754be12d716b06E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_contracts_by_macros.rs",
+      "src": "fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }",
+      "macro_backtrace_len": 1,
+      "macro_backtrace": [
+        {
+          "callsite": "gen! { proof1: contract1(arg), arg > 0}",
+          "defsite": "macro_rules! gen {\n    ($proof:ident: $contract_name:ident($arg:ident), $e:expr) => {\n        #[kani::requires($e)]\n        fn $contract_name($arg: u8) -> u8 { $arg }\n\n        #[kani::proof_for_contract($contract_name)]\n        fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }\n    }\n}"
+        }
+      ]
+    },
+    "callees_len": 251,
+    "callees": [
+      {
+        "def_id": "DefId { id: 56, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 130, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 132, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 137, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 46, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 253, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 207, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 66, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 74, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 188, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"kani::kani_intrinsic\" }"
+      },
+      {
+        "def_id": "DefId { id: 42, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 44, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 236, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 68, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 47, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 60, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 254, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 165, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 135, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 255, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 45, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 48, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 214, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 0, name: \"verify::contract1\" }"
+      },
+      {
+        "def_id": "DefId { id: 2, name: \"verify::contract1::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract1::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "68469033701256472383683903298250524375",
+    "def_id": "DefId { id: 27, name: \"verify::proof2\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract2\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::proof2",
+      "mangled_name": "_ZN23gen_contracts_by_macros6verify6proof217hedb9389a247d4c11E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_contracts_by_macros.rs",
+      "src": "fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }",
+      "macro_backtrace_len": 1,
+      "macro_backtrace": [
+        {
+          "callsite": "gen! { proof2: contract2(arg), arg != 0}",
+          "defsite": "macro_rules! gen {\n    ($proof:ident: $contract_name:ident($arg:ident), $e:expr) => {\n        #[kani::requires($e)]\n        fn $contract_name($arg: u8) -> u8 { $arg }\n\n        #[kani::proof_for_contract($contract_name)]\n        fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }\n    }\n}"
+        }
+      ]
+    },
+    "callees_len": 251,
+    "callees": [
+      {
+        "def_id": "DefId { id: 56, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 130, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 132, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 137, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 46, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 253, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 207, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 66, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 74, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 188, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"kani::kani_intrinsic\" }"
+      },
+      {
+        "def_id": "DefId { id: 42, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 44, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 236, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 68, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 47, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 60, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 254, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 165, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 135, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 255, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 45, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 48, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 214, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 14, name: \"verify::contract2\" }"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"verify::contract2::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract2::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "541738454925646440912281930290055954593",
+    "def_id": "DefId { id: 41, name: \"verify::proof3\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract3\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::proof3",
+      "mangled_name": "_ZN23gen_contracts_by_macros6verify6proof317hae65fadbc9bef89cE",
+      "kind": "Item",
+      "file": "tests/proofs/gen_contracts_by_macros.rs",
+      "src": "fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }",
+      "macro_backtrace_len": 1,
+      "macro_backtrace": [
+        {
+          "callsite": "gen! { proof3: contract3(arg), arg < 10}",
+          "defsite": "macro_rules! gen {\n    ($proof:ident: $contract_name:ident($arg:ident), $e:expr) => {\n        #[kani::requires($e)]\n        fn $contract_name($arg: u8) -> u8 { $arg }\n\n        #[kani::proof_for_contract($contract_name)]\n        fn $proof() {\n            $contract_name(kani::any::<u8>());\n        }\n    }\n}"
+        }
+      ]
+    },
+    "callees_len": 251,
+    "callees": [
+      {
+        "def_id": "DefId { id: 56, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 130, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 222, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 132, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 137, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 46, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 253, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 212, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 207, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 180, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 66, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 74, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 188, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"kani::kani_intrinsic\" }"
+      },
+      {
+        "def_id": "DefId { id: 42, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 44, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 236, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 68, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 47, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 60, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 254, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 165, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 135, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 255, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 45, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 48, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 214, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 216, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 28, name: \"verify::contract3\" }"
+      },
+      {
+        "def_id": "DefId { id: 30, name: \"verify::contract3::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 29, name: \"verify::contract3::kani_register_contract\" }"
+      }
+    ]
+  }
+]

--- a/tests/simplified/gen_proofs_by_macros.json
+++ b/tests/simplified/gen_proofs_by_macros.json
@@ -1,0 +1,131 @@
+[
+  {
+    "hash": "45672845279674531917747866704305470621",
+    "def_id": "DefId { id: 0, name: \"verify::proof1\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::proof1",
+      "mangled_name": "_ZN20gen_proofs_by_macros6verify6proof117h43b17e3623e88509E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_proofs_by_macros.rs",
+      "src": "fn $name() $block",
+      "macro_backtrace_len": 1,
+      "macro_backtrace": [
+        {
+          "callsite": "gen! { proof1, { assert_eq!(kani::any::<u8>(), 0) }}",
+          "defsite": "macro_rules! gen {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
+        }
+      ]
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  },
+  {
+    "hash": "16769813219805389697085801977882300332",
+    "def_id": "DefId { id: 1, name: \"verify::proof2\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::proof2",
+      "mangled_name": "_ZN20gen_proofs_by_macros6verify6proof217hb475ce00f7715816E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_proofs_by_macros.rs",
+      "src": "fn $name() $block",
+      "macro_backtrace_len": 1,
+      "macro_backtrace": [
+        {
+          "callsite": "gen! { proof2, { assert_eq!(kani::any::<u8>(), 0) }}",
+          "defsite": "macro_rules! gen {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
+        }
+      ]
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  },
+  {
+    "hash": "172717196120001941861626194128140056205",
+    "def_id": "DefId { id: 2, name: \"verify::proof3\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::proof3",
+      "mangled_name": "_ZN20gen_proofs_by_macros6verify6proof317hccc39c57871c9d43E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_proofs_by_macros.rs",
+      "src": "fn $name() $block",
+      "macro_backtrace_len": 1,
+      "macro_backtrace": [
+        {
+          "callsite": "gen! { proof3, { assert_eq!(kani::any::<u8>(), 1) }}",
+          "defsite": "macro_rules! gen {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
+        }
+      ]
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  }
+]

--- a/tests/simplified/gen_proofs_by_macros.json
+++ b/tests/simplified/gen_proofs_by_macros.json
@@ -1,131 +1,53 @@
 [
   {
     "hash": "45672845279674531917747866704305470621",
-    "def_id": "DefId { id: 0, name: \"verify::proof1\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::proof1",
-      "mangled_name": "_ZN20gen_proofs_by_macros6verify6proof117h43b17e3623e88509E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_proofs_by_macros.rs",
-      "src": "fn $name() $block",
-      "macro_backtrace_len": 1,
-      "macro_backtrace": [
-        {
-          "callsite": "gen! { proof1, { assert_eq!(kani::any::<u8>(), 0) }}",
-          "defsite": "macro_rules! gen {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
-        }
-      ]
-    },
+    "name": "verify::proof1",
+    "file": "tests/proofs/gen_proofs_by_macros.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   },
   {
     "hash": "16769813219805389697085801977882300332",
-    "def_id": "DefId { id: 1, name: \"verify::proof2\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::proof2",
-      "mangled_name": "_ZN20gen_proofs_by_macros6verify6proof217hb475ce00f7715816E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_proofs_by_macros.rs",
-      "src": "fn $name() $block",
-      "macro_backtrace_len": 1,
-      "macro_backtrace": [
-        {
-          "callsite": "gen! { proof2, { assert_eq!(kani::any::<u8>(), 0) }}",
-          "defsite": "macro_rules! gen {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
-        }
-      ]
-    },
+    "name": "verify::proof2",
+    "file": "tests/proofs/gen_proofs_by_macros.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   },
   {
     "hash": "172717196120001941861626194128140056205",
-    "def_id": "DefId { id: 2, name: \"verify::proof3\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::proof3",
-      "mangled_name": "_ZN20gen_proofs_by_macros6verify6proof317hccc39c57871c9d43E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_proofs_by_macros.rs",
-      "src": "fn $name() $block",
-      "macro_backtrace_len": 1,
-      "macro_backtrace": [
-        {
-          "callsite": "gen! { proof3, { assert_eq!(kani::any::<u8>(), 1) }}",
-          "defsite": "macro_rules! gen {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
-        }
-      ]
-    },
+    "name": "verify::proof3",
+    "file": "tests/proofs/gen_proofs_by_macros.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   }
 ]

--- a/tests/simplified/gen_proofs_by_nested_macros.json
+++ b/tests/simplified/gen_proofs_by_nested_macros.json
@@ -1,0 +1,143 @@
+[
+  {
+    "hash": "41582986283704132878062549597684826483",
+    "def_id": "DefId { id: 0, name: \"verify::proof1\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::proof1",
+      "mangled_name": "_ZN27gen_proofs_by_nested_macros6verify6proof117h03f220c2c919c810E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
+      "src": "fn",
+      "macro_backtrace_len": 2,
+      "macro_backtrace": [
+        {
+          "callsite": "inner!($name, $block)",
+          "defsite": "macro_rules! inner {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
+        },
+        {
+          "callsite": "outer! { proof1, { assert_eq!(kani::any::<u8>(), 0) }}",
+          "defsite": "macro_rules! outer {\n    ($name:ident, $block:block) => {\n        inner!($name, $block);\n    };\n}"
+        }
+      ]
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  },
+  {
+    "hash": "3715710769455654796682612876069204290",
+    "def_id": "DefId { id: 1, name: \"verify::proof2\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::proof2",
+      "mangled_name": "_ZN27gen_proofs_by_nested_macros6verify6proof217h7e38d46e6d527c44E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
+      "src": "fn",
+      "macro_backtrace_len": 2,
+      "macro_backtrace": [
+        {
+          "callsite": "inner!($name, $block)",
+          "defsite": "macro_rules! inner {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
+        },
+        {
+          "callsite": "outer! { proof2, { assert_eq!(kani::any::<u8>(), 0) }}",
+          "defsite": "macro_rules! outer {\n    ($name:ident, $block:block) => {\n        inner!($name, $block);\n    };\n}"
+        }
+      ]
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  },
+  {
+    "hash": "467879827405170862511365878159558907664",
+    "def_id": "DefId { id: 2, name: \"verify::proof3\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::proof3",
+      "mangled_name": "_ZN27gen_proofs_by_nested_macros6verify6proof317he5d9440688aebe97E",
+      "kind": "Item",
+      "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
+      "src": "fn",
+      "macro_backtrace_len": 2,
+      "macro_backtrace": [
+        {
+          "callsite": "inner!($name, $block)",
+          "defsite": "macro_rules! inner {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
+        },
+        {
+          "callsite": "outer! { proof3, { assert_eq!(kani::any::<u8>(), 1) }}",
+          "defsite": "macro_rules! outer {\n    ($name:ident, $block:block) => {\n        inner!($name, $block);\n    };\n}"
+        }
+      ]
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  }
+]

--- a/tests/simplified/gen_proofs_by_nested_macros.json
+++ b/tests/simplified/gen_proofs_by_nested_macros.json
@@ -1,143 +1,53 @@
 [
   {
     "hash": "41582986283704132878062549597684826483",
-    "def_id": "DefId { id: 0, name: \"verify::proof1\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::proof1",
-      "mangled_name": "_ZN27gen_proofs_by_nested_macros6verify6proof117h03f220c2c919c810E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
-      "src": "fn",
-      "macro_backtrace_len": 2,
-      "macro_backtrace": [
-        {
-          "callsite": "inner!($name, $block)",
-          "defsite": "macro_rules! inner {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
-        },
-        {
-          "callsite": "outer! { proof1, { assert_eq!(kani::any::<u8>(), 0) }}",
-          "defsite": "macro_rules! outer {\n    ($name:ident, $block:block) => {\n        inner!($name, $block);\n    };\n}"
-        }
-      ]
-    },
+    "name": "verify::proof1",
+    "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   },
   {
     "hash": "3715710769455654796682612876069204290",
-    "def_id": "DefId { id: 1, name: \"verify::proof2\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::proof2",
-      "mangled_name": "_ZN27gen_proofs_by_nested_macros6verify6proof217h7e38d46e6d527c44E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
-      "src": "fn",
-      "macro_backtrace_len": 2,
-      "macro_backtrace": [
-        {
-          "callsite": "inner!($name, $block)",
-          "defsite": "macro_rules! inner {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
-        },
-        {
-          "callsite": "outer! { proof2, { assert_eq!(kani::any::<u8>(), 0) }}",
-          "defsite": "macro_rules! outer {\n    ($name:ident, $block:block) => {\n        inner!($name, $block);\n    };\n}"
-        }
-      ]
-    },
+    "name": "verify::proof2",
+    "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   },
   {
     "hash": "467879827405170862511365878159558907664",
-    "def_id": "DefId { id: 2, name: \"verify::proof3\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::proof3",
-      "mangled_name": "_ZN27gen_proofs_by_nested_macros6verify6proof317he5d9440688aebe97E",
-      "kind": "Item",
-      "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
-      "src": "fn",
-      "macro_backtrace_len": 2,
-      "macro_backtrace": [
-        {
-          "callsite": "inner!($name, $block)",
-          "defsite": "macro_rules! inner {\n    ($name:ident, $block:block) => {\n        #[kani::proof]\n        fn $name() $block\n    }\n}"
-        },
-        {
-          "callsite": "outer! { proof3, { assert_eq!(kani::any::<u8>(), 1) }}",
-          "defsite": "macro_rules! outer {\n    ($name:ident, $block:block) => {\n        inner!($name, $block);\n    };\n}"
-        }
-      ]
-    },
+    "name": "verify::proof3",
+    "file": "tests/proofs/gen_proofs_by_nested_macros.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 6, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 8, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 7, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   }
 ]

--- a/tests/simplified/proofs_for_contract.json
+++ b/tests/simplified/proofs_for_contract.json
@@ -1,3067 +1,1041 @@
 [
   {
     "hash": "1643705096648428146712583300589083040693",
-    "def_id": "DefId { id: 52, name: \"verify::single_contract\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::single_contract",
-      "mangled_name": "_ZN19proofs_for_contract6verify15single_contract17h603f1e30a3feb669E",
-      "kind": "Item",
-      "file": "tests/proofs/proofs_for_contract.rs",
-      "src": "fn single_contract() {\n        let val = contract(1);\n        assert!(val > 0);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::single_contract",
+    "file": "tests/proofs/proofs_for_contract.rs",
     "callees_len": 247,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 270, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 34, name: \"verify::contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 36, name: \"verify::contract::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::assert",
+      "kani::internal::init_contracts",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract",
+      "verify::contract::kani_contract_mode",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>"
     ]
   },
   {
     "hash": "100890017277600594668279345893151486314",
-    "def_id": "DefId { id: 13, name: \"verify::single_contract_requires\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract_requires\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::single_contract_requires",
-      "mangled_name": "_ZN19proofs_for_contract6verify24single_contract_requires17hf7a4d820aa5b40b8E",
-      "kind": "Item",
-      "file": "tests/proofs/proofs_for_contract.rs",
-      "src": "fn single_contract_requires() {\n        contract_requires(0);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::single_contract_requires",
+    "file": "tests/proofs/proofs_for_contract.rs",
     "callees_len": 246,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
-      },
-      {
-        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::internal::init_contracts",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract_requires",
+      "verify::contract_requires::kani_contract_mode",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>"
     ]
   },
   {
     "hash": "6673033441765793042434434469087455757",
-    "def_id": "DefId { id: 32, name: \"verify::single_with_contract_ensures\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract_ensures\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::single_with_contract_ensures",
-      "mangled_name": "_ZN19proofs_for_contract6verify28single_with_contract_ensures17h7d17038dced94556E",
-      "kind": "Item",
-      "file": "tests/proofs/proofs_for_contract.rs",
-      "src": "fn single_with_contract_ensures() {\n        contract_ensures(0);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::single_with_contract_ensures",
+    "file": "tests/proofs/proofs_for_contract.rs",
     "callees_len": 246,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
-      },
-      {
-        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::internal::init_contracts",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract_ensures",
+      "verify::contract_ensures::kani_contract_mode",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>"
     ]
   },
   {
     "hash": "1529389956159808515812041814679572385024",
-    "def_id": "DefId { id: 33, name: \"verify::two_contracts_requires_and_ensures\" }",
     "attrs": [
       "#[kanitool::proof_for_contract = \"contract_requires\"]"
     ],
-    "kind": "Contract",
-    "func": {
-      "name": "verify::two_contracts_requires_and_ensures",
-      "mangled_name": "_ZN19proofs_for_contract6verify34two_contracts_requires_and_ensures17h8a26a5664950158bE",
-      "kind": "Item",
-      "file": "tests/proofs/proofs_for_contract.rs",
-      "src": "fn two_contracts_requires_and_ensures() {\n        let val = contract_ensures(0);\n        contract_requires(val);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::two_contracts_requires_and_ensures",
+    "file": "tests/proofs/proofs_for_contract.rs",
     "callees_len": 256,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
-      },
-      {
-        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
-      },
-      {
-        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::internal::init_contracts",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract_ensures",
+      "verify::contract_ensures::kani_contract_mode",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+      "verify::contract_requires",
+      "verify::contract_requires::kani_contract_mode",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>"
     ]
   }
 ]

--- a/tests/simplified/proofs_for_contract.json
+++ b/tests/simplified/proofs_for_contract.json
@@ -1,0 +1,3067 @@
+[
+  {
+    "hash": "1643705096648428146712583300589083040693",
+    "def_id": "DefId { id: 52, name: \"verify::single_contract\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::single_contract",
+      "mangled_name": "_ZN19proofs_for_contract6verify15single_contract17h603f1e30a3feb669E",
+      "kind": "Item",
+      "file": "tests/proofs/proofs_for_contract.rs",
+      "src": "fn single_contract() {\n        let val = contract(1);\n        assert!(val > 0);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 247,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 270, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"verify::contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 36, name: \"verify::contract::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "100890017277600594668279345893151486314",
+    "def_id": "DefId { id: 13, name: \"verify::single_contract_requires\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract_requires\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::single_contract_requires",
+      "mangled_name": "_ZN19proofs_for_contract6verify24single_contract_requires17hf7a4d820aa5b40b8E",
+      "kind": "Item",
+      "file": "tests/proofs/proofs_for_contract.rs",
+      "src": "fn single_contract_requires() {\n        contract_requires(0);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 246,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
+      },
+      {
+        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "6673033441765793042434434469087455757",
+    "def_id": "DefId { id: 32, name: \"verify::single_with_contract_ensures\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract_ensures\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::single_with_contract_ensures",
+      "mangled_name": "_ZN19proofs_for_contract6verify28single_with_contract_ensures17h7d17038dced94556E",
+      "kind": "Item",
+      "file": "tests/proofs/proofs_for_contract.rs",
+      "src": "fn single_with_contract_ensures() {\n        contract_ensures(0);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 246,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "1529389956159808515812041814679572385024",
+    "def_id": "DefId { id: 33, name: \"verify::two_contracts_requires_and_ensures\" }",
+    "attrs": [
+      "#[kanitool::proof_for_contract = \"contract_requires\"]"
+    ],
+    "kind": "Contract",
+    "func": {
+      "name": "verify::two_contracts_requires_and_ensures",
+      "mangled_name": "_ZN19proofs_for_contract6verify34two_contracts_requires_and_ensures17h8a26a5664950158bE",
+      "kind": "Item",
+      "file": "tests/proofs/proofs_for_contract.rs",
+      "src": "fn two_contracts_requires_and_ensures() {\n        let val = contract_ensures(0);\n        contract_requires(val);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 256,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::internal::init_contracts\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
+      },
+      {
+        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      }
+    ]
+  }
+]

--- a/tests/simplified/standard_proofs.json
+++ b/tests/simplified/standard_proofs.json
@@ -1,399 +1,146 @@
 [
   {
     "hash": "407797103376261238612495655534918835712",
-    "def_id": "DefId { id: 2, name: \"verify::recursive_callees\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::recursive_callees",
-      "mangled_name": "_ZN15standard_proofs6verify17recursive_callees17h27fada5ffc99c85cE",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs.rs",
-      "src": "fn recursive_callees() {\n        crate::top_level();\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::recursive_callees",
+    "file": "tests/proofs/standard_proofs.rs",
     "callees_len": 107,
     "callees": [
-      {
-        "def_id": "DefId { id: 81, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 92, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"<std::slice::Iter<'a, T> as std::iter::DoubleEndedIterator>::next_back\" }"
-      },
-      {
-        "def_id": "DefId { id: 34, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 36, name: \"<std::str::CharIndices<'a> as std::iter::DoubleEndedIterator>::next_back\" }"
-      },
-      {
-        "def_id": "DefId { id: 39, name: \"<std::str::CharIndices<'a> as std::iter::DoubleEndedIterator>::next_back::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 40, name: \"<std::str::Chars<'a> as std::iter::DoubleEndedIterator>::next_back\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"<std::str::Chars<'a> as std::iter::DoubleEndedIterator>::next_back::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 20, name: \"<std::str::pattern::CharPredicateSearcher<'a, F> as std::str::pattern::ReverseSearcher<'a>>::next_reject_back\" }"
-      },
-      {
-        "def_id": "DefId { id: 18, name: \"<std::str::pattern::CharPredicateSearcher<'a, F> as std::str::pattern::Searcher<'a>>::next_reject\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"<std::str::pattern::MultiCharEqPattern<C> as std::str::pattern::Pattern>::into_searcher\" }"
-      },
-      {
-        "def_id": "DefId { id: 28, name: \"<std::str::pattern::MultiCharEqSearcher<'a, C> as std::str::pattern::ReverseSearcher<'a>>::next_back\" }"
-      },
-      {
-        "def_id": "DefId { id: 19, name: \"std::str::pattern::ReverseSearcher::next_reject_back\" }"
-      },
-      {
-        "def_id": "DefId { id: 131, name: \"<std::str::pattern::MultiCharEqSearcher<'a, C> as std::str::pattern::Searcher<'a>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 17, name: \"std::str::pattern::Searcher::next_reject\" }"
-      },
-      {
-        "def_id": "DefId { id: 38, name: \"<F as std::str::pattern::MultiCharEq>::matches\" }"
-      },
-      {
-        "def_id": "DefId { id: 16, name: \"<F as std::str::pattern::Pattern>::into_searcher\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"core::num::<impl isize>::overflowing_neg\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::num::<impl isize>::unchecked_neg\" }"
-      },
-      {
-        "def_id": "DefId { id: 101, name: \"core::num::<impl isize>::unchecked_neg::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 78, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 137, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 139, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 67, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 68, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 113, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 111, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 21, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 12, name: \"core::str::<impl str>::trim\" }"
-      },
-      {
-        "def_id": "DefId { id: 23, name: \"core::str::<impl str>::trim::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 13, name: \"core::str::<impl str>::trim_matches\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 135, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 70, name: \"core::str::validations::next_code_point_reverse\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 86, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 50, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 63, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 107, name: \"core::unicode::unicode_data::white_space::lookup\" }"
-      },
-      {
-        "def_id": "DefId { id: 4, name: \"m::func1\" }"
-      },
-      {
-        "def_id": "DefId { id: 75, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 73, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 74, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 72, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::char::methods::<impl char>::is_whitespace\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 89, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 52, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 41, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 41, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 41, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 47, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 47, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 95, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 45, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 98, name: \"std::ptr::NonNull::<T>::sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 51, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 66, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 43, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 46, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 49, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 97, name: \"std::ptr::mut_ptr::<impl *mut T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 97, name: \"std::ptr::mut_ptr::<impl *mut T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 96, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 48, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 115, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"std::slice::Iter::<'a, T>::next_back_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"std::slice::Iter::<'a, T>::pre_dec_end\" }"
-      },
-      {
-        "def_id": "DefId { id: 3, name: \"top_level\" }"
-      }
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::slice::Iter<'_, u8> as std::iter::DoubleEndedIterator>::next_back",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back",
+      "<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back",
+      "<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<std::str::pattern::CharPredicateSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::ReverseSearcher<'_>>::next_reject_back",
+      "<std::str::pattern::CharPredicateSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::Searcher<'_>>::next_reject",
+      "<std::str::pattern::MultiCharEqPattern<{closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::Pattern>::into_searcher",
+      "<std::str::pattern::MultiCharEqSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::ReverseSearcher<'_>>::next_back",
+      "<std::str::pattern::MultiCharEqSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::ReverseSearcher<'_>>::next_reject_back",
+      "<std::str::pattern::MultiCharEqSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::Searcher<'_>>::next",
+      "<std::str::pattern::MultiCharEqSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}> as std::str::pattern::Searcher<'_>>::next_reject",
+      "<{closure@core::str::<impl str>::trim::{closure#0}} as std::str::pattern::MultiCharEq>::matches",
+      "<{closure@core::str::<impl str>::trim::{closure#0}} as std::str::pattern::Pattern>::into_searcher",
+      "core::num::<impl isize>::overflowing_neg",
+      "core::num::<impl isize>::unchecked_neg",
+      "core::num::<impl isize>::unchecked_neg::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [u8]>::iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::Range<usize>>",
+      "core::str::<impl str>::trim",
+      "core::str::<impl str>::trim::{closure#0}",
+      "core::str::<impl str>::trim_matches::<{closure@core::str::<impl str>::trim::{closure#0}}>",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::next_code_point_reverse::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::unicode::unicode_data::white_space::lookup",
+      "m::func1",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::char::methods::<impl char>::is_whitespace",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::mem::size_of::<u8>",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<char>::map::<(usize, char), {closure@<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<u8>::sub",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::drop_in_place::<std::str::pattern::CharPredicateSearcher<'_, {closure@core::str::<impl str>::trim::{closure#0}}>>",
+      "std::ptr::drop_in_place::<{closure@<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut *const u8>::cast::<std::ptr::NonNull<u8>>",
+      "std::ptr::mut_ptr::<impl *mut *const u8>::cast::<usize>",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_fmt",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, u8>::next_back_unchecked",
+      "std::slice::Iter::<'_, u8>::pre_dec_end",
+      "top_level"
     ]
   },
   {
     "hash": "130593389360887046121730487531425257701",
-    "def_id": "DefId { id: 0, name: \"verify::standard_proof\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::standard_proof",
-      "mangled_name": "_ZN15standard_proofs6verify14standard_proof17h755badced94c944aE",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs.rs",
-      "src": "fn standard_proof() {\n        let val: u8 = kani::any();\n        assert_eq!(val, 1, \"Not eq to 1.\");\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::standard_proof",
+    "file": "tests/proofs/standard_proofs.rs",
     "callees_len": 6,
     "callees": [
-      {
-        "def_id": "DefId { id: 8, name: \"<u8 as kani::Arbitrary>::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 5, name: \"kani::any\" }"
-      },
-      {
-        "def_id": "DefId { id: 10, name: \"kani::any_raw\" }"
-      },
-      {
-        "def_id": "DefId { id: 9, name: \"kani::any_raw_internal\" }"
-      },
-      {
-        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 11, name: \"kani::kani_intrinsic\" }"
-      }
+      "<u8 as kani::Arbitrary>::any",
+      "kani::any::<u8>",
+      "kani::any_raw::<u8>",
+      "kani::any_raw_internal::<u8>",
+      "kani::assert",
+      "kani::kani_intrinsic::<u8>"
     ]
   },
   {
     "hash": "14450731345693588624745887593183259349",
-    "def_id": "DefId { id: 1, name: \"verify::standard_proof_empty\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::standard_proof_empty",
-      "mangled_name": "_ZN15standard_proofs6verify20standard_proof_empty17he1ce2465bbad64d2E",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs.rs",
-      "src": "fn standard_proof_empty() {}",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::standard_proof_empty",
+    "file": "tests/proofs/standard_proofs.rs",
     "callees_len": 0,
     "callees": []
   }

--- a/tests/simplified/standard_proofs.json
+++ b/tests/simplified/standard_proofs.json
@@ -1,0 +1,400 @@
+[
+  {
+    "hash": "407797103376261238612495655534918835712",
+    "def_id": "DefId { id: 2, name: \"verify::recursive_callees\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::recursive_callees",
+      "mangled_name": "_ZN15standard_proofs6verify17recursive_callees17h27fada5ffc99c85cE",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs.rs",
+      "src": "fn recursive_callees() {\n        crate::top_level();\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 107,
+    "callees": [
+      {
+        "def_id": "DefId { id: 81, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 92, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"<std::slice::Iter<'a, T> as std::iter::DoubleEndedIterator>::next_back\" }"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 36, name: \"<std::str::CharIndices<'a> as std::iter::DoubleEndedIterator>::next_back\" }"
+      },
+      {
+        "def_id": "DefId { id: 39, name: \"<std::str::CharIndices<'a> as std::iter::DoubleEndedIterator>::next_back::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 40, name: \"<std::str::Chars<'a> as std::iter::DoubleEndedIterator>::next_back\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"<std::str::Chars<'a> as std::iter::DoubleEndedIterator>::next_back::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 20, name: \"<std::str::pattern::CharPredicateSearcher<'a, F> as std::str::pattern::ReverseSearcher<'a>>::next_reject_back\" }"
+      },
+      {
+        "def_id": "DefId { id: 18, name: \"<std::str::pattern::CharPredicateSearcher<'a, F> as std::str::pattern::Searcher<'a>>::next_reject\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"<std::str::pattern::MultiCharEqPattern<C> as std::str::pattern::Pattern>::into_searcher\" }"
+      },
+      {
+        "def_id": "DefId { id: 28, name: \"<std::str::pattern::MultiCharEqSearcher<'a, C> as std::str::pattern::ReverseSearcher<'a>>::next_back\" }"
+      },
+      {
+        "def_id": "DefId { id: 19, name: \"std::str::pattern::ReverseSearcher::next_reject_back\" }"
+      },
+      {
+        "def_id": "DefId { id: 131, name: \"<std::str::pattern::MultiCharEqSearcher<'a, C> as std::str::pattern::Searcher<'a>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 17, name: \"std::str::pattern::Searcher::next_reject\" }"
+      },
+      {
+        "def_id": "DefId { id: 38, name: \"<F as std::str::pattern::MultiCharEq>::matches\" }"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"<F as std::str::pattern::Pattern>::into_searcher\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"core::num::<impl isize>::overflowing_neg\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::num::<impl isize>::unchecked_neg\" }"
+      },
+      {
+        "def_id": "DefId { id: 101, name: \"core::num::<impl isize>::unchecked_neg::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 78, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 137, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 139, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 67, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 68, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 113, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 111, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 21, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 12, name: \"core::str::<impl str>::trim\" }"
+      },
+      {
+        "def_id": "DefId { id: 23, name: \"core::str::<impl str>::trim::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 13, name: \"core::str::<impl str>::trim_matches\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 135, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 70, name: \"core::str::validations::next_code_point_reverse\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 86, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 50, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 63, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 107, name: \"core::unicode::unicode_data::white_space::lookup\" }"
+      },
+      {
+        "def_id": "DefId { id: 4, name: \"m::func1\" }"
+      },
+      {
+        "def_id": "DefId { id: 75, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 73, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 74, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 72, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::char::methods::<impl char>::is_whitespace\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 89, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 52, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 41, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 41, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 41, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 47, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 47, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 95, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"std::ptr::NonNull::<T>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 45, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 98, name: \"std::ptr::NonNull::<T>::sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 51, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 66, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 43, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 46, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 49, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 22, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 97, name: \"std::ptr::mut_ptr::<impl *mut T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 97, name: \"std::ptr::mut_ptr::<impl *mut T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 96, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 48, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 115, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"std::slice::Iter::<'a, T>::next_back_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"std::slice::Iter::<'a, T>::pre_dec_end\" }"
+      },
+      {
+        "def_id": "DefId { id: 3, name: \"top_level\" }"
+      }
+    ]
+  },
+  {
+    "hash": "130593389360887046121730487531425257701",
+    "def_id": "DefId { id: 0, name: \"verify::standard_proof\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::standard_proof",
+      "mangled_name": "_ZN15standard_proofs6verify14standard_proof17h755badced94c944aE",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs.rs",
+      "src": "fn standard_proof() {\n        let val: u8 = kani::any();\n        assert_eq!(val, 1, \"Not eq to 1.\");\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 6,
+    "callees": [
+      {
+        "def_id": "DefId { id: 8, name: \"<u8 as kani::Arbitrary>::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 5, name: \"kani::any\" }"
+      },
+      {
+        "def_id": "DefId { id: 10, name: \"kani::any_raw\" }"
+      },
+      {
+        "def_id": "DefId { id: 9, name: \"kani::any_raw_internal\" }"
+      },
+      {
+        "def_id": "DefId { id: 6, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 11, name: \"kani::kani_intrinsic\" }"
+      }
+    ]
+  },
+  {
+    "hash": "14450731345693588624745887593183259349",
+    "def_id": "DefId { id: 1, name: \"verify::standard_proof_empty\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::standard_proof_empty",
+      "mangled_name": "_ZN15standard_proofs6verify20standard_proof_empty17he1ce2465bbad64d2E",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs.rs",
+      "src": "fn standard_proof_empty() {}",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 0,
+    "callees": []
+  }
+]

--- a/tests/simplified/standard_proofs_with_contracts.json
+++ b/tests/simplified/standard_proofs_with_contracts.json
@@ -1,3055 +1,1037 @@
 [
   {
     "hash": "1676262618701481246211841339249437203190",
-    "def_id": "DefId { id: 52, name: \"verify::single_contract\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::single_contract",
-      "mangled_name": "_ZN30standard_proofs_with_contracts6verify15single_contract17hf7857e33f4dfc6e8E",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs_with_contracts.rs",
-      "src": "fn single_contract() {\n        let val = contract(1);\n        assert!(val > 0);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::single_contract",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "callees_len": 246,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 269, name: \"kani::assert\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 34, name: \"verify::contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 36, name: \"verify::contract::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::assert",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract",
+      "verify::contract::kani_contract_mode",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+      "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>"
     ]
   },
   {
     "hash": "5630215822409612035601738689308321273",
-    "def_id": "DefId { id: 13, name: \"verify::single_contract_requires\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::single_contract_requires",
-      "mangled_name": "_ZN30standard_proofs_with_contracts6verify24single_contract_requires17h47e48c487cf9756fE",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs_with_contracts.rs",
-      "src": "fn single_contract_requires() {\n        contract_requires(0);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::single_contract_requires",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "callees_len": 245,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
-      },
-      {
-        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract_requires",
+      "verify::contract_requires::kani_contract_mode",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>"
     ]
   },
   {
     "hash": "71159678709398506361037444045517209506",
-    "def_id": "DefId { id: 32, name: \"verify::single_with_contract_ensures\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::single_with_contract_ensures",
-      "mangled_name": "_ZN30standard_proofs_with_contracts6verify28single_with_contract_ensures17hb623f49dc07b46deE",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs_with_contracts.rs",
-      "src": "fn single_with_contract_ensures() {\n        contract_ensures(0);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::single_with_contract_ensures",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "callees_len": 245,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
-      },
-      {
-        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract_ensures",
+      "verify::contract_ensures::kani_contract_mode",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>"
     ]
   },
   {
     "hash": "53237701649618771521648312975277163615",
-    "def_id": "DefId { id: 33, name: \"verify::two_contracts_requires_and_ensures\" }",
     "attrs": [
       "#[kanitool::proof]"
     ],
-    "kind": "Standard",
-    "func": {
-      "name": "verify::two_contracts_requires_and_ensures",
-      "mangled_name": "_ZN30standard_proofs_with_contracts6verify34two_contracts_requires_and_ensures17h8d99e46efa3a05b9E",
-      "kind": "Item",
-      "file": "tests/proofs/standard_proofs_with_contracts.rs",
-      "src": "fn two_contracts_requires_and_ensures() {\n        let val = contract_ensures(0);\n        contract_requires(val);\n    }",
-      "macro_backtrace_len": 0,
-      "macro_backtrace": []
-    },
+    "name": "verify::two_contracts_requires_and_ensures",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "callees_len": 255,
     "callees": [
-      {
-        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
-      },
-      {
-        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
-      },
-      {
-        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
-      },
-      {
-        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
-      },
-      {
-        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
-      },
-      {
-        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
-      },
-      {
-        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
-      },
-      {
-        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
-      },
-      {
-        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
-      },
-      {
-        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
-      },
-      {
-        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
-      },
-      {
-        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
-      },
-      {
-        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
-      },
-      {
-        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
-      },
-      {
-        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
-      },
-      {
-        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
-      },
-      {
-        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
-      },
-      {
-        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
-      },
-      {
-        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
-      },
-      {
-        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
-      },
-      {
-        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
-      },
-      {
-        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
-      },
-      {
-        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
-      },
-      {
-        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
-      },
-      {
-        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
-      },
-      {
-        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
-      },
-      {
-        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
-      },
-      {
-        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
-      },
-      {
-        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
-      },
-      {
-        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
-      },
-      {
-        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
-      },
-      {
-        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
-      },
-      {
-        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
-      },
-      {
-        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
-      },
-      {
-        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
-      },
-      {
-        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
-      },
-      {
-        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
-      },
-      {
-        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
-      },
-      {
-        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
-      },
-      {
-        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
-      },
-      {
-        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
-      },
-      {
-        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
-      },
-      {
-        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
-      },
-      {
-        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
-      },
-      {
-        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
-      },
-      {
-        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
-      },
-      {
-        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
-      },
-      {
-        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
-      },
-      {
-        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
-      },
-      {
-        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
-      },
-      {
-        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
-      },
-      {
-        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
-      },
-      {
-        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
-      },
-      {
-        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
-      },
-      {
-        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
-      },
-      {
-        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
-      },
-      {
-        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
-      },
-      {
-        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
-      },
-      {
-        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
-      },
-      {
-        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
-      },
-      {
-        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
-      },
-      {
-        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
-      },
-      {
-        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
-      },
-      {
-        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
-      },
-      {
-        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
-      },
-      {
-        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
-      },
-      {
-        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
-      },
-      {
-        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      },
-      {
-        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
-      }
+      "<&str as std::fmt::Display>::fmt",
+      "<std::fmt::Error as std::convert::From<std::fmt::Error>>::from",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
+      "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
+      "<std::ops::Range<u16> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::ops::Range<usize> as std::iter::IntoIterator>::into_iter",
+      "<std::ops::Range<usize> as std::iter::range::RangeIteratorImpl>::spec_next",
+      "<std::option::Option<&u8> as std::ops::Try>::branch",
+      "<std::option::Option<u32> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual",
+      "<std::ptr::NonNull<[usize; 4]> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<u8> as std::cmp::PartialEq>::eq",
+      "<std::ptr::NonNull<usize> as std::cmp::PartialEq>::eq",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<(), std::fmt::Error> as std::ops::Try>::branch",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, std::fmt::Error>>>::from_residual",
+      "<std::result::Result<core::fmt::PostPadding, std::fmt::Error> as std::ops::Try>::branch",
+      "<std::slice::Chunks<'_, usize> as std::iter::IntoIterator>::into_iter",
+      "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, u8> as std::iter::ExactSizeIterator>::len",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::filter::<{closure@core::str::count::char_count_general_case::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::map::<usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>",
+      "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
+      "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
+      "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::count",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next",
+      "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
+      "<str as std::fmt::Display>::fmt",
+      "<u16 as std::iter::Step>::forward_unchecked",
+      "<usize as std::cmp::Ord>::min",
+      "<usize as std::iter::Step>::forward_unchecked",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
+      "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}",
+      "core::fmt::PostPadding::new",
+      "core::fmt::PostPadding::write",
+      "core::fmt::rt::Argument::<'_>::new_display::<&str>",
+      "core::num::<impl u16>::overflowing_add",
+      "core::num::<impl u16>::unchecked_add",
+      "core::num::<impl u16>::unchecked_add::precondition_check",
+      "core::num::<impl u32>::wrapping_sub",
+      "core::num::<impl usize>::count_ones",
+      "core::num::<impl usize>::is_power_of_two",
+      "core::num::<impl usize>::overflowing_add",
+      "core::num::<impl usize>::overflowing_sub",
+      "core::num::<impl usize>::unchecked_add",
+      "core::num::<impl usize>::unchecked_add::precondition_check",
+      "core::num::<impl usize>::unchecked_sub",
+      "core::num::<impl usize>::unchecked_sub::precondition_check",
+      "core::num::<impl usize>::wrapping_mul",
+      "core::panic::panic_info::PanicInfo::<'_>::new",
+      "core::panicking::panic",
+      "core::panicking::panic_nounwind",
+      "core::panicking::panic_nounwind_fmt",
+      "core::panicking::panic_nounwind_fmt::runtime",
+      "core::slice::<impl [T]>::as_chunks_unchecked::precondition_check",
+      "core::slice::<impl [T]>::split_at_unchecked::precondition_check",
+      "core::slice::<impl [[usize; 4]]>::iter",
+      "core::slice::<impl [u8]>::align_to::<usize>",
+      "core::slice::<impl [u8]>::align_to_offsets::<usize>",
+      "core::slice::<impl [u8]>::as_ptr",
+      "core::slice::<impl [u8]>::iter",
+      "core::slice::<impl [u8]>::split_at",
+      "core::slice::<impl [u8]>::split_at_checked",
+      "core::slice::<impl [u8]>::split_at_unchecked",
+      "core::slice::<impl [usize]>::as_chunks::<4>",
+      "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
+      "core::slice::<impl [usize]>::as_ptr",
+      "core::slice::<impl [usize]>::chunks",
+      "core::slice::<impl [usize]>::is_empty",
+      "core::slice::<impl [usize]>::iter",
+      "core::slice::<impl [usize]>::split_at",
+      "core::slice::<impl [usize]>::split_at_checked",
+      "core::slice::<impl [usize]>::split_at_unchecked",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[[usize; 4]]>::into_iter",
+      "core::slice::iter::<impl std::iter::IntoIterator for &[usize]>::into_iter",
+      "core::str::<impl str>::as_bytes",
+      "core::str::<impl str>::char_indices",
+      "core::str::<impl str>::chars",
+      "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
+      "core::str::<impl str>::len",
+      "core::str::count::char_count_general_case",
+      "core::str::count::char_count_general_case::{closure#0}",
+      "core::str::count::contains_non_continuation_byte",
+      "core::str::count::count_chars",
+      "core::str::count::do_count_chars",
+      "core::str::count::sum_bytes_in_usize",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check",
+      "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
+      "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
+      "core::str::validations::utf8_acc_cont_byte",
+      "core::str::validations::utf8_first_byte",
+      "core::str::validations::utf8_is_cont_byte",
+      "core::ub_checks::check_language_ub",
+      "core::ub_checks::check_language_ub::runtime",
+      "core::ub_checks::is_valid_allocation_size",
+      "core::ub_checks::maybe_is_aligned_and_not_null",
+      "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
+      "kani::panic",
+      "kani::panic::panic_cold_display::<&str>",
+      "std::array::<impl std::iter::IntoIterator for &[usize; 4]>::into_iter",
+      "std::char::convert::char_try_from_u32",
+      "std::char::convert::from_u32_unchecked",
+      "std::char::convert::from_u32_unchecked::precondition_check",
+      "std::char::methods::<impl char>::from_u32_unchecked",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt",
+      "std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt",
+      "std::cmp::min::<usize>",
+      "std::convert::num::<impl std::convert::From<u16> for usize>::from",
+      "std::fmt::Arguments::<'_>::new_const::<1>",
+      "std::fmt::Arguments::<'_>::new_v1::<1, 1>",
+      "std::fmt::Formatter::<'_>::pad",
+      "std::fmt::Formatter::<'_>::padding",
+      "std::fmt::FormattingOptions::get_align",
+      "std::fmt::FormattingOptions::get_fill",
+      "std::fmt::FormattingOptions::get_precision",
+      "std::hint::unreachable_unchecked",
+      "std::hint::unreachable_unchecked::precondition_check",
+      "std::intrinsics::cold_path",
+      "std::intrinsics::unlikely",
+      "std::iter::Filter::<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}>::new",
+      "std::iter::Map::<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>::new",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
+      "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
+      "std::iter::range::<impl std::iter::Iterator for std::ops::Range<usize>>::next",
+      "std::mem::align_of::<[usize; 4]>",
+      "std::mem::align_of::<u8>",
+      "std::mem::align_of::<usize>",
+      "std::mem::size_of::<[usize; 4]>",
+      "std::mem::size_of::<u8>",
+      "std::mem::size_of::<usize>",
+      "std::num::NonZero::<T>::new_unchecked::precondition_check",
+      "std::num::NonZero::<usize>::get",
+      "std::num::NonZero::<usize>::new",
+      "std::num::NonZero::<usize>::new_unchecked",
+      "std::option::Option::<&u8>::unwrap_unchecked",
+      "std::option::Option::<(usize, char)>::is_none",
+      "std::option::Option::<(usize, char)>::is_some",
+      "std::option::Option::<std::fmt::Alignment>::unwrap_or",
+      "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::panic::Location::<'_>::caller",
+      "std::ptr::NonNull::<&str>::as_ptr",
+      "std::ptr::NonNull::<&str>::cast::<()>",
+      "std::ptr::NonNull::<&str>::from_ref",
+      "std::ptr::NonNull::<[[usize; 4]]>::as_ptr",
+      "std::ptr::NonNull::<[[usize; 4]]>::cast::<[usize; 4]>",
+      "std::ptr::NonNull::<[[usize; 4]]>::from_ref",
+      "std::ptr::NonNull::<[u8]>::as_ptr",
+      "std::ptr::NonNull::<[u8]>::cast::<u8>",
+      "std::ptr::NonNull::<[u8]>::from_ref",
+      "std::ptr::NonNull::<[usize; 4]>::add",
+      "std::ptr::NonNull::<[usize; 4]>::as_ptr",
+      "std::ptr::NonNull::<[usize; 4]>::as_ref::<'_>",
+      "std::ptr::NonNull::<[usize]>::as_ptr",
+      "std::ptr::NonNull::<[usize]>::cast::<usize>",
+      "std::ptr::NonNull::<[usize]>::from_ref",
+      "std::ptr::NonNull::<u8>::add",
+      "std::ptr::NonNull::<u8>::as_ptr",
+      "std::ptr::NonNull::<u8>::as_ref::<'_>",
+      "std::ptr::NonNull::<u8>::offset_from_unsigned",
+      "std::ptr::NonNull::<usize>::add",
+      "std::ptr::NonNull::<usize>::as_ptr",
+      "std::ptr::NonNull::<usize>::as_ref::<'_>",
+      "std::ptr::align_offset::<u8>",
+      "std::ptr::align_offset::mod_inv",
+      "std::ptr::const_ptr::<impl *const ()>::addr",
+      "std::ptr::const_ptr::<impl *const ()>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
+      "std::ptr::const_ptr::<impl *const ()>::is_null",
+      "std::ptr::const_ptr::<impl *const T>::is_null::runtime",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge",
+      "std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime",
+      "std::ptr::const_ptr::<impl *const [u8]>::as_ptr",
+      "std::ptr::const_ptr::<impl *const [u8]>::len",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::addr",
+      "std::ptr::const_ptr::<impl *const [usize; 4]>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::add",
+      "std::ptr::const_ptr::<impl *const u8>::addr",
+      "std::ptr::const_ptr::<impl *const u8>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const u8>::offset_from_unsigned",
+      "std::ptr::const_ptr::<impl *const usize>::add",
+      "std::ptr::const_ptr::<impl *const usize>::addr",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<()>",
+      "std::ptr::const_ptr::<impl *const usize>::cast::<[usize; 4]>",
+      "std::ptr::drop_in_place::<&u8>",
+      "std::ptr::drop_in_place::<std::fmt::Alignment>",
+      "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
+      "std::ptr::drop_in_place::<usize>",
+      "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
+      "std::ptr::from_raw_parts::<[u8], u8>",
+      "std::ptr::from_raw_parts::<[usize], usize>",
+      "std::ptr::metadata::<[u8]>",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::add",
+      "std::ptr::mut_ptr::<impl *mut [usize; 4]>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::add",
+      "std::ptr::mut_ptr::<impl *mut u8>::cast_const",
+      "std::ptr::mut_ptr::<impl *mut u8>::offset_from_unsigned",
+      "std::ptr::mut_ptr::<impl *mut usize>::add",
+      "std::ptr::mut_ptr::<impl *mut usize>::cast_const",
+      "std::ptr::slice_from_raw_parts::<[usize; 4]>",
+      "std::ptr::slice_from_raw_parts::<u8>",
+      "std::ptr::slice_from_raw_parts::<usize>",
+      "std::ptr::without_provenance::<[usize; 4]>",
+      "std::ptr::without_provenance::<u8>",
+      "std::ptr::without_provenance::<usize>",
+      "std::ptr::without_provenance_mut::<[usize; 4]>",
+      "std::ptr::without_provenance_mut::<u8>",
+      "std::ptr::without_provenance_mut::<usize>",
+      "std::result::Result::<char, std::char::CharTryFromError>::is_ok",
+      "std::rt::panic_display::<&str>",
+      "std::rt::panic_fmt",
+      "std::slice::Chunks::<'_, usize>::new",
+      "std::slice::Iter::<'_, [usize; 4]>::new",
+      "std::slice::Iter::<'_, u8>::as_slice",
+      "std::slice::Iter::<'_, u8>::make_slice",
+      "std::slice::Iter::<'_, u8>::new",
+      "std::slice::Iter::<'_, usize>::new",
+      "std::slice::from_raw_parts::<'_, [usize; 4]>",
+      "std::slice::from_raw_parts::<'_, u8>",
+      "std::slice::from_raw_parts::<'_, usize>",
+      "std::slice::from_raw_parts::precondition_check",
+      "std::str::CharIndices::<'_>::offset",
+      "std::str::Chars::<'_>::as_str",
+      "std::str::from_utf8_unchecked",
+      "verify::contract_ensures",
+      "verify::contract_ensures::kani_contract_mode",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+      "verify::contract_requires",
+      "verify::contract_requires::kani_contract_mode",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+      "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>"
     ]
   }
 ]

--- a/tests/simplified/standard_proofs_with_contracts.json
+++ b/tests/simplified/standard_proofs_with_contracts.json
@@ -1,0 +1,3055 @@
+[
+  {
+    "hash": "1676262618701481246211841339249437203190",
+    "def_id": "DefId { id: 52, name: \"verify::single_contract\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::single_contract",
+      "mangled_name": "_ZN30standard_proofs_with_contracts6verify15single_contract17hf7857e33f4dfc6e8E",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs_with_contracts.rs",
+      "src": "fn single_contract() {\n        let val = contract(1);\n        assert!(val > 0);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 246,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 269, name: \"kani::assert\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 34, name: \"verify::contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 36, name: \"verify::contract::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 35, name: \"verify::contract::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "5630215822409612035601738689308321273",
+    "def_id": "DefId { id: 13, name: \"verify::single_contract_requires\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::single_contract_requires",
+      "mangled_name": "_ZN30standard_proofs_with_contracts6verify24single_contract_requires17h47e48c487cf9756fE",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs_with_contracts.rs",
+      "src": "fn single_contract_requires() {\n        contract_requires(0);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 245,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
+      },
+      {
+        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "71159678709398506361037444045517209506",
+    "def_id": "DefId { id: 32, name: \"verify::single_with_contract_ensures\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::single_with_contract_ensures",
+      "mangled_name": "_ZN30standard_proofs_with_contracts6verify28single_with_contract_ensures17hb623f49dc07b46deE",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs_with_contracts.rs",
+      "src": "fn single_with_contract_ensures() {\n        contract_ensures(0);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 245,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      }
+    ]
+  },
+  {
+    "hash": "53237701649618771521648312975277163615",
+    "def_id": "DefId { id: 33, name: \"verify::two_contracts_requires_and_ensures\" }",
+    "attrs": [
+      "#[kanitool::proof]"
+    ],
+    "kind": "Standard",
+    "func": {
+      "name": "verify::two_contracts_requires_and_ensures",
+      "mangled_name": "_ZN30standard_proofs_with_contracts6verify34two_contracts_requires_and_ensures17h8d99e46efa3a05b9E",
+      "kind": "Item",
+      "file": "tests/proofs/standard_proofs_with_contracts.rs",
+      "src": "fn two_contracts_requires_and_ensures() {\n        let val = contract_ensures(0);\n        contract_requires(val);\n    }",
+      "macro_backtrace_len": 0,
+      "macro_backtrace": []
+    },
+    "callees_len": 255,
+    "callees": [
+      {
+        "def_id": "DefId { id: 67, name: \"<&T as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 117, name: \"<T as std::convert::From<T>>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 209, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 213, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 206, name: \"<std::iter::Filter<I, P> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 217, name: \"<std::iter::Map<I, F> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 211, name: \"std::iter::Iterator::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 136, name: \"<std::ops::Range<T> as std::iter::range::RangeIteratorImpl>::spec_next\" }"
+      },
+      {
+        "def_id": "DefId { id: 171, name: \"<std::option::Option<T> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 172, name: \"<std::option::Option<T> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 181, name: \"<std::ptr::NonNull<T> as std::cmp::PartialEq>::eq\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 93, name: \"<std::result::Result<T, F> as std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>>::from_residual\" }"
+      },
+      {
+        "def_id": "DefId { id: 90, name: \"<std::result::Result<T, E> as std::ops::Try>::branch\" }"
+      },
+      {
+        "def_id": "DefId { id: 112, name: \"<I as std::iter::IntoIterator>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 230, name: \"<std::slice::Chunks<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 166, name: \"<std::slice::Iter<'_, T> as std::iter::ExactSizeIterator>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 205, name: \"std::iter::Iterator::filter\" }"
+      },
+      {
+        "def_id": "DefId { id: 219, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 210, name: \"std::iter::Iterator::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 170, name: \"<std::slice::Iter<'a, T> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 80, name: \"std::iter::Iterator::advance_by\" }"
+      },
+      {
+        "def_id": "DefId { id: 154, name: \"<std::str::CharIndices<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 87, name: \"<std::str::Chars<'a> as std::iter::Iterator>::count\" }"
+      },
+      {
+        "def_id": "DefId { id: 167, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 189, name: \"<std::str::Chars<'a> as std::iter::Iterator>::next::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 69, name: \"<str as std::fmt::Display>::fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 140, name: \"<u16 as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 261, name: \"std::cmp::Ord::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 159, name: \"<usize as std::iter::Step>::forward_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 215, name: \"<usize as std::iter::Sum>::sum\" }"
+      },
+      {
+        "def_id": "DefId { id: 220, name: \"<usize as std::iter::Sum>::sum::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 116, name: \"core::fmt::PostPadding::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 94, name: \"core::fmt::PostPadding::write\" }"
+      },
+      {
+        "def_id": "DefId { id: 57, name: \"core::fmt::rt::Argument::<'_>::new_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 143, name: \"core::num::<impl u16>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 141, name: \"core::num::<impl u16>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 142, name: \"core::num::<impl u16>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 133, name: \"core::num::<impl u32>::wrapping_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 252, name: \"core::num::<impl usize>::count_ones\" }"
+      },
+      {
+        "def_id": "DefId { id: 251, name: \"core::num::<impl usize>::is_power_of_two\" }"
+      },
+      {
+        "def_id": "DefId { id: 162, name: \"core::num::<impl usize>::overflowing_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 186, name: \"core::num::<impl usize>::overflowing_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 160, name: \"core::num::<impl usize>::unchecked_add\" }"
+      },
+      {
+        "def_id": "DefId { id: 161, name: \"core::num::<impl usize>::unchecked_add::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 179, name: \"core::num::<impl usize>::unchecked_sub\" }"
+      },
+      {
+        "def_id": "DefId { id: 185, name: \"core::num::<impl usize>::unchecked_sub::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 237, name: \"core::num::<impl usize>::wrapping_mul\" }"
+      },
+      {
+        "def_id": "DefId { id: 129, name: \"core::panic::panic_info::PanicInfo::<'a>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 196, name: \"core::panicking::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 124, name: \"core::panicking::panic_nounwind\" }"
+      },
+      {
+        "def_id": "DefId { id: 126, name: \"core::panicking::panic_nounwind_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 127, name: \"core::panicking::panic_nounwind_fmt::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 264, name: \"core::slice::<impl [T]>::as_chunks_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 259, name: \"core::slice::<impl [T]>::split_at_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 226, name: \"core::slice::<impl [T]>::align_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 242, name: \"core::slice::<impl [T]>::align_to_offsets\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 231, name: \"core::slice::<impl [T]>::as_chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 263, name: \"core::slice::<impl [T]>::as_chunks_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 238, name: \"core::slice::<impl [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 229, name: \"core::slice::<impl [T]>::chunks\" }"
+      },
+      {
+        "def_id": "DefId { id: 227, name: \"core::slice::<impl [T]>::is_empty\" }"
+      },
+      {
+        "def_id": "DefId { id: 100, name: \"core::slice::<impl [T]>::iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 241, name: \"core::slice::<impl [T]>::split_at\" }"
+      },
+      {
+        "def_id": "DefId { id: 257, name: \"core::slice::<impl [T]>::split_at_checked\" }"
+      },
+      {
+        "def_id": "DefId { id: 258, name: \"core::slice::<impl [T]>::split_at_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 232, name: \"core::slice::iter::<impl std::iter::IntoIterator for &'a [T]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 99, name: \"core::str::<impl str>::as_bytes\" }"
+      },
+      {
+        "def_id": "DefId { id: 77, name: \"core::str::<impl str>::char_indices\" }"
+      },
+      {
+        "def_id": "DefId { id: 85, name: \"core::str::<impl str>::chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 84, name: \"core::str::<impl str>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 202, name: \"core::str::<impl str>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 203, name: \"core::str::count::char_count_general_case\" }"
+      },
+      {
+        "def_id": "DefId { id: 208, name: \"core::str::count::char_count_general_case::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 235, name: \"core::str::count::contains_non_continuation_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 201, name: \"core::str::count::count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 204, name: \"core::str::count::do_count_chars\" }"
+      },
+      {
+        "def_id": "DefId { id: 234, name: \"core::str::count::sum_bytes_in_usize\" }"
+      },
+      {
+        "def_id": "DefId { id: 146, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 148, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 145, name: \"core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 168, name: \"core::str::validations::next_code_point\" }"
+      },
+      {
+        "def_id": "DefId { id: 175, name: \"core::str::validations::utf8_acc_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 173, name: \"core::str::validations::utf8_first_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 223, name: \"core::str::validations::utf8_is_cont_byte\" }"
+      },
+      {
+        "def_id": "DefId { id: 120, name: \"core::ub_checks::check_language_ub\" }"
+      },
+      {
+        "def_id": "DefId { id: 134, name: \"core::ub_checks::check_language_ub::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 246, name: \"core::ub_checks::is_valid_allocation_size\" }"
+      },
+      {
+        "def_id": "DefId { id: 245, name: \"core::ub_checks::maybe_is_aligned_and_not_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 247, name: \"core::ub_checks::maybe_is_aligned_and_not_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 53, name: \"kani::panic\" }"
+      },
+      {
+        "def_id": "DefId { id: 55, name: \"kani::panic::panic_cold_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 233, name: \"std::array::<impl std::iter::IntoIterator for &'a [T; N]>::into_iter\" }"
+      },
+      {
+        "def_id": "DefId { id: 122, name: \"std::char::convert::char_try_from_u32\" }"
+      },
+      {
+        "def_id": "DefId { id: 119, name: \"std::char::convert::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 121, name: \"std::char::convert::from_u32_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 118, name: \"std::char::methods::<impl char>::from_u32_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 138, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for u16>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 158, name: \"std::cmp::impls::<impl std::cmp::PartialOrd for usize>::lt\" }"
+      },
+      {
+        "def_id": "DefId { id: 260, name: \"std::cmp::min\" }"
+      },
+      {
+        "def_id": "DefId { id: 79, name: \"std::convert::num::<impl std::convert::From<u16> for usize>::from\" }"
+      },
+      {
+        "def_id": "DefId { id: 125, name: \"std::fmt::Arguments::<'a>::new_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 58, name: \"std::fmt::Arguments::<'a>::new_v1\" }"
+      },
+      {
+        "def_id": "DefId { id: 71, name: \"std::fmt::Formatter::<'a>::pad\" }"
+      },
+      {
+        "def_id": "DefId { id: 88, name: \"std::fmt::Formatter::<'a>::padding\" }"
+      },
+      {
+        "def_id": "DefId { id: 108, name: \"std::fmt::FormattingOptions::get_align\" }"
+      },
+      {
+        "def_id": "DefId { id: 110, name: \"std::fmt::FormattingOptions::get_fill\" }"
+      },
+      {
+        "def_id": "DefId { id: 76, name: \"std::fmt::FormattingOptions::get_precision\" }"
+      },
+      {
+        "def_id": "DefId { id: 176, name: \"std::hint::unreachable_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 177, name: \"std::hint::unreachable_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 262, name: \"std::intrinsics::cold_path\" }"
+      },
+      {
+        "def_id": "DefId { id: 228, name: \"std::intrinsics::unlikely\" }"
+      },
+      {
+        "def_id": "DefId { id: 225, name: \"std::iter::Filter::<I, P>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 224, name: \"std::iter::Map::<I, F>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 218, name: \"std::iter::adapters::map::map_fold\" }"
+      },
+      {
+        "def_id": "DefId { id: 221, name: \"std::iter::adapters::map::map_fold::{closure#0}\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 114, name: \"std::iter::range::<impl std::iter::Iterator for std::ops::Range<A>>::next\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 239, name: \"std::mem::align_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 194, name: \"std::mem::size_of\" }"
+      },
+      {
+        "def_id": "DefId { id: 164, name: \"std::num::NonZero::<T>::new_unchecked::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 82, name: \"std::num::NonZero::<T>::get\" }"
+      },
+      {
+        "def_id": "DefId { id: 163, name: \"std::num::NonZero::<T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 156, name: \"std::num::NonZero::<T>::new_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 174, name: \"std::option::Option::<T>::unwrap_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 155, name: \"std::option::Option::<T>::is_none\" }"
+      },
+      {
+        "def_id": "DefId { id: 157, name: \"std::option::Option::<T>::is_some\" }"
+      },
+      {
+        "def_id": "DefId { id: 109, name: \"std::option::Option::<T>::unwrap_or\" }"
+      },
+      {
+        "def_id": "DefId { id: 169, name: \"std::option::Option::<T>::map\" }"
+      },
+      {
+        "def_id": "DefId { id: 128, name: \"std::panic::Location::<'a>::caller\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 65, name: \"std::ptr::NonNull::<T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 64, name: \"std::ptr::NonNull::<T>::from_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 190, name: \"std::ptr::NonNull::<T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 182, name: \"std::ptr::NonNull::<T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 104, name: \"std::ptr::NonNull::<T>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 183, name: \"std::ptr::NonNull::<T>::as_ref\" }"
+      },
+      {
+        "def_id": "DefId { id: 240, name: \"std::ptr::align_offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 256, name: \"std::ptr::align_offset::mod_inv\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 248, name: \"std::ptr::const_ptr::<impl *const T>::is_aligned_to\" }"
+      },
+      {
+        "def_id": "DefId { id: 249, name: \"std::ptr::const_ptr::<impl *const T>::is_null\" }"
+      },
+      {
+        "def_id": "DefId { id: 250, name: \"std::ptr::const_ptr::<impl *const T>::is_null::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 193, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 198, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge\" }"
+      },
+      {
+        "def_id": "DefId { id: 199, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned::runtime_ptr_ge::runtime\" }"
+      },
+      {
+        "def_id": "DefId { id: 149, name: \"std::ptr::const_ptr::<impl *const [T]>::as_ptr\" }"
+      },
+      {
+        "def_id": "DefId { id: 147, name: \"std::ptr::const_ptr::<impl *const [T]>::len\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 192, name: \"std::ptr::const_ptr::<impl *const T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 150, name: \"std::ptr::const_ptr::<impl *const T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 178, name: \"std::ptr::const_ptr::<impl *const T>::addr\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 184, name: \"std::ptr::const_ptr::<impl *const T>::cast\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 54, name: \"std::ptr::drop_in_place\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 153, name: \"std::ptr::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 152, name: \"std::ptr::metadata\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 191, name: \"std::ptr::mut_ptr::<impl *mut T>::offset_from_unsigned\" }"
+      },
+      {
+        "def_id": "DefId { id: 105, name: \"std::ptr::mut_ptr::<impl *mut T>::add\" }"
+      },
+      {
+        "def_id": "DefId { id: 187, name: \"std::ptr::mut_ptr::<impl *mut T>::cast_const\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 151, name: \"std::ptr::slice_from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 103, name: \"std::ptr::without_provenance\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 106, name: \"std::ptr::without_provenance_mut\" }"
+      },
+      {
+        "def_id": "DefId { id: 123, name: \"std::result::Result::<T, E>::is_ok\" }"
+      },
+      {
+        "def_id": "DefId { id: 56, name: \"std::rt::panic_display\" }"
+      },
+      {
+        "def_id": "DefId { id: 59, name: \"std::rt::panic_fmt\" }"
+      },
+      {
+        "def_id": "DefId { id: 265, name: \"std::slice::Chunks::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 266, name: \"std::slice::Iter::<'a, T>::as_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 268, name: \"std::slice::Iter::<'a, T>::make_slice\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 102, name: \"std::slice::Iter::<'a, T>::new\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 243, name: \"std::slice::from_raw_parts\" }"
+      },
+      {
+        "def_id": "DefId { id: 244, name: \"std::slice::from_raw_parts::precondition_check\" }"
+      },
+      {
+        "def_id": "DefId { id: 83, name: \"std::str::CharIndices::<'a>::offset\" }"
+      },
+      {
+        "def_id": "DefId { id: 200, name: \"std::str::Chars::<'a>::as_str\" }"
+      },
+      {
+        "def_id": "DefId { id: 267, name: \"std::str::from_utf8_unchecked\" }"
+      },
+      {
+        "def_id": "DefId { id: 14, name: \"verify::contract_ensures\" }"
+      },
+      {
+        "def_id": "DefId { id: 16, name: \"verify::contract_ensures::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 15, name: \"verify::contract_ensures::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 0, name: \"verify::contract_requires\" }"
+      },
+      {
+        "def_id": "DefId { id: 2, name: \"verify::contract_requires::kani_contract_mode\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      },
+      {
+        "def_id": "DefId { id: 1, name: \"verify::contract_requires::kani_register_contract\" }"
+      }
+    ]
+  }
+]

--- a/tests/simplify_json.rs
+++ b/tests/simplify_json.rs
@@ -1,0 +1,30 @@
+mod utils;
+use utils::{assert_eq, *};
+
+#[test]
+fn ensure_identical_hash() -> Result<()> {
+    let proofs = get_proofs("tests/proofs")?;
+
+    for path in &proofs {
+        let snapshot = format!("simplified/{}.json", file_stem(path));
+        dbg!(&snapshot);
+
+        let path = path.to_str().unwrap();
+
+        // run `distributed-verificatio file.rs`
+        let text_full = cmd(&[path]);
+        let v_ser_function_full: Vec<SerFunction> = serde_json::from_str(&text_full).unwrap();
+
+        // run `distributed-verification file.rs --simplify-json`
+        let text_simplified = cmd(&[path, "--simplify-json"]);
+        let v_ser_function_simplified: Vec<SerFunction> =
+            serde_json::from_str(&text_simplified).unwrap();
+        expect_file![snapshot].assert_eq(&text_simplified);
+
+        for (full, simplified) in v_ser_function_full.iter().zip(&v_ser_function_simplified) {
+            assert_eq!(full.hash, simplified.hash, "Full={full:?}\nSimplified={simplified:?}");
+        }
+    }
+
+    Ok(())
+}

--- a/tests/simplify_json.rs
+++ b/tests/simplify_json.rs
@@ -1,4 +1,5 @@
 mod utils;
+use distributed_verification::SimplifiedSerFunction;
 use utils::{assert_eq, *};
 
 #[test]
@@ -17,7 +18,7 @@ fn ensure_identical_hash() -> Result<()> {
 
         // run `distributed-verification file.rs --simplify-json`
         let text_simplified = cmd(&[path, "--simplify-json"]);
-        let v_ser_function_simplified: Vec<SerFunction> =
+        let v_ser_function_simplified: Vec<SimplifiedSerFunction> =
             serde_json::from_str(&text_simplified).unwrap();
         expect_file![snapshot].assert_eq(&text_simplified);
 


### PR DESCRIPTION
* close #57 

Example JSON:

```json
  {
    "hash": "45672845279674531917747866704305470621",
    "attrs": [
      "#[kanitool::proof]"
    ],
    "name": "verify::proof1",
    "file": "tests/proofs/gen_proofs_by_macros.rs",
    "callees_len": 6,
    "callees": [
      "<u8 as kani::Arbitrary>::any",
      "kani::any::<u8>",
      "kani::any_raw::<u8>",
      "kani::any_raw_internal::<u8>",
      "kani::assert",
      "kani::kani_intrinsic::<u8>"
    ]
  }
```

This reduces the execution time from [22 minutes](https://github.com/os-checker/distributed-verification/pull/58) to 2 mintutes:
![截图_20250427161023](https://github.com/user-attachments/assets/0448b644-417a-4d0a-8e9c-8133ad8c9a62)
