### PR TITLE
Sync: kani and verify-rust-std; toolchain up to nightly-2025-07-02 

### DIFF
--- a/tests/snapshots/compare/contract1.json
+++ b/tests/snapshots/compare/contract1.json
@@ -1,6 +1,6 @@
 [
   {
-    "hash": "9110013437157474711273995327575973953",
+    "hash": "170185868534852403517319670654034345935",
     "name": "kani::panic",
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
@@ -10,22 +10,22 @@
     "file": "library/core/src/array/mod.rs"
   },
   {
-    "hash": "1835555409892641968715518659512763629305",
+    "hash": "1253501917253063290515286798079291406022",
     "name": "std::char::convert::char_try_from_u32",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "181272475585460647517443557415321318659",
+    "hash": "131606170482807693362175987803096434760",
     "name": "std::char::convert::from_u32_unchecked",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "1320043678392507861115191954133317143490",
+    "hash": "141777398513335345408154280402043326980",
     "name": "std::char::methods::<impl char>::from_u32_unchecked",
     "file": "library/core/src/char/methods.rs"
   },
   {
-    "hash": "105293143189968001175910723606472847453",
+    "hash": "80249903325342526932651822469818924130",
     "name": "<usize as std::cmp::Ord>::min",
     "file": "library/core/src/cmp.rs"
   },
@@ -40,7 +40,7 @@
     "file": "library/core/src/cmp.rs"
   },
   {
-    "hash": "45420099425906739229972611360828906996",
+    "hash": "1774680678790287728814454280293715994219",
     "name": "std::cmp::min::<usize>",
     "file": "library/core/src/cmp.rs"
   },
@@ -55,12 +55,12 @@
     "file": "library/core/src/convert/num.rs"
   },
   {
-    "hash": "1371746331589039016331056560044945030",
+    "hash": "55365444148228517684466806986787559606",
     "name": "<&str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1354177614729625835117775292546531775014",
+    "hash": "694412030810075507040989598874491585",
     "name": "<str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -70,17 +70,17 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "172944738288885290083276427975264664072",
+    "hash": "4372901837201700045367109528985425757",
     "name": "core::fmt::PostPadding::write",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1533180195846334583617947954899683798657",
+    "hash": "699002900709069648812102067476367562990",
     "name": "std::fmt::Formatter::<'_>::pad",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "142514712097694120346572792450431499665",
+    "hash": "141869330349636326479565094854406012453",
     "name": "std::fmt::Formatter::<'_>::padding",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -90,7 +90,7 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "151549091835301814569478420826126555649",
+    "hash": "1161005037905311640618283830950292411169",
     "name": "std::fmt::FormattingOptions::get_fill",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -110,7 +110,7 @@
     "file": "library/core/src/fmt/rt.rs"
   },
   {
-    "hash": "931076662517735820116389385577792859706",
+    "hash": "64831333328555634737835457686945546342",
     "name": "core::fmt::rt::Argument::<'_>::new_display::<&str>",
     "file": "library/core/src/fmt/rt.rs"
   },
@@ -130,7 +130,7 @@
     "file": "library/core/src/intrinsics/mod.rs"
   },
   {
-    "hash": "1408393638760277889216161485462822825467",
+    "hash": "91375825332728499584552473133800788915",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
     "file": "library/core/src/intrinsics/mod.rs"
   },
@@ -160,12 +160,12 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "766528270008730576414797874131980563974",
+    "hash": "1169454885572802949911851882877522755773",
     "name": "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "98972097590179534414450729561525715395",
+    "hash": "545707798122007980817913094500135596036",
     "name": "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
@@ -175,7 +175,7 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "136460023026271463242964210703970143574",
+    "hash": "1311510069182000871611712506430824967365",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
     "file": "library/core/src/iter/adapters/map.rs"
   },
@@ -190,27 +190,27 @@
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1298212628145154126618156816134265951344",
+    "hash": "143385254926310059114601711607934802626",
     "name": "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1232889667129580128612195481125876355895",
+    "hash": "69836621587154186912082287672825986701",
     "name": "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "65191485396793801441708908227891945976",
+    "hash": "74263642424770005886585667687132666700",
     "name": "<u16 as std::iter::Step>::forward_unchecked",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "188312196520496208216777120611981411403",
+    "hash": "150021953543632011655891713384046546195",
     "name": "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "1118720028921197857316850364974898782644",
+    "hash": "83212516662910391527380784146422699337",
     "name": "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
     "file": "library/core/src/iter/traits/accum.rs"
   },
@@ -230,7 +230,7 @@
     "file": "library/core/src/iter/traits/collect.rs"
   },
   {
-    "hash": "117160024467577062374814279693937914308",
+    "hash": "1476188077969759501416587624527731620422",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -245,22 +245,22 @@
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "169254447276496917964889824994222006487",
+    "hash": "746335627686636360311089028698215315621",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "95354230261524383717847373957185145555",
+    "hash": "890743343806001783818377326543496764999",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "64016173223473785207354785894730039924",
+    "hash": "38248963824617361146577789155806220457",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "68746763044528098428227291452128003750",
+    "hash": "162963300457841015274153803823417766214",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::try_fold::<std::num::NonZero<usize>, {closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}, std::option::Option<std::num::NonZero<usize>>>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -305,52 +305,52 @@
     "file": "library/core/src/num/nonzero.rs"
   },
   {
-    "hash": "28416299455941732499272441497123863286",
+    "hash": "66472461948522780286669743098512884020",
     "name": "core::num::<impl u16>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1767882825766330041012289079684840123988",
+    "hash": "1755481411544761241911010338868424028032",
     "name": "core::num::<impl u16>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "531547630013775774616630521705918956890",
+    "hash": "778307969913358517318134351169293017006",
     "name": "core::num::<impl u32>::wrapping_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1491976204649427753712444486504685158667",
+    "hash": "1817700327438920062811986284895946972360",
     "name": "core::num::<impl usize>::count_ones",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "267503639466522371016185904314247059966",
+    "hash": "1198745042195432320316237250098976336783",
     "name": "core::num::<impl usize>::is_power_of_two",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "420027195811498354113361982279400413970",
+    "hash": "29280884443006517116686346795110467729",
     "name": "core::num::<impl usize>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "9766519181220151615102176802326253862",
+    "hash": "680697364573271958516692421008805893594",
     "name": "core::num::<impl usize>::overflowing_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "861075789615506151054802343958342702",
+    "hash": "10088042682663381447210876152059630410",
     "name": "core::num::<impl usize>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1240112622965974978610989681601335370041",
+    "hash": "163514900348266881411363175083503667972",
     "name": "core::num::<impl usize>::unchecked_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "176480214868331547301536851964719628253",
+    "hash": "115578125622558050988953568575947871951",
     "name": "core::num::<impl usize>::wrapping_mul",
     "file": "library/core/src/num/uint_macros.rs"
   },
@@ -385,17 +385,17 @@
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "131534592200098059029750365218172562280",
+    "hash": "551284205942989744010603758892918003809",
     "name": "std::option::Option::<std::fmt::Alignment>::unwrap_or",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "37329511099916694324318814422027472373",
+    "hash": "139548131330438493408310223143043863897",
     "name": "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "145379337856805001595892687783013497010",
+    "hash": "93873349781065085267543059115936351593",
     "name": "kani::panic::panic_cold_display::<&str>",
     "file": "library/core/src/panic.rs"
   },
@@ -420,7 +420,7 @@
     "file": "library/core/src/panicking.rs"
   },
   {
-    "hash": "161984531712227522752564874190257605258",
+    "hash": "156103043049447019914417901809615508350",
     "name": "std::rt::panic_display::<&str>",
     "file": "library/core/src/panicking.rs"
   },
@@ -440,7 +440,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "172740984469479579071665404435289701023",
+    "hash": "135040582385212612735475257113813496500",
     "name": "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -460,7 +460,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "11106989263465620674119447375151988759",
+    "hash": "21654441677010109529687023928280502180",
     "name": "std::ptr::const_ptr::<impl *const [u8]>::len",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -515,22 +515,22 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "1300271856392091645916001889619506617490",
+    "hash": "1618707962037661705218318211105471942120",
     "name": "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "14412815270469178284372346649253214057",
+    "hash": "171364413319637295715083043732096201442",
     "name": "std::ptr::from_raw_parts::<[u8], u8>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "759301201495386013914096069500577582268",
+    "hash": "10108227029034297089458694313942657216",
     "name": "std::ptr::from_raw_parts::<[usize], usize>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "1363429953646800642818322319211259624481",
+    "hash": "65477300936560271722610262085043582244",
     "name": "std::ptr::metadata::<[u8]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
@@ -545,77 +545,77 @@
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "507486726895721764016555491610607611305",
+    "hash": "844348294257748951813515064259923850502",
     "name": "std::ptr::drop_in_place::<&u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "32758264716275548135301815416129443538",
+    "hash": "786281027352090909410587866630825111124",
     "name": "std::ptr::drop_in_place::<(usize, char)>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "92620507381766029301237587487992527213",
+    "hash": "1602108665480339150417063482100093944787",
     "name": "std::ptr::drop_in_place::<std::fmt::Alignment>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "102773287537006387418136460951493449150",
+    "hash": "14750464030756559092072511389613712638",
     "name": "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "149239371713813135466988763744767882801",
+    "hash": "180547684808059406565403285055600712836",
     "name": "std::ptr::drop_in_place::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "55367978787089163010793217435139837876",
+    "hash": "554158701962205684218313987735220350468",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1209564197857095228814830958456579553221",
+    "hash": "82095542769953368154912485864031886270",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "748209534850776693517100400031629133312",
+    "hash": "5831255669648730149843380384415246652",
     "name": "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "267935267854751480818415065985053337078",
+    "hash": "937477061605388048115884892480312288537",
     "name": "std::ptr::slice_from_raw_parts::<[usize; 4]>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "57392431669649698342516110218176469764",
+    "hash": "892461914248527136611431264334752468555",
     "name": "std::ptr::slice_from_raw_parts::<u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "122558071050321327518145172778423713781",
+    "hash": "1297187182340166219213119975319687609972",
     "name": "std::ptr::slice_from_raw_parts::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
@@ -835,7 +835,7 @@
     "file": "library/core/src/result.rs"
   },
   {
-    "hash": "88633046024721928868158000904972228167",
+    "hash": "54888678836671866272358132516024826502",
     "name": "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -860,7 +860,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "125489371537082193378561958245297073133",
+    "hash": "45060499419383805014075082957353484074",
     "name": "std::slice::Iter::<'_, u8>::as_slice",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -875,7 +875,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "112093191663101859282706845470326278900",
+    "hash": "47269698298620023111796944825903179130",
     "name": "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -885,22 +885,22 @@
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "136484293011665227087512181501588076411",
+    "hash": "674881123049448667512672737959208587337",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "7250475688043728136115351013068090102",
+    "hash": "154659969182662416984535348444125844",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "155597816474146809159504684113290845792",
+    "hash": "1219085896046917615810259583008727206943",
     "name": "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "145530532616617731099568344791001893798",
+    "hash": "793309437318306726913806640804801036999",
     "name": "std::slice::Iter::<'_, u8>::make_slice",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -910,7 +910,7 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1593063580605279640314183922934412511157",
+    "hash": "51188353216572513337552947382367213612",
     "name": "core::slice::<impl [u8]>::align_to::<usize>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -930,27 +930,27 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1785941139609704198311972964660228370976",
+    "hash": "1041529063314010914218218438532577583921",
     "name": "core::slice::<impl [u8]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "84572646525781694072079679591848027002",
+    "hash": "11017778733362591934337269956689912680",
     "name": "core::slice::<impl [u8]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "58089700496514419381325942148928567391",
+    "hash": "89128813248987492211721493584967359724",
     "name": "core::slice::<impl [u8]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "917728468319067451416388429251863159678",
+    "hash": "348372507889018041910054944302851661070",
     "name": "core::slice::<impl [usize]>::as_chunks::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1621046050041371142817756793657558429507",
+    "hash": "144624929410860970405573471555686596396",
     "name": "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -975,32 +975,32 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "3900672375060331021424481618253650288",
+    "hash": "1689731528734002832615362599744307150563",
     "name": "core::slice::<impl [usize]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "171173179240508091544601281736583524354",
+    "hash": "157354110368917150977548446164644269157",
     "name": "core::slice::<impl [usize]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "116483621522571785213244680499922945415",
+    "hash": "1325059444048598179110854173592682518417",
     "name": "core::slice::<impl [usize]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "325660469324403897513522339552212646632",
+    "hash": "1617537487569895078313557542670536892075",
     "name": "std::slice::from_raw_parts::<'_, [usize; 4]>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "47514593099713610332964838893229837936",
+    "hash": "44787092142404380205959599561725184847",
     "name": "std::slice::from_raw_parts::<'_, u8>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "184867918752959488617184774691899169910",
+    "hash": "630819595617041232110620176331560268262",
     "name": "std::slice::from_raw_parts::<'_, usize>",
     "file": "library/core/src/slice/raw.rs"
   },
@@ -1010,7 +1010,7 @@
     "file": "library/core/src/str/converts.rs"
   },
   {
-    "hash": "145201222854331195178815443675397277392",
+    "hash": "105509042728785276095738116562226884135",
     "name": "core::str::count::char_count_general_case",
     "file": "library/core/src/str/count.rs"
   },
@@ -1025,37 +1025,37 @@
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "47468782241743602393810882143023349945",
+    "hash": "101539333883602999142743294499662142781",
     "name": "core::str::count::count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "944297586695660734811678461952919859244",
+    "hash": "155145547891548244516298634347765599627",
     "name": "core::str::count::do_count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "268701197549167845816540622531722429171",
+    "hash": "12025566570273099920903542994299871817",
     "name": "core::str::count::sum_bytes_in_usize",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "174931159159579161911556326084018243713",
+    "hash": "152715002861639775393988580799560247805",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "759516041501256089813279787494912941682",
+    "hash": "644663214087010307916081317719588641492",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::count",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "151051332114409904941604214564891538957",
+    "hash": "660978859467132204713340652707099987613",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "42461548492323519705759720031945445712",
+    "hash": "16139698699567968342904534840657946470",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1065,7 +1065,7 @@
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "50301635678991252011107801667626389768",
+    "hash": "1563992362164201785411080871236623299079",
     "name": "std::str::Chars::<'_>::as_str",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1085,7 +1085,7 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "867395007143103994512438910488508336973",
+    "hash": "71021883313881662847215860786847447423",
     "name": "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
     "file": "library/core/src/str/mod.rs"
   },
@@ -1095,17 +1095,17 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "112020109271780179669495653821738681551",
+    "hash": "91070850951614709601933024856310781945",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "152909514978300660252157530308776102467",
+    "hash": "145757805227894694174215691004963108394",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "68493124835835642495275913021346263998",
+    "hash": "1317118350612563145817400323127232106582",
     "name": "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
     "file": "library/core/src/str/validations.rs"
   },
@@ -1125,17 +1125,17 @@
     "file": "library/core/src/str/validations.rs"
   },
   {
-    "hash": "1563172082169351546616225899813991043484",
+    "hash": "172646548629003079288424832349823487421",
     "name": "core::num::<impl u16>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "33957922410128141509625682565657813466",
+    "hash": "1248191826238009221015171546017389042989",
     "name": "core::num::<impl usize>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "100872428199167332544577177169244129806",
+    "hash": "13514854596489369474334665362530945420",
     "name": "core::num::<impl usize>::unchecked_sub::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1165,12 +1165,12 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "1158923569256985321513541004220644151856",
+    "hash": "748210795816008050710623801889599715701",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "140048639800126365939997225010682400254",
+    "hash": "7461493046945910432435712880095080611",
     "name": "std::char::convert::from_u32_unchecked::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1185,18 +1185,18 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "71108690579660086896269737077011959868",
+    "hash": "399721967138328910814551048930416922779",
     "name": "std::slice::from_raw_parts::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "1376915858339353144310140900781257640904",
+    "hash": "149126667344574031617275998201144313616",
     "name": "verify::f",
     "file": "tests/compare/contract.rs",
     "proof_kind": "Standard"
   },
   {
-    "hash": "156859034860515298896252699466771897262",
+    "hash": "158526682867152455191082175869548730527",
     "name": "verify::contract",
     "file": "tests/compare/contract.rs"
   },
@@ -1206,22 +1206,42 @@
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },

--- a/tests/snapshots/compare/contract2.json
+++ b/tests/snapshots/compare/contract2.json
@@ -1,6 +1,6 @@
 [
   {
-    "hash": "9110013437157474711273995327575973953",
+    "hash": "170185868534852403517319670654034345935",
     "name": "kani::panic",
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
@@ -10,22 +10,22 @@
     "file": "library/core/src/array/mod.rs"
   },
   {
-    "hash": "1835555409892641968715518659512763629305",
+    "hash": "1253501917253063290515286798079291406022",
     "name": "std::char::convert::char_try_from_u32",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "181272475585460647517443557415321318659",
+    "hash": "131606170482807693362175987803096434760",
     "name": "std::char::convert::from_u32_unchecked",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "1320043678392507861115191954133317143490",
+    "hash": "141777398513335345408154280402043326980",
     "name": "std::char::methods::<impl char>::from_u32_unchecked",
     "file": "library/core/src/char/methods.rs"
   },
   {
-    "hash": "105293143189968001175910723606472847453",
+    "hash": "80249903325342526932651822469818924130",
     "name": "<usize as std::cmp::Ord>::min",
     "file": "library/core/src/cmp.rs"
   },
@@ -40,7 +40,7 @@
     "file": "library/core/src/cmp.rs"
   },
   {
-    "hash": "45420099425906739229972611360828906996",
+    "hash": "1774680678790287728814454280293715994219",
     "name": "std::cmp::min::<usize>",
     "file": "library/core/src/cmp.rs"
   },
@@ -55,12 +55,12 @@
     "file": "library/core/src/convert/num.rs"
   },
   {
-    "hash": "1371746331589039016331056560044945030",
+    "hash": "55365444148228517684466806986787559606",
     "name": "<&str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1354177614729625835117775292546531775014",
+    "hash": "694412030810075507040989598874491585",
     "name": "<str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -70,17 +70,17 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "172944738288885290083276427975264664072",
+    "hash": "4372901837201700045367109528985425757",
     "name": "core::fmt::PostPadding::write",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1533180195846334583617947954899683798657",
+    "hash": "699002900709069648812102067476367562990",
     "name": "std::fmt::Formatter::<'_>::pad",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "142514712097694120346572792450431499665",
+    "hash": "141869330349636326479565094854406012453",
     "name": "std::fmt::Formatter::<'_>::padding",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -90,7 +90,7 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "151549091835301814569478420826126555649",
+    "hash": "1161005037905311640618283830950292411169",
     "name": "std::fmt::FormattingOptions::get_fill",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -110,7 +110,7 @@
     "file": "library/core/src/fmt/rt.rs"
   },
   {
-    "hash": "931076662517735820116389385577792859706",
+    "hash": "64831333328555634737835457686945546342",
     "name": "core::fmt::rt::Argument::<'_>::new_display::<&str>",
     "file": "library/core/src/fmt/rt.rs"
   },
@@ -130,7 +130,7 @@
     "file": "library/core/src/intrinsics/mod.rs"
   },
   {
-    "hash": "1408393638760277889216161485462822825467",
+    "hash": "91375825332728499584552473133800788915",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
     "file": "library/core/src/intrinsics/mod.rs"
   },
@@ -160,12 +160,12 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "766528270008730576414797874131980563974",
+    "hash": "1169454885572802949911851882877522755773",
     "name": "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "98972097590179534414450729561525715395",
+    "hash": "545707798122007980817913094500135596036",
     "name": "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
@@ -175,7 +175,7 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "136460023026271463242964210703970143574",
+    "hash": "1311510069182000871611712506430824967365",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
     "file": "library/core/src/iter/adapters/map.rs"
   },
@@ -190,27 +190,27 @@
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1298212628145154126618156816134265951344",
+    "hash": "143385254926310059114601711607934802626",
     "name": "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1232889667129580128612195481125876355895",
+    "hash": "69836621587154186912082287672825986701",
     "name": "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "65191485396793801441708908227891945976",
+    "hash": "74263642424770005886585667687132666700",
     "name": "<u16 as std::iter::Step>::forward_unchecked",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "188312196520496208216777120611981411403",
+    "hash": "150021953543632011655891713384046546195",
     "name": "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "1118720028921197857316850364974898782644",
+    "hash": "83212516662910391527380784146422699337",
     "name": "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
     "file": "library/core/src/iter/traits/accum.rs"
   },
@@ -230,7 +230,7 @@
     "file": "library/core/src/iter/traits/collect.rs"
   },
   {
-    "hash": "117160024467577062374814279693937914308",
+    "hash": "1476188077969759501416587624527731620422",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -245,22 +245,22 @@
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "169254447276496917964889824994222006487",
+    "hash": "746335627686636360311089028698215315621",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "95354230261524383717847373957185145555",
+    "hash": "890743343806001783818377326543496764999",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "64016173223473785207354785894730039924",
+    "hash": "38248963824617361146577789155806220457",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "68746763044528098428227291452128003750",
+    "hash": "162963300457841015274153803823417766214",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::try_fold::<std::num::NonZero<usize>, {closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}, std::option::Option<std::num::NonZero<usize>>>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -305,52 +305,52 @@
     "file": "library/core/src/num/nonzero.rs"
   },
   {
-    "hash": "28416299455941732499272441497123863286",
+    "hash": "66472461948522780286669743098512884020",
     "name": "core::num::<impl u16>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1767882825766330041012289079684840123988",
+    "hash": "1755481411544761241911010338868424028032",
     "name": "core::num::<impl u16>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "531547630013775774616630521705918956890",
+    "hash": "778307969913358517318134351169293017006",
     "name": "core::num::<impl u32>::wrapping_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1491976204649427753712444486504685158667",
+    "hash": "1817700327438920062811986284895946972360",
     "name": "core::num::<impl usize>::count_ones",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "267503639466522371016185904314247059966",
+    "hash": "1198745042195432320316237250098976336783",
     "name": "core::num::<impl usize>::is_power_of_two",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "420027195811498354113361982279400413970",
+    "hash": "29280884443006517116686346795110467729",
     "name": "core::num::<impl usize>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "9766519181220151615102176802326253862",
+    "hash": "680697364573271958516692421008805893594",
     "name": "core::num::<impl usize>::overflowing_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "861075789615506151054802343958342702",
+    "hash": "10088042682663381447210876152059630410",
     "name": "core::num::<impl usize>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1240112622965974978610989681601335370041",
+    "hash": "163514900348266881411363175083503667972",
     "name": "core::num::<impl usize>::unchecked_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "176480214868331547301536851964719628253",
+    "hash": "115578125622558050988953568575947871951",
     "name": "core::num::<impl usize>::wrapping_mul",
     "file": "library/core/src/num/uint_macros.rs"
   },
@@ -385,17 +385,17 @@
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "131534592200098059029750365218172562280",
+    "hash": "551284205942989744010603758892918003809",
     "name": "std::option::Option::<std::fmt::Alignment>::unwrap_or",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "37329511099916694324318814422027472373",
+    "hash": "139548131330438493408310223143043863897",
     "name": "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "145379337856805001595892687783013497010",
+    "hash": "93873349781065085267543059115936351593",
     "name": "kani::panic::panic_cold_display::<&str>",
     "file": "library/core/src/panic.rs"
   },
@@ -420,7 +420,7 @@
     "file": "library/core/src/panicking.rs"
   },
   {
-    "hash": "161984531712227522752564874190257605258",
+    "hash": "156103043049447019914417901809615508350",
     "name": "std::rt::panic_display::<&str>",
     "file": "library/core/src/panicking.rs"
   },
@@ -440,7 +440,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "172740984469479579071665404435289701023",
+    "hash": "135040582385212612735475257113813496500",
     "name": "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -460,7 +460,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "11106989263465620674119447375151988759",
+    "hash": "21654441677010109529687023928280502180",
     "name": "std::ptr::const_ptr::<impl *const [u8]>::len",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -515,22 +515,22 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "1300271856392091645916001889619506617490",
+    "hash": "1618707962037661705218318211105471942120",
     "name": "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "14412815270469178284372346649253214057",
+    "hash": "171364413319637295715083043732096201442",
     "name": "std::ptr::from_raw_parts::<[u8], u8>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "759301201495386013914096069500577582268",
+    "hash": "10108227029034297089458694313942657216",
     "name": "std::ptr::from_raw_parts::<[usize], usize>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "1363429953646800642818322319211259624481",
+    "hash": "65477300936560271722610262085043582244",
     "name": "std::ptr::metadata::<[u8]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
@@ -545,97 +545,97 @@
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "507486726895721764016555491610607611305",
+    "hash": "844348294257748951813515064259923850502",
     "name": "std::ptr::drop_in_place::<&u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "32758264716275548135301815416129443538",
+    "hash": "786281027352090909410587866630825111124",
     "name": "std::ptr::drop_in_place::<(usize, char)>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "92620507381766029301237587487992527213",
+    "hash": "1602108665480339150417063482100093944787",
     "name": "std::ptr::drop_in_place::<std::fmt::Alignment>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "102773287537006387418136460951493449150",
+    "hash": "14750464030756559092072511389613712638",
     "name": "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "149239371713813135466988763744767882801",
+    "hash": "180547684808059406565403285055600712836",
     "name": "std::ptr::drop_in_place::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "55367978787089163010793217435139837876",
+    "hash": "554158701962205684218313987735220350468",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1209564197857095228814830958456579553221",
+    "hash": "82095542769953368154912485864031886270",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "748209534850776693517100400031629133312",
+    "hash": "5831255669648730149843380384415246652",
     "name": "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "872873842487783724415188500638809413396",
+    "hash": "7408966437950817423829987553525117833",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "872873842487783724415188500638809413396",
+    "hash": "7408966437950817423829987553525117833",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "872873842487783724415188500638809413396",
+    "hash": "7408966437950817423829987553525117833",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "872873842487783724415188500638809413396",
+    "hash": "7408966437950817423829987553525117833",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "190837597624617232015114819500806879740",
+    "hash": "761690677905938584111106489819760024436",
     "name": "std::ptr::drop_in_place::<{closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "267935267854751480818415065985053337078",
+    "hash": "937477061605388048115884892480312288537",
     "name": "std::ptr::slice_from_raw_parts::<[usize; 4]>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "57392431669649698342516110218176469764",
+    "hash": "892461914248527136611431264334752468555",
     "name": "std::ptr::slice_from_raw_parts::<u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "122558071050321327518145172778423713781",
+    "hash": "1297187182340166219213119975319687609972",
     "name": "std::ptr::slice_from_raw_parts::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
@@ -855,7 +855,7 @@
     "file": "library/core/src/result.rs"
   },
   {
-    "hash": "88633046024721928868158000904972228167",
+    "hash": "54888678836671866272358132516024826502",
     "name": "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -880,7 +880,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "125489371537082193378561958245297073133",
+    "hash": "45060499419383805014075082957353484074",
     "name": "std::slice::Iter::<'_, u8>::as_slice",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -895,7 +895,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "112093191663101859282706845470326278900",
+    "hash": "47269698298620023111796944825903179130",
     "name": "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -905,22 +905,22 @@
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "136484293011665227087512181501588076411",
+    "hash": "674881123049448667512672737959208587337",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "7250475688043728136115351013068090102",
+    "hash": "154659969182662416984535348444125844",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "155597816474146809159504684113290845792",
+    "hash": "1219085896046917615810259583008727206943",
     "name": "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "145530532616617731099568344791001893798",
+    "hash": "793309437318306726913806640804801036999",
     "name": "std::slice::Iter::<'_, u8>::make_slice",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -930,7 +930,7 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1593063580605279640314183922934412511157",
+    "hash": "51188353216572513337552947382367213612",
     "name": "core::slice::<impl [u8]>::align_to::<usize>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -950,27 +950,27 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1785941139609704198311972964660228370976",
+    "hash": "1041529063314010914218218438532577583921",
     "name": "core::slice::<impl [u8]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "84572646525781694072079679591848027002",
+    "hash": "11017778733362591934337269956689912680",
     "name": "core::slice::<impl [u8]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "58089700496514419381325942148928567391",
+    "hash": "89128813248987492211721493584967359724",
     "name": "core::slice::<impl [u8]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "917728468319067451416388429251863159678",
+    "hash": "348372507889018041910054944302851661070",
     "name": "core::slice::<impl [usize]>::as_chunks::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1621046050041371142817756793657558429507",
+    "hash": "144624929410860970405573471555686596396",
     "name": "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -995,32 +995,32 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "3900672375060331021424481618253650288",
+    "hash": "1689731528734002832615362599744307150563",
     "name": "core::slice::<impl [usize]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "171173179240508091544601281736583524354",
+    "hash": "157354110368917150977548446164644269157",
     "name": "core::slice::<impl [usize]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "116483621522571785213244680499922945415",
+    "hash": "1325059444048598179110854173592682518417",
     "name": "core::slice::<impl [usize]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "325660469324403897513522339552212646632",
+    "hash": "1617537487569895078313557542670536892075",
     "name": "std::slice::from_raw_parts::<'_, [usize; 4]>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "47514593099713610332964838893229837936",
+    "hash": "44787092142404380205959599561725184847",
     "name": "std::slice::from_raw_parts::<'_, u8>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "184867918752959488617184774691899169910",
+    "hash": "630819595617041232110620176331560268262",
     "name": "std::slice::from_raw_parts::<'_, usize>",
     "file": "library/core/src/slice/raw.rs"
   },
@@ -1030,7 +1030,7 @@
     "file": "library/core/src/str/converts.rs"
   },
   {
-    "hash": "145201222854331195178815443675397277392",
+    "hash": "105509042728785276095738116562226884135",
     "name": "core::str::count::char_count_general_case",
     "file": "library/core/src/str/count.rs"
   },
@@ -1045,37 +1045,37 @@
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "47468782241743602393810882143023349945",
+    "hash": "101539333883602999142743294499662142781",
     "name": "core::str::count::count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "944297586695660734811678461952919859244",
+    "hash": "155145547891548244516298634347765599627",
     "name": "core::str::count::do_count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "268701197549167845816540622531722429171",
+    "hash": "12025566570273099920903542994299871817",
     "name": "core::str::count::sum_bytes_in_usize",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "174931159159579161911556326084018243713",
+    "hash": "152715002861639775393988580799560247805",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "759516041501256089813279787494912941682",
+    "hash": "644663214087010307916081317719588641492",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::count",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "151051332114409904941604214564891538957",
+    "hash": "660978859467132204713340652707099987613",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "42461548492323519705759720031945445712",
+    "hash": "16139698699567968342904534840657946470",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1085,7 +1085,7 @@
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "50301635678991252011107801667626389768",
+    "hash": "1563992362164201785411080871236623299079",
     "name": "std::str::Chars::<'_>::as_str",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1105,7 +1105,7 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "867395007143103994512438910488508336973",
+    "hash": "71021883313881662847215860786847447423",
     "name": "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
     "file": "library/core/src/str/mod.rs"
   },
@@ -1115,17 +1115,17 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "112020109271780179669495653821738681551",
+    "hash": "91070850951614709601933024856310781945",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "152909514978300660252157530308776102467",
+    "hash": "145757805227894694174215691004963108394",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "68493124835835642495275913021346263998",
+    "hash": "1317118350612563145817400323127232106582",
     "name": "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
     "file": "library/core/src/str/validations.rs"
   },
@@ -1145,17 +1145,17 @@
     "file": "library/core/src/str/validations.rs"
   },
   {
-    "hash": "1563172082169351546616225899813991043484",
+    "hash": "172646548629003079288424832349823487421",
     "name": "core::num::<impl u16>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "33957922410128141509625682565657813466",
+    "hash": "1248191826238009221015171546017389042989",
     "name": "core::num::<impl usize>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "100872428199167332544577177169244129806",
+    "hash": "13514854596489369474334665362530945420",
     "name": "core::num::<impl usize>::unchecked_sub::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1185,12 +1185,12 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "1158923569256985321513541004220644151856",
+    "hash": "748210795816008050710623801889599715701",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "140048639800126365939997225010682400254",
+    "hash": "7461493046945910432435712880095080611",
     "name": "std::char::convert::from_u32_unchecked::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1205,18 +1205,18 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "71108690579660086896269737077011959868",
+    "hash": "399721967138328910814551048930416922779",
     "name": "std::slice::from_raw_parts::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "1376915858339353144310140900781257640904",
+    "hash": "149126667344574031617275998201144313616",
     "name": "verify::f",
     "file": "tests/compare/contract.rs",
     "proof_kind": "Standard"
   },
   {
-    "hash": "156859034860515298896252699466771897262",
+    "hash": "158526682867152455191082175869548730527",
     "name": "verify::contract",
     "file": "tests/compare/contract.rs"
   },
@@ -1226,22 +1226,42 @@
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "463729425312346235114003524280183540035",
+    "name": "verify::contract::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "50413664688313882447631101106796111126",
+    "hash": "521936935663953309014171735291090591991",
     "name": "verify::contract::kani_register_contract::<(), {closure@tests/compare/contract.rs:3:5: 3:29}>",
     "file": "tests/compare/contract.rs"
   },
@@ -1251,7 +1271,7 @@
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "32420680924082528347088382350399033625",
+    "hash": "177082831763611644679358309509007888650",
     "name": "verify::g",
     "file": "tests/compare/contract.rs"
   },
@@ -1261,22 +1281,42 @@
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "833520033169721702415554016916565707705",
+    "hash": "1741631858695210515314585865333587484551",
+    "name": "verify::g::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "1741631858695210515314585865333587484551",
+    "name": "verify::g::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "1741631858695210515314585865333587484551",
+    "name": "verify::g::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "1741631858695210515314585865333587484551",
+    "name": "verify::g::kani_force_fn_once::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
+    "file": "tests/compare/contract.rs"
+  },
+  {
+    "hash": "1367880383678798457515607118954996643541",
     "name": "verify::g::kani_register_contract::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "833520033169721702415554016916565707705",
+    "hash": "1367880383678798457515607118954996643541",
     "name": "verify::g::kani_register_contract::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "833520033169721702415554016916565707705",
+    "hash": "1367880383678798457515607118954996643541",
     "name": "verify::g::kani_register_contract::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "tests/compare/contract.rs"
   },
   {
-    "hash": "833520033169721702415554016916565707705",
+    "hash": "1367880383678798457515607118954996643541",
     "name": "verify::g::kani_register_contract::<(), {closure@tests/compare/contract.rs:11:5: 11:29}>",
     "file": "tests/compare/contract.rs"
   },

--- a/tests/snapshots/kani_list/ad_hoc.txt
+++ b/tests/snapshots/kani_list/ad_hoc.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {
         "tests/proofs/ad_hoc.rs": {

--- a/tests/snapshots/kani_list/gen_contracts_by_macros.txt
+++ b/tests/snapshots/kani_list/gen_contracts_by_macros.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {},
     contract_harnesses: {

--- a/tests/snapshots/kani_list/gen_proofs_by_macros.txt
+++ b/tests/snapshots/kani_list/gen_proofs_by_macros.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {
         "tests/proofs/gen_proofs_by_macros.rs": {

--- a/tests/snapshots/kani_list/gen_proofs_by_nested_macros.txt
+++ b/tests/snapshots/kani_list/gen_proofs_by_nested_macros.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {
         "tests/proofs/gen_proofs_by_nested_macros.rs": {

--- a/tests/snapshots/kani_list/proofs_for_contract.txt
+++ b/tests/snapshots/kani_list/proofs_for_contract.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {},
     contract_harnesses: {

--- a/tests/snapshots/kani_list/standard_proofs.txt
+++ b/tests/snapshots/kani_list/standard_proofs.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {
         "tests/proofs/standard_proofs.rs": {

--- a/tests/snapshots/kani_list/standard_proofs_with_contracts.txt
+++ b/tests/snapshots/kani_list/standard_proofs_with_contracts.txt
@@ -1,5 +1,5 @@
 KaniList {
-    kani_version: "0.63.0",
+    kani_version: "0.64.0",
     file_version: "0.1",
     standard_harnesses: {
         "tests/proofs/standard_proofs_with_contracts.rs": {

--- a/tests/snapshots/proofs/proofs_for_contract.json
+++ b/tests/snapshots/proofs/proofs_for_contract.json
@@ -10,7 +10,7 @@
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
   {
-    "hash": "9110013437157474711273995327575973953",
+    "hash": "170185868534852403517319670654034345935",
     "name": "kani::panic",
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
@@ -20,22 +20,22 @@
     "file": "library/core/src/array/mod.rs"
   },
   {
-    "hash": "1835555409892641968715518659512763629305",
+    "hash": "1253501917253063290515286798079291406022",
     "name": "std::char::convert::char_try_from_u32",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "181272475585460647517443557415321318659",
+    "hash": "131606170482807693362175987803096434760",
     "name": "std::char::convert::from_u32_unchecked",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "1320043678392507861115191954133317143490",
+    "hash": "141777398513335345408154280402043326980",
     "name": "std::char::methods::<impl char>::from_u32_unchecked",
     "file": "library/core/src/char/methods.rs"
   },
   {
-    "hash": "105293143189968001175910723606472847453",
+    "hash": "80249903325342526932651822469818924130",
     "name": "<usize as std::cmp::Ord>::min",
     "file": "library/core/src/cmp.rs"
   },
@@ -50,7 +50,7 @@
     "file": "library/core/src/cmp.rs"
   },
   {
-    "hash": "45420099425906739229972611360828906996",
+    "hash": "1774680678790287728814454280293715994219",
     "name": "std::cmp::min::<usize>",
     "file": "library/core/src/cmp.rs"
   },
@@ -65,12 +65,12 @@
     "file": "library/core/src/convert/num.rs"
   },
   {
-    "hash": "1371746331589039016331056560044945030",
+    "hash": "55365444148228517684466806986787559606",
     "name": "<&str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1354177614729625835117775292546531775014",
+    "hash": "694412030810075507040989598874491585",
     "name": "<str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -80,17 +80,17 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "172944738288885290083276427975264664072",
+    "hash": "4372901837201700045367109528985425757",
     "name": "core::fmt::PostPadding::write",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1533180195846334583617947954899683798657",
+    "hash": "699002900709069648812102067476367562990",
     "name": "std::fmt::Formatter::<'_>::pad",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "142514712097694120346572792450431499665",
+    "hash": "141869330349636326479565094854406012453",
     "name": "std::fmt::Formatter::<'_>::padding",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -100,7 +100,7 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "151549091835301814569478420826126555649",
+    "hash": "1161005037905311640618283830950292411169",
     "name": "std::fmt::FormattingOptions::get_fill",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -120,7 +120,7 @@
     "file": "library/core/src/fmt/rt.rs"
   },
   {
-    "hash": "931076662517735820116389385577792859706",
+    "hash": "64831333328555634737835457686945546342",
     "name": "core::fmt::rt::Argument::<'_>::new_display::<&str>",
     "file": "library/core/src/fmt/rt.rs"
   },
@@ -140,7 +140,7 @@
     "file": "library/core/src/intrinsics/mod.rs"
   },
   {
-    "hash": "1408393638760277889216161485462822825467",
+    "hash": "91375825332728499584552473133800788915",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
     "file": "library/core/src/intrinsics/mod.rs"
   },
@@ -170,12 +170,12 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "766528270008730576414797874131980563974",
+    "hash": "1169454885572802949911851882877522755773",
     "name": "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "98972097590179534414450729561525715395",
+    "hash": "545707798122007980817913094500135596036",
     "name": "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
@@ -185,7 +185,7 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "136460023026271463242964210703970143574",
+    "hash": "1311510069182000871611712506430824967365",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
     "file": "library/core/src/iter/adapters/map.rs"
   },
@@ -200,27 +200,27 @@
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1298212628145154126618156816134265951344",
+    "hash": "143385254926310059114601711607934802626",
     "name": "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1232889667129580128612195481125876355895",
+    "hash": "69836621587154186912082287672825986701",
     "name": "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "65191485396793801441708908227891945976",
+    "hash": "74263642424770005886585667687132666700",
     "name": "<u16 as std::iter::Step>::forward_unchecked",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "188312196520496208216777120611981411403",
+    "hash": "150021953543632011655891713384046546195",
     "name": "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "1118720028921197857316850364974898782644",
+    "hash": "83212516662910391527380784146422699337",
     "name": "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
     "file": "library/core/src/iter/traits/accum.rs"
   },
@@ -240,7 +240,7 @@
     "file": "library/core/src/iter/traits/collect.rs"
   },
   {
-    "hash": "117160024467577062374814279693937914308",
+    "hash": "1476188077969759501416587624527731620422",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -255,22 +255,22 @@
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "169254447276496917964889824994222006487",
+    "hash": "746335627686636360311089028698215315621",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "95354230261524383717847373957185145555",
+    "hash": "890743343806001783818377326543496764999",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "64016173223473785207354785894730039924",
+    "hash": "38248963824617361146577789155806220457",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "68746763044528098428227291452128003750",
+    "hash": "162963300457841015274153803823417766214",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::try_fold::<std::num::NonZero<usize>, {closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}, std::option::Option<std::num::NonZero<usize>>>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -315,52 +315,52 @@
     "file": "library/core/src/num/nonzero.rs"
   },
   {
-    "hash": "28416299455941732499272441497123863286",
+    "hash": "66472461948522780286669743098512884020",
     "name": "core::num::<impl u16>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1767882825766330041012289079684840123988",
+    "hash": "1755481411544761241911010338868424028032",
     "name": "core::num::<impl u16>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "531547630013775774616630521705918956890",
+    "hash": "778307969913358517318134351169293017006",
     "name": "core::num::<impl u32>::wrapping_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1491976204649427753712444486504685158667",
+    "hash": "1817700327438920062811986284895946972360",
     "name": "core::num::<impl usize>::count_ones",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "267503639466522371016185904314247059966",
+    "hash": "1198745042195432320316237250098976336783",
     "name": "core::num::<impl usize>::is_power_of_two",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "420027195811498354113361982279400413970",
+    "hash": "29280884443006517116686346795110467729",
     "name": "core::num::<impl usize>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "9766519181220151615102176802326253862",
+    "hash": "680697364573271958516692421008805893594",
     "name": "core::num::<impl usize>::overflowing_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "861075789615506151054802343958342702",
+    "hash": "10088042682663381447210876152059630410",
     "name": "core::num::<impl usize>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1240112622965974978610989681601335370041",
+    "hash": "163514900348266881411363175083503667972",
     "name": "core::num::<impl usize>::unchecked_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "176480214868331547301536851964719628253",
+    "hash": "115578125622558050988953568575947871951",
     "name": "core::num::<impl usize>::wrapping_mul",
     "file": "library/core/src/num/uint_macros.rs"
   },
@@ -395,17 +395,17 @@
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "131534592200098059029750365218172562280",
+    "hash": "551284205942989744010603758892918003809",
     "name": "std::option::Option::<std::fmt::Alignment>::unwrap_or",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "37329511099916694324318814422027472373",
+    "hash": "139548131330438493408310223143043863897",
     "name": "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "145379337856805001595892687783013497010",
+    "hash": "93873349781065085267543059115936351593",
     "name": "kani::panic::panic_cold_display::<&str>",
     "file": "library/core/src/panic.rs"
   },
@@ -430,7 +430,7 @@
     "file": "library/core/src/panicking.rs"
   },
   {
-    "hash": "161984531712227522752564874190257605258",
+    "hash": "156103043049447019914417901809615508350",
     "name": "std::rt::panic_display::<&str>",
     "file": "library/core/src/panicking.rs"
   },
@@ -450,7 +450,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "172740984469479579071665404435289701023",
+    "hash": "135040582385212612735475257113813496500",
     "name": "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -470,7 +470,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "11106989263465620674119447375151988759",
+    "hash": "21654441677010109529687023928280502180",
     "name": "std::ptr::const_ptr::<impl *const [u8]>::len",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -525,22 +525,22 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "1300271856392091645916001889619506617490",
+    "hash": "1618707962037661705218318211105471942120",
     "name": "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "14412815270469178284372346649253214057",
+    "hash": "171364413319637295715083043732096201442",
     "name": "std::ptr::from_raw_parts::<[u8], u8>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "759301201495386013914096069500577582268",
+    "hash": "10108227029034297089458694313942657216",
     "name": "std::ptr::from_raw_parts::<[usize], usize>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "1363429953646800642818322319211259624481",
+    "hash": "65477300936560271722610262085043582244",
     "name": "std::ptr::metadata::<[u8]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
@@ -555,117 +555,117 @@
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "507486726895721764016555491610607611305",
+    "hash": "844348294257748951813515064259923850502",
     "name": "std::ptr::drop_in_place::<&u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "32758264716275548135301815416129443538",
+    "hash": "786281027352090909410587866630825111124",
     "name": "std::ptr::drop_in_place::<(usize, char)>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "92620507381766029301237587487992527213",
+    "hash": "1602108665480339150417063482100093944787",
     "name": "std::ptr::drop_in_place::<std::fmt::Alignment>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "102773287537006387418136460951493449150",
+    "hash": "14750464030756559092072511389613712638",
     "name": "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "149239371713813135466988763744767882801",
+    "hash": "180547684808059406565403285055600712836",
     "name": "std::ptr::drop_in_place::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "55367978787089163010793217435139837876",
+    "hash": "554158701962205684218313987735220350468",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1209564197857095228814830958456579553221",
+    "hash": "82095542769953368154912485864031886270",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "748209534850776693517100400031629133312",
+    "hash": "5831255669648730149843380384415246652",
     "name": "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "604266344039168659216032964566050355997",
+    "hash": "175036670015225221411772188187965169190",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "604266344039168659216032964566050355997",
+    "hash": "175036670015225221411772188187965169190",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "604266344039168659216032964566050355997",
+    "hash": "175036670015225221411772188187965169190",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "604266344039168659216032964566050355997",
+    "hash": "175036670015225221411772188187965169190",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "123444524744287359945969605918134445431",
+    "hash": "1819755273233344233944960289259596867",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "123444524744287359945969605918134445431",
+    "hash": "1819755273233344233944960289259596867",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "123444524744287359945969605918134445431",
+    "hash": "1819755273233344233944960289259596867",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "123444524744287359945969605918134445431",
+    "hash": "1819755273233344233944960289259596867",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "101492910187298678619036524670569532491",
+    "hash": "31562733682696207696545845758769098332",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "101492910187298678619036524670569532491",
+    "hash": "31562733682696207696545845758769098332",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "101492910187298678619036524670569532491",
+    "hash": "31562733682696207696545845758769098332",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "101492910187298678619036524670569532491",
+    "hash": "31562733682696207696545845758769098332",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "267935267854751480818415065985053337078",
+    "hash": "937477061605388048115884892480312288537",
     "name": "std::ptr::slice_from_raw_parts::<[usize; 4]>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "57392431669649698342516110218176469764",
+    "hash": "892461914248527136611431264334752468555",
     "name": "std::ptr::slice_from_raw_parts::<u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "122558071050321327518145172778423713781",
+    "hash": "1297187182340166219213119975319687609972",
     "name": "std::ptr::slice_from_raw_parts::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
@@ -885,7 +885,7 @@
     "file": "library/core/src/result.rs"
   },
   {
-    "hash": "88633046024721928868158000904972228167",
+    "hash": "54888678836671866272358132516024826502",
     "name": "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -910,7 +910,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "125489371537082193378561958245297073133",
+    "hash": "45060499419383805014075082957353484074",
     "name": "std::slice::Iter::<'_, u8>::as_slice",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -925,7 +925,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "112093191663101859282706845470326278900",
+    "hash": "47269698298620023111796944825903179130",
     "name": "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -935,22 +935,22 @@
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "136484293011665227087512181501588076411",
+    "hash": "674881123049448667512672737959208587337",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "7250475688043728136115351013068090102",
+    "hash": "154659969182662416984535348444125844",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "155597816474146809159504684113290845792",
+    "hash": "1219085896046917615810259583008727206943",
     "name": "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "145530532616617731099568344791001893798",
+    "hash": "793309437318306726913806640804801036999",
     "name": "std::slice::Iter::<'_, u8>::make_slice",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -960,7 +960,7 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1593063580605279640314183922934412511157",
+    "hash": "51188353216572513337552947382367213612",
     "name": "core::slice::<impl [u8]>::align_to::<usize>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -980,27 +980,27 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1785941139609704198311972964660228370976",
+    "hash": "1041529063314010914218218438532577583921",
     "name": "core::slice::<impl [u8]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "84572646525781694072079679591848027002",
+    "hash": "11017778733362591934337269956689912680",
     "name": "core::slice::<impl [u8]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "58089700496514419381325942148928567391",
+    "hash": "89128813248987492211721493584967359724",
     "name": "core::slice::<impl [u8]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "917728468319067451416388429251863159678",
+    "hash": "348372507889018041910054944302851661070",
     "name": "core::slice::<impl [usize]>::as_chunks::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1621046050041371142817756793657558429507",
+    "hash": "144624929410860970405573471555686596396",
     "name": "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -1025,32 +1025,32 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "3900672375060331021424481618253650288",
+    "hash": "1689731528734002832615362599744307150563",
     "name": "core::slice::<impl [usize]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "171173179240508091544601281736583524354",
+    "hash": "157354110368917150977548446164644269157",
     "name": "core::slice::<impl [usize]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "116483621522571785213244680499922945415",
+    "hash": "1325059444048598179110854173592682518417",
     "name": "core::slice::<impl [usize]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "325660469324403897513522339552212646632",
+    "hash": "1617537487569895078313557542670536892075",
     "name": "std::slice::from_raw_parts::<'_, [usize; 4]>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "47514593099713610332964838893229837936",
+    "hash": "44787092142404380205959599561725184847",
     "name": "std::slice::from_raw_parts::<'_, u8>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "184867918752959488617184774691899169910",
+    "hash": "630819595617041232110620176331560268262",
     "name": "std::slice::from_raw_parts::<'_, usize>",
     "file": "library/core/src/slice/raw.rs"
   },
@@ -1060,7 +1060,7 @@
     "file": "library/core/src/str/converts.rs"
   },
   {
-    "hash": "145201222854331195178815443675397277392",
+    "hash": "105509042728785276095738116562226884135",
     "name": "core::str::count::char_count_general_case",
     "file": "library/core/src/str/count.rs"
   },
@@ -1075,37 +1075,37 @@
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "47468782241743602393810882143023349945",
+    "hash": "101539333883602999142743294499662142781",
     "name": "core::str::count::count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "944297586695660734811678461952919859244",
+    "hash": "155145547891548244516298634347765599627",
     "name": "core::str::count::do_count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "268701197549167845816540622531722429171",
+    "hash": "12025566570273099920903542994299871817",
     "name": "core::str::count::sum_bytes_in_usize",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "174931159159579161911556326084018243713",
+    "hash": "152715002861639775393988580799560247805",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "759516041501256089813279787494912941682",
+    "hash": "644663214087010307916081317719588641492",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::count",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "151051332114409904941604214564891538957",
+    "hash": "660978859467132204713340652707099987613",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "42461548492323519705759720031945445712",
+    "hash": "16139698699567968342904534840657946470",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1115,7 +1115,7 @@
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "50301635678991252011107801667626389768",
+    "hash": "1563992362164201785411080871236623299079",
     "name": "std::str::Chars::<'_>::as_str",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1135,7 +1135,7 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "867395007143103994512438910488508336973",
+    "hash": "71021883313881662847215860786847447423",
     "name": "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
     "file": "library/core/src/str/mod.rs"
   },
@@ -1145,17 +1145,17 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "112020109271780179669495653821738681551",
+    "hash": "91070850951614709601933024856310781945",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "152909514978300660252157530308776102467",
+    "hash": "145757805227894694174215691004963108394",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "68493124835835642495275913021346263998",
+    "hash": "1317118350612563145817400323127232106582",
     "name": "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
     "file": "library/core/src/str/validations.rs"
   },
@@ -1175,17 +1175,17 @@
     "file": "library/core/src/str/validations.rs"
   },
   {
-    "hash": "1563172082169351546616225899813991043484",
+    "hash": "172646548629003079288424832349823487421",
     "name": "core::num::<impl u16>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "33957922410128141509625682565657813466",
+    "hash": "1248191826238009221015171546017389042989",
     "name": "core::num::<impl usize>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "100872428199167332544577177169244129806",
+    "hash": "13514854596489369474334665362530945420",
     "name": "core::num::<impl usize>::unchecked_sub::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1215,12 +1215,12 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "1158923569256985321513541004220644151856",
+    "hash": "748210795816008050710623801889599715701",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "140048639800126365939997225010682400254",
+    "hash": "7461493046945910432435712880095080611",
     "name": "std::char::convert::from_u32_unchecked::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1235,36 +1235,36 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "71108690579660086896269737077011959868",
+    "hash": "399721967138328910814551048930416922779",
     "name": "std::slice::from_raw_parts::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "701526988294430207414821647670184897330",
+    "hash": "793225298737803974414835553001713146394",
     "name": "verify::single_contract",
     "file": "tests/proofs/proofs_for_contract.rs",
     "proof_kind": "Contract"
   },
   {
-    "hash": "157358757356173787254952107394866850361",
+    "hash": "190958661898519013513875693945335012974",
     "name": "verify::single_contract_requires",
     "file": "tests/proofs/proofs_for_contract.rs",
     "proof_kind": "Contract"
   },
   {
-    "hash": "163886666099788461512155870154695223372",
+    "hash": "72605166534883769010740627084392583844",
     "name": "verify::single_with_contract_ensures",
     "file": "tests/proofs/proofs_for_contract.rs",
     "proof_kind": "Contract"
   },
   {
-    "hash": "1269040190462182887711828666912254439700",
+    "hash": "78552360882815941222871696662580086661",
     "name": "verify::two_contracts_requires_and_ensures",
     "file": "tests/proofs/proofs_for_contract.rs",
     "proof_kind": "Contract"
   },
   {
-    "hash": "2623055860877728893199821296195161800",
+    "hash": "146510885743608713509163719806804039748",
     "name": "verify::contract",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
@@ -1274,22 +1274,42 @@
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "13639025576242879361733715326367503686",
+    "hash": "1182434864504194244015029782800165074459",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "1182434864504194244015029782800165074459",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "1182434864504194244015029782800165074459",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "1182434864504194244015029782800165074459",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "157249491237794083928428048602624188053",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "13639025576242879361733715326367503686",
+    "hash": "157249491237794083928428048602624188053",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "13639025576242879361733715326367503686",
+    "hash": "157249491237794083928428048602624188053",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "13639025576242879361733715326367503686",
+    "hash": "157249491237794083928428048602624188053",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:27:5: 27:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
@@ -1299,7 +1319,7 @@
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "1206580667269463865914834143548694613363",
+    "hash": "1195331541890807965216321001278771493568",
     "name": "verify::contract_ensures",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
@@ -1309,22 +1329,42 @@
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "155574938752675177533544455983464431109",
+    "hash": "72091074602908430379999836884376602519",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "72091074602908430379999836884376602519",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "72091074602908430379999836884376602519",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "72091074602908430379999836884376602519",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "2349763213441544269314060789600297712",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "155574938752675177533544455983464431109",
+    "hash": "2349763213441544269314060789600297712",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "155574938752675177533544455983464431109",
+    "hash": "2349763213441544269314060789600297712",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "155574938752675177533544455983464431109",
+    "hash": "2349763213441544269314060789600297712",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/proofs_for_contract.rs:11:5: 11:37}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
@@ -1334,7 +1374,7 @@
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "4878027181794487515844454088721928356",
+    "hash": "880175715806394731914059849796451720387",
     "name": "verify::contract_requires",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
@@ -1344,22 +1384,42 @@
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "1688923391201567444911995970604371434073",
+    "hash": "28621828018843203299283958331135706694",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "28621828018843203299283958331135706694",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "28621828018843203299283958331135706694",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "28621828018843203299283958331135706694",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
+    "file": "tests/proofs/proofs_for_contract.rs"
+  },
+  {
+    "hash": "99485635645147491446124587870675969389",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "1688923391201567444911995970604371434073",
+    "hash": "99485635645147491446124587870675969389",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "1688923391201567444911995970604371434073",
+    "hash": "99485635645147491446124587870675969389",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },
   {
-    "hash": "1688923391201567444911995970604371434073",
+    "hash": "99485635645147491446124587870675969389",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/proofs_for_contract.rs:3:5: 3:29}>",
     "file": "tests/proofs/proofs_for_contract.rs"
   },

--- a/tests/snapshots/proofs/standard_proofs.json
+++ b/tests/snapshots/proofs/standard_proofs.json
@@ -30,17 +30,17 @@
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
   {
-    "hash": "1835555409892641968715518659512763629305",
+    "hash": "1253501917253063290515286798079291406022",
     "name": "std::char::convert::char_try_from_u32",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "181272475585460647517443557415321318659",
+    "hash": "131606170482807693362175987803096434760",
     "name": "std::char::convert::from_u32_unchecked",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "1320043678392507861115191954133317143490",
+    "hash": "141777398513335345408154280402043326980",
     "name": "std::char::methods::<impl char>::from_u32_unchecked",
     "file": "library/core/src/char/methods.rs"
   },
@@ -90,27 +90,27 @@
     "file": "library/core/src/mem/mod.rs"
   },
   {
-    "hash": "136031922766430141475029829833236928247",
+    "hash": "68431161752181641414484933001898060422",
     "name": "core::num::<impl isize>::overflowing_neg",
     "file": "library/core/src/num/int_macros.rs"
   },
   {
-    "hash": "128555923863573443926234458093678936131",
+    "hash": "99196751783792925943400447449121951486",
     "name": "core::num::<impl isize>::unchecked_neg",
     "file": "library/core/src/num/int_macros.rs"
   },
   {
-    "hash": "531547630013775774616630521705918956890",
+    "hash": "778307969913358517318134351169293017006",
     "name": "core::num::<impl u32>::wrapping_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "9766519181220151615102176802326253862",
+    "hash": "680697364573271958516692421008805893594",
     "name": "core::num::<impl usize>::overflowing_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1240112622965974978610989681601335370041",
+    "hash": "163514900348266881411363175083503667972",
     "name": "core::num::<impl usize>::unchecked_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
@@ -135,17 +135,17 @@
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "32132229389387834086627970503154217672",
+    "hash": "109385176472642702115257968545485189902",
     "name": "std::option::Option::<char>::map::<(usize, char), {closure@<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "93823320107012720417032838886044010690",
+    "hash": "93526250790004031471906599419143816654",
     "name": "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "37329511099916694324318814422027472373",
+    "hash": "139548131330438493408310223143043863897",
     "name": "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
@@ -185,7 +185,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "11106989263465620674119447375151988759",
+    "hash": "21654441677010109529687023928280502180",
     "name": "std::ptr::const_ptr::<impl *const [u8]>::len",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -210,42 +210,42 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "14412815270469178284372346649253214057",
+    "hash": "171364413319637295715083043732096201442",
     "name": "std::ptr::from_raw_parts::<[u8], u8>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "1363429953646800642818322319211259624481",
+    "hash": "65477300936560271722610262085043582244",
     "name": "std::ptr::metadata::<[u8]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "28322876068627831251469156510260466593",
+    "hash": "763526022499778438016478457260487813362",
     "name": "std::ptr::drop_in_place::<[u8; 256]>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "155408645642466530118086473531043529423",
+    "hash": "77196811231125203975274613713011090632",
     "name": "std::ptr::drop_in_place::<std::str::pattern::CharPredicateSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}>>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "60854719194781845212708913161129285146",
+    "hash": "1464986396688487412314560322607324435430",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1414388888952747393315410489161081096116",
+    "hash": "893061533288394316213923282035694252369",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1209564197857095228814830958456579553221",
+    "hash": "82095542769953368154912485864031886270",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "57392431669649698342516110218176469764",
+    "hash": "892461914248527136611431264334752468555",
     "name": "std::ptr::slice_from_raw_parts::<u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
@@ -330,7 +330,7 @@
     "file": "library/core/src/ptr/non_null.rs"
   },
   {
-    "hash": "1484496475346703881513614362315361630932",
+    "hash": "44050422002102056065419212094942600820",
     "name": "std::ptr::NonNull::<u8>::sub",
     "file": "library/core/src/ptr/non_null.rs"
   },
@@ -345,7 +345,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "383287521678454564613434609682451898939",
+    "hash": "187436426501324743618412607508830914106",
     "name": "<std::slice::Iter<'_, u8> as std::iter::DoubleEndedIterator>::next_back",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -355,17 +355,17 @@
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "7250475688043728136115351013068090102",
+    "hash": "154659969182662416984535348444125844",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "1209398002955812968818167484785357055084",
+    "hash": "439060468196624478618351857989978916322",
     "name": "std::slice::Iter::<'_, u8>::next_back_unchecked",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "959735891163173312412872249633990615950",
+    "hash": "88302643269870605817647896585215232588",
     "name": "std::slice::Iter::<'_, u8>::pre_dec_end",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -375,7 +375,7 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1220797885475637925315319986695673178247",
+    "hash": "1600793067427995966117951132574009622835",
     "name": "<std::str::CharIndices<'_> as std::iter::DoubleEndedIterator>::next_back",
     "file": "library/core/src/str/iter.rs"
   },
@@ -385,27 +385,27 @@
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "174931159159579161911556326084018243713",
+    "hash": "152715002861639775393988580799560247805",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "43790633062823707465232438700141790738",
+    "hash": "203299270282650216711849692141603321998",
     "name": "<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "10100656673993390409999916864644063362",
+    "hash": "145778172834776373404454916597382558267",
     "name": "<std::str::Chars<'_> as std::iter::DoubleEndedIterator>::next_back::{closure#0}",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "151051332114409904941604214564891538957",
+    "hash": "660978859467132204713340652707099987613",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "42461548492323519705759720031945445712",
+    "hash": "16139698699567968342904534840657946470",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
     "file": "library/core/src/str/iter.rs"
   },
@@ -425,17 +425,17 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "718538245394236899311634178535896462693",
+    "hash": "568476700694776934407421978686203026",
     "name": "core::str::<impl str>::get_unchecked::<std::ops::Range<usize>>",
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "148893650982386109273956226414498659455",
+    "hash": "567173681531154279218296512637220369082",
     "name": "core::str::<impl str>::trim",
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "417725132111411054714717432895673282345",
+    "hash": "9693894676321952815355429995054057025",
     "name": "core::str::<impl str>::trim_matches::<fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}>",
     "file": "library/core/src/str/mod.rs"
   },
@@ -450,12 +450,12 @@
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "136885733275442317894809007134672107577",
+    "hash": "916260299002420620213303575465445801045",
     "name": "<std::str::pattern::CharPredicateSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}> as std::str::pattern::ReverseSearcher<'_>>::next_reject_back",
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "73507486733844788321314739415762318276",
+    "hash": "1525625489453947944917512082162169543118",
     "name": "<std::str::pattern::CharPredicateSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}> as std::str::pattern::Searcher<'_>>::next_reject",
     "file": "library/core/src/str/pattern.rs"
   },
@@ -465,37 +465,37 @@
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "820316713134370000312831289777781242030",
+    "hash": "1111635474439559909233102576243507100",
     "name": "<std::str::pattern::MultiCharEqSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}> as std::str::pattern::ReverseSearcher<'_>>::next_back",
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "105748910014749711218935925532623934204",
+    "hash": "108492770323485280674389488868081059627",
     "name": "<std::str::pattern::MultiCharEqSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}> as std::str::pattern::ReverseSearcher<'_>>::next_reject_back",
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "72502984974151083624594641991317767976",
+    "hash": "1678390452388873267010299124183561816183",
     "name": "<std::str::pattern::MultiCharEqSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}> as std::str::pattern::Searcher<'_>>::next",
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "685481956097193564110518396334489447857",
+    "hash": "1546358471913062153412631284591389044570",
     "name": "<std::str::pattern::MultiCharEqSearcher<'_, fn(char) -> bool {std::char::methods::<impl char>::is_whitespace}> as std::str::pattern::Searcher<'_>>::next_reject",
     "file": "library/core/src/str/pattern.rs"
   },
   {
-    "hash": "112020109271780179669495653821738681551",
+    "hash": "91070850951614709601933024856310781945",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "68493124835835642495275913021346263998",
+    "hash": "1317118350612563145817400323127232106582",
     "name": "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
     "file": "library/core/src/str/validations.rs"
   },
   {
-    "hash": "93770800302877279369779905364736522507",
+    "hash": "656910077698661910813175299455865574740",
     "name": "core::str::validations::next_code_point_reverse::<'_, std::slice::Iter<'_, u8>>",
     "file": "library/core/src/str/validations.rs"
   },
@@ -515,12 +515,12 @@
     "file": "library/core/src/str/validations.rs"
   },
   {
-    "hash": "182452919908091242794321126204378733860",
+    "hash": "501088403581321422714896845924434515454",
     "name": "core::num::<impl isize>::unchecked_neg::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "100872428199167332544577177169244129806",
+    "hash": "13514854596489369474334665362530945420",
     "name": "core::num::<impl usize>::unchecked_sub::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -535,7 +535,7 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "140048639800126365939997225010682400254",
+    "hash": "7461493046945910432435712880095080611",
     "name": "std::char::convert::from_u32_unchecked::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -555,7 +555,7 @@
     "file": "library/core/src/unicode/unicode_data.rs"
   },
   {
-    "hash": "1761490472524323384016309344156489449042",
+    "hash": "4334811063674073226813469283385178240",
     "name": "verify::recursive_callees",
     "file": "tests/proofs/standard_proofs.rs",
     "proof_kind": "Standard"
@@ -573,12 +573,12 @@
     "proof_kind": "Standard"
   },
   {
-    "hash": "1332116524179732939017409417942661658462",
+    "hash": "677480054236845771815111058937132547057",
     "name": "m::func1",
     "file": "tests/proofs/standard_proofs.rs"
   },
   {
-    "hash": "334827438410901873211540754013625964478",
+    "hash": "1752482367619339351416462201666492809793",
     "name": "top_level",
     "file": "tests/proofs/standard_proofs.rs"
   }

--- a/tests/snapshots/proofs/standard_proofs_with_contracts.json
+++ b/tests/snapshots/proofs/standard_proofs_with_contracts.json
@@ -5,7 +5,7 @@
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
   {
-    "hash": "9110013437157474711273995327575973953",
+    "hash": "170185868534852403517319670654034345935",
     "name": "kani::panic",
     "file": "distributed-verification/kani/library/kani_core/src/lib.rs"
   },
@@ -15,22 +15,22 @@
     "file": "library/core/src/array/mod.rs"
   },
   {
-    "hash": "1835555409892641968715518659512763629305",
+    "hash": "1253501917253063290515286798079291406022",
     "name": "std::char::convert::char_try_from_u32",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "181272475585460647517443557415321318659",
+    "hash": "131606170482807693362175987803096434760",
     "name": "std::char::convert::from_u32_unchecked",
     "file": "library/core/src/char/convert.rs"
   },
   {
-    "hash": "1320043678392507861115191954133317143490",
+    "hash": "141777398513335345408154280402043326980",
     "name": "std::char::methods::<impl char>::from_u32_unchecked",
     "file": "library/core/src/char/methods.rs"
   },
   {
-    "hash": "105293143189968001175910723606472847453",
+    "hash": "80249903325342526932651822469818924130",
     "name": "<usize as std::cmp::Ord>::min",
     "file": "library/core/src/cmp.rs"
   },
@@ -45,7 +45,7 @@
     "file": "library/core/src/cmp.rs"
   },
   {
-    "hash": "45420099425906739229972611360828906996",
+    "hash": "1774680678790287728814454280293715994219",
     "name": "std::cmp::min::<usize>",
     "file": "library/core/src/cmp.rs"
   },
@@ -60,12 +60,12 @@
     "file": "library/core/src/convert/num.rs"
   },
   {
-    "hash": "1371746331589039016331056560044945030",
+    "hash": "55365444148228517684466806986787559606",
     "name": "<&str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1354177614729625835117775292546531775014",
+    "hash": "694412030810075507040989598874491585",
     "name": "<str as std::fmt::Display>::fmt",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -75,17 +75,17 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "172944738288885290083276427975264664072",
+    "hash": "4372901837201700045367109528985425757",
     "name": "core::fmt::PostPadding::write",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "1533180195846334583617947954899683798657",
+    "hash": "699002900709069648812102067476367562990",
     "name": "std::fmt::Formatter::<'_>::pad",
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "142514712097694120346572792450431499665",
+    "hash": "141869330349636326479565094854406012453",
     "name": "std::fmt::Formatter::<'_>::padding",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -95,7 +95,7 @@
     "file": "library/core/src/fmt/mod.rs"
   },
   {
-    "hash": "151549091835301814569478420826126555649",
+    "hash": "1161005037905311640618283830950292411169",
     "name": "std::fmt::FormattingOptions::get_fill",
     "file": "library/core/src/fmt/mod.rs"
   },
@@ -115,7 +115,7 @@
     "file": "library/core/src/fmt/rt.rs"
   },
   {
-    "hash": "931076662517735820116389385577792859706",
+    "hash": "64831333328555634737835457686945546342",
     "name": "core::fmt::rt::Argument::<'_>::new_display::<&str>",
     "file": "library/core/src/fmt/rt.rs"
   },
@@ -135,7 +135,7 @@
     "file": "library/core/src/intrinsics/mod.rs"
   },
   {
-    "hash": "1408393638760277889216161485462822825467",
+    "hash": "91375825332728499584552473133800788915",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null::runtime",
     "file": "library/core/src/intrinsics/mod.rs"
   },
@@ -165,12 +165,12 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "766528270008730576414797874131980563974",
+    "hash": "1169454885572802949911851882877522755773",
     "name": "<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize::<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "98972097590179534414450729561525715395",
+    "hash": "545707798122007980817913094500135596036",
     "name": "<std::iter::Filter<std::slice::Iter<'_, u8>, {closure@core::str::count::char_count_general_case::{closure#0}}> as std::iter::Iterator>::count",
     "file": "library/core/src/iter/adapters/filter.rs"
   },
@@ -180,7 +180,7 @@
     "file": "library/core/src/iter/adapters/filter.rs"
   },
   {
-    "hash": "136460023026271463242964210703970143574",
+    "hash": "1311510069182000871611712506430824967365",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::fold::<usize, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>",
     "file": "library/core/src/iter/adapters/map.rs"
   },
@@ -195,27 +195,27 @@
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1298212628145154126618156816134265951344",
+    "hash": "143385254926310059114601711607934802626",
     "name": "std::iter::adapters::map::map_fold::<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}",
     "file": "library/core/src/iter/adapters/map.rs"
   },
   {
-    "hash": "1232889667129580128612195481125876355895",
+    "hash": "69836621587154186912082287672825986701",
     "name": "<std::ops::Range<u16> as std::iter::range::RangeIteratorImpl>::spec_next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "65191485396793801441708908227891945976",
+    "hash": "74263642424770005886585667687132666700",
     "name": "<u16 as std::iter::Step>::forward_unchecked",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "188312196520496208216777120611981411403",
+    "hash": "150021953543632011655891713384046546195",
     "name": "std::iter::range::<impl std::iter::Iterator for std::ops::Range<u16>>::next",
     "file": "library/core/src/iter/range.rs"
   },
   {
-    "hash": "1118720028921197857316850364974898782644",
+    "hash": "83212516662910391527380784146422699337",
     "name": "<usize as std::iter::Sum>::sum::<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>",
     "file": "library/core/src/iter/traits/accum.rs"
   },
@@ -235,7 +235,7 @@
     "file": "library/core/src/iter/traits/collect.rs"
   },
   {
-    "hash": "117160024467577062374814279693937914308",
+    "hash": "1476188077969759501416587624527731620422",
     "name": "<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}> as std::iter::Iterator>::sum::<usize>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -250,22 +250,22 @@
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "169254447276496917964889824994222006487",
+    "hash": "746335627686636360311089028698215315621",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "95354230261524383717847373957185145555",
+    "hash": "890743343806001783818377326543496764999",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "64016173223473785207354785894730039924",
+    "hash": "38248963824617361146577789155806220457",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::advance_by",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
   {
-    "hash": "68746763044528098428227291452128003750",
+    "hash": "162963300457841015274153803823417766214",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::try_fold::<std::num::NonZero<usize>, {closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}, std::option::Option<std::num::NonZero<usize>>>",
     "file": "library/core/src/iter/traits/iterator.rs"
   },
@@ -310,52 +310,52 @@
     "file": "library/core/src/num/nonzero.rs"
   },
   {
-    "hash": "28416299455941732499272441497123863286",
+    "hash": "66472461948522780286669743098512884020",
     "name": "core::num::<impl u16>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1767882825766330041012289079684840123988",
+    "hash": "1755481411544761241911010338868424028032",
     "name": "core::num::<impl u16>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "531547630013775774616630521705918956890",
+    "hash": "778307969913358517318134351169293017006",
     "name": "core::num::<impl u32>::wrapping_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1491976204649427753712444486504685158667",
+    "hash": "1817700327438920062811986284895946972360",
     "name": "core::num::<impl usize>::count_ones",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "267503639466522371016185904314247059966",
+    "hash": "1198745042195432320316237250098976336783",
     "name": "core::num::<impl usize>::is_power_of_two",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "420027195811498354113361982279400413970",
+    "hash": "29280884443006517116686346795110467729",
     "name": "core::num::<impl usize>::overflowing_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "9766519181220151615102176802326253862",
+    "hash": "680697364573271958516692421008805893594",
     "name": "core::num::<impl usize>::overflowing_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "861075789615506151054802343958342702",
+    "hash": "10088042682663381447210876152059630410",
     "name": "core::num::<impl usize>::unchecked_add",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "1240112622965974978610989681601335370041",
+    "hash": "163514900348266881411363175083503667972",
     "name": "core::num::<impl usize>::unchecked_sub",
     "file": "library/core/src/num/uint_macros.rs"
   },
   {
-    "hash": "176480214868331547301536851964719628253",
+    "hash": "115578125622558050988953568575947871951",
     "name": "core::num::<impl usize>::wrapping_mul",
     "file": "library/core/src/num/uint_macros.rs"
   },
@@ -390,17 +390,17 @@
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "131534592200098059029750365218172562280",
+    "hash": "551284205942989744010603758892918003809",
     "name": "std::option::Option::<std::fmt::Alignment>::unwrap_or",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "37329511099916694324318814422027472373",
+    "hash": "139548131330438493408310223143043863897",
     "name": "std::option::Option::<u32>::map::<char, {closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/option.rs"
   },
   {
-    "hash": "145379337856805001595892687783013497010",
+    "hash": "93873349781065085267543059115936351593",
     "name": "kani::panic::panic_cold_display::<&str>",
     "file": "library/core/src/panic.rs"
   },
@@ -425,7 +425,7 @@
     "file": "library/core/src/panicking.rs"
   },
   {
-    "hash": "161984531712227522752564874190257605258",
+    "hash": "156103043049447019914417901809615508350",
     "name": "std::rt::panic_display::<&str>",
     "file": "library/core/src/panicking.rs"
   },
@@ -445,7 +445,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "172740984469479579071665404435289701023",
+    "hash": "135040582385212612735475257113813496500",
     "name": "std::ptr::const_ptr::<impl *const ()>::is_aligned_to",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -465,7 +465,7 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "11106989263465620674119447375151988759",
+    "hash": "21654441677010109529687023928280502180",
     "name": "std::ptr::const_ptr::<impl *const [u8]>::len",
     "file": "library/core/src/ptr/const_ptr.rs"
   },
@@ -520,22 +520,22 @@
     "file": "library/core/src/ptr/const_ptr.rs"
   },
   {
-    "hash": "1300271856392091645916001889619506617490",
+    "hash": "1618707962037661705218318211105471942120",
     "name": "std::ptr::from_raw_parts::<[[usize; 4]], [usize; 4]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "14412815270469178284372346649253214057",
+    "hash": "171364413319637295715083043732096201442",
     "name": "std::ptr::from_raw_parts::<[u8], u8>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "759301201495386013914096069500577582268",
+    "hash": "10108227029034297089458694313942657216",
     "name": "std::ptr::from_raw_parts::<[usize], usize>",
     "file": "library/core/src/ptr/metadata.rs"
   },
   {
-    "hash": "1363429953646800642818322319211259624481",
+    "hash": "65477300936560271722610262085043582244",
     "name": "std::ptr::metadata::<[u8]>",
     "file": "library/core/src/ptr/metadata.rs"
   },
@@ -550,117 +550,117 @@
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "507486726895721764016555491610607611305",
+    "hash": "844348294257748951813515064259923850502",
     "name": "std::ptr::drop_in_place::<&u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "32758264716275548135301815416129443538",
+    "hash": "786281027352090909410587866630825111124",
     "name": "std::ptr::drop_in_place::<(usize, char)>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "92620507381766029301237587487992527213",
+    "hash": "1602108665480339150417063482100093944787",
     "name": "std::ptr::drop_in_place::<std::fmt::Alignment>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "102773287537006387418136460951493449150",
+    "hash": "14750464030756559092072511389613712638",
     "name": "std::ptr::drop_in_place::<std::option::Option<(usize, char)>>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "149239371713813135466988763744767882801",
+    "hash": "180547684808059406565403285055600712836",
     "name": "std::ptr::drop_in_place::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "55367978787089163010793217435139837876",
+    "hash": "554158701962205684218313987735220350468",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::CharIndices<'_> as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1209564197857095228814830958456579553221",
+    "hash": "82095542769953368154912485864031886270",
     "name": "std::ptr::drop_in_place::<{closure@<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "748209534850776693517100400031629133312",
+    "hash": "5831255669648730149843380384415246652",
     "name": "std::ptr::drop_in_place::<{closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1030608205211034552612382402895255510895",
+    "hash": "120812647971752648112454196925746667219",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1030608205211034552612382402895255510895",
+    "hash": "120812647971752648112454196925746667219",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1030608205211034552612382402895255510895",
+    "hash": "120812647971752648112454196925746667219",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1030608205211034552612382402895255510895",
+    "hash": "120812647971752648112454196925746667219",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "90138924116052373967364036684749878632",
+    "hash": "210472309617713603440705080135320370",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "90138924116052373967364036684749878632",
+    "hash": "210472309617713603440705080135320370",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "90138924116052373967364036684749878632",
+    "hash": "210472309617713603440705080135320370",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "90138924116052373967364036684749878632",
+    "hash": "210472309617713603440705080135320370",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1331435189230694691617606409202631687650",
+    "hash": "55263576481608626669829552555760998993",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1331435189230694691617606409202631687650",
+    "hash": "55263576481608626669829552555760998993",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1331435189230694691617606409202631687650",
+    "hash": "55263576481608626669829552555760998993",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "1331435189230694691617606409202631687650",
+    "hash": "55263576481608626669829552555760998993",
     "name": "std::ptr::drop_in_place::<{closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "267935267854751480818415065985053337078",
+    "hash": "937477061605388048115884892480312288537",
     "name": "std::ptr::slice_from_raw_parts::<[usize; 4]>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "57392431669649698342516110218176469764",
+    "hash": "892461914248527136611431264334752468555",
     "name": "std::ptr::slice_from_raw_parts::<u8>",
     "file": "library/core/src/ptr/mod.rs"
   },
   {
-    "hash": "122558071050321327518145172778423713781",
+    "hash": "1297187182340166219213119975319687609972",
     "name": "std::ptr::slice_from_raw_parts::<usize>",
     "file": "library/core/src/ptr/mod.rs"
   },
@@ -880,7 +880,7 @@
     "file": "library/core/src/result.rs"
   },
   {
-    "hash": "88633046024721928868158000904972228167",
+    "hash": "54888678836671866272358132516024826502",
     "name": "<std::slice::Chunks<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -905,7 +905,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "125489371537082193378561958245297073133",
+    "hash": "45060499419383805014075082957353484074",
     "name": "std::slice::Iter::<'_, u8>::as_slice",
     "file": "library/core/src/slice/iter.rs"
   },
@@ -920,7 +920,7 @@
     "file": "library/core/src/slice/iter.rs"
   },
   {
-    "hash": "112093191663101859282706845470326278900",
+    "hash": "47269698298620023111796944825903179130",
     "name": "<std::slice::Iter<'_, [usize; 4]> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -930,22 +930,22 @@
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "136484293011665227087512181501588076411",
+    "hash": "674881123049448667512672737959208587337",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::fold::<usize, {closure@std::iter::adapters::map::map_fold<&u8, usize, usize, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}, {closure@<usize as std::iter::Sum>::sum<std::iter::Map<std::slice::Iter<'_, u8>, {closure@<std::iter::Filter<I, P> as std::iter::Iterator>::count::to_usize<&u8, {closure@core::str::count::char_count_general_case::{closure#0}}>::{closure#0}}>>::{closure#0}}>::{closure#0}}>",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "7250475688043728136115351013068090102",
+    "hash": "154659969182662416984535348444125844",
     "name": "<std::slice::Iter<'_, u8> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "155597816474146809159504684113290845792",
+    "hash": "1219085896046917615810259583008727206943",
     "name": "<std::slice::Iter<'_, usize> as std::iter::Iterator>::next",
     "file": "library/core/src/slice/iter/macros.rs"
   },
   {
-    "hash": "145530532616617731099568344791001893798",
+    "hash": "793309437318306726913806640804801036999",
     "name": "std::slice::Iter::<'_, u8>::make_slice",
     "file": "library/core/src/slice/iter/macros.rs"
   },
@@ -955,7 +955,7 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1593063580605279640314183922934412511157",
+    "hash": "51188353216572513337552947382367213612",
     "name": "core::slice::<impl [u8]>::align_to::<usize>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -975,27 +975,27 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1785941139609704198311972964660228370976",
+    "hash": "1041529063314010914218218438532577583921",
     "name": "core::slice::<impl [u8]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "84572646525781694072079679591848027002",
+    "hash": "11017778733362591934337269956689912680",
     "name": "core::slice::<impl [u8]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "58089700496514419381325942148928567391",
+    "hash": "89128813248987492211721493584967359724",
     "name": "core::slice::<impl [u8]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "917728468319067451416388429251863159678",
+    "hash": "348372507889018041910054944302851661070",
     "name": "core::slice::<impl [usize]>::as_chunks::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "1621046050041371142817756793657558429507",
+    "hash": "144624929410860970405573471555686596396",
     "name": "core::slice::<impl [usize]>::as_chunks_unchecked::<4>",
     "file": "library/core/src/slice/mod.rs"
   },
@@ -1020,32 +1020,32 @@
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "3900672375060331021424481618253650288",
+    "hash": "1689731528734002832615362599744307150563",
     "name": "core::slice::<impl [usize]>::split_at",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "171173179240508091544601281736583524354",
+    "hash": "157354110368917150977548446164644269157",
     "name": "core::slice::<impl [usize]>::split_at_checked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "116483621522571785213244680499922945415",
+    "hash": "1325059444048598179110854173592682518417",
     "name": "core::slice::<impl [usize]>::split_at_unchecked",
     "file": "library/core/src/slice/mod.rs"
   },
   {
-    "hash": "325660469324403897513522339552212646632",
+    "hash": "1617537487569895078313557542670536892075",
     "name": "std::slice::from_raw_parts::<'_, [usize; 4]>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "47514593099713610332964838893229837936",
+    "hash": "44787092142404380205959599561725184847",
     "name": "std::slice::from_raw_parts::<'_, u8>",
     "file": "library/core/src/slice/raw.rs"
   },
   {
-    "hash": "184867918752959488617184774691899169910",
+    "hash": "630819595617041232110620176331560268262",
     "name": "std::slice::from_raw_parts::<'_, usize>",
     "file": "library/core/src/slice/raw.rs"
   },
@@ -1055,7 +1055,7 @@
     "file": "library/core/src/str/converts.rs"
   },
   {
-    "hash": "145201222854331195178815443675397277392",
+    "hash": "105509042728785276095738116562226884135",
     "name": "core::str::count::char_count_general_case",
     "file": "library/core/src/str/count.rs"
   },
@@ -1070,37 +1070,37 @@
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "47468782241743602393810882143023349945",
+    "hash": "101539333883602999142743294499662142781",
     "name": "core::str::count::count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "944297586695660734811678461952919859244",
+    "hash": "155145547891548244516298634347765599627",
     "name": "core::str::count::do_count_chars",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "268701197549167845816540622531722429171",
+    "hash": "12025566570273099920903542994299871817",
     "name": "core::str::count::sum_bytes_in_usize",
     "file": "library/core/src/str/count.rs"
   },
   {
-    "hash": "174931159159579161911556326084018243713",
+    "hash": "152715002861639775393988580799560247805",
     "name": "<std::str::CharIndices<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "759516041501256089813279787494912941682",
+    "hash": "644663214087010307916081317719588641492",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::count",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "151051332114409904941604214564891538957",
+    "hash": "660978859467132204713340652707099987613",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next",
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "42461548492323519705759720031945445712",
+    "hash": "16139698699567968342904534840657946470",
     "name": "<std::str::Chars<'_> as std::iter::Iterator>::next::{closure#0}",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1110,7 +1110,7 @@
     "file": "library/core/src/str/iter.rs"
   },
   {
-    "hash": "50301635678991252011107801667626389768",
+    "hash": "1563992362164201785411080871236623299079",
     "name": "std::str::Chars::<'_>::as_str",
     "file": "library/core/src/str/iter.rs"
   },
@@ -1130,7 +1130,7 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "867395007143103994512438910488508336973",
+    "hash": "71021883313881662847215860786847447423",
     "name": "core::str::<impl str>::get_unchecked::<std::ops::RangeTo<usize>>",
     "file": "library/core/src/str/mod.rs"
   },
@@ -1140,17 +1140,17 @@
     "file": "library/core/src/str/mod.rs"
   },
   {
-    "hash": "112020109271780179669495653821738681551",
+    "hash": "91070850951614709601933024856310781945",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::Range<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "152909514978300660252157530308776102467",
+    "hash": "145757805227894694174215691004963108394",
     "name": "core::str::traits::<impl std::slice::SliceIndex<str> for std::ops::RangeTo<usize>>::get_unchecked",
     "file": "library/core/src/str/traits.rs"
   },
   {
-    "hash": "68493124835835642495275913021346263998",
+    "hash": "1317118350612563145817400323127232106582",
     "name": "core::str::validations::next_code_point::<'_, std::slice::Iter<'_, u8>>",
     "file": "library/core/src/str/validations.rs"
   },
@@ -1170,17 +1170,17 @@
     "file": "library/core/src/str/validations.rs"
   },
   {
-    "hash": "1563172082169351546616225899813991043484",
+    "hash": "172646548629003079288424832349823487421",
     "name": "core::num::<impl u16>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "33957922410128141509625682565657813466",
+    "hash": "1248191826238009221015171546017389042989",
     "name": "core::num::<impl usize>::unchecked_add::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "100872428199167332544577177169244129806",
+    "hash": "13514854596489369474334665362530945420",
     "name": "core::num::<impl usize>::unchecked_sub::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1210,12 +1210,12 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "1158923569256985321513541004220644151856",
+    "hash": "748210795816008050710623801889599715701",
     "name": "core::ub_checks::maybe_is_aligned_and_not_null",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "140048639800126365939997225010682400254",
+    "hash": "7461493046945910432435712880095080611",
     "name": "std::char::convert::from_u32_unchecked::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
@@ -1230,36 +1230,36 @@
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "71108690579660086896269737077011959868",
+    "hash": "399721967138328910814551048930416922779",
     "name": "std::slice::from_raw_parts::precondition_check",
     "file": "library/core/src/ub_checks.rs"
   },
   {
-    "hash": "22559702917001511576038663994103257845",
+    "hash": "906455478359755404216101974030354732609",
     "name": "verify::single_contract",
     "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "proof_kind": "Standard"
   },
   {
-    "hash": "43976682396293232936133858708036975857",
+    "hash": "6952787958612224032678902726851678789",
     "name": "verify::single_contract_requires",
     "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "proof_kind": "Standard"
   },
   {
-    "hash": "627473084776515476013701825067452675439",
+    "hash": "96592257838095277304588624487903024586",
     "name": "verify::single_with_contract_ensures",
     "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "proof_kind": "Standard"
   },
   {
-    "hash": "106940377420370317512388163502471126408",
+    "hash": "1322375490106549660017301391030508076719",
     "name": "verify::two_contracts_requires_and_ensures",
     "file": "tests/proofs/standard_proofs_with_contracts.rs",
     "proof_kind": "Standard"
   },
   {
-    "hash": "162151934380798551833864186338046125276",
+    "hash": "1592078685230826824511081495807544441635",
     "name": "verify::contract",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
@@ -1269,22 +1269,42 @@
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "66856133105108597692134006196183966866",
+    "hash": "801032749296319443310269654519517605501",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "801032749296319443310269654519517605501",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "801032749296319443310269654519517605501",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "801032749296319443310269654519517605501",
+    "name": "verify::contract::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "19404630978945762659973140805870833559",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "66856133105108597692134006196183966866",
+    "hash": "19404630978945762659973140805870833559",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "66856133105108597692134006196183966866",
+    "hash": "19404630978945762659973140805870833559",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "66856133105108597692134006196183966866",
+    "hash": "19404630978945762659973140805870833559",
     "name": "verify::contract::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:27:5: 27:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
@@ -1294,7 +1314,7 @@
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "1386504343726672842711828758132285435800",
+    "hash": "36161964154120346762073085381668424168",
     "name": "verify::contract_ensures",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
@@ -1304,22 +1324,42 @@
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "281742532494141071613012348566387603346",
+    "hash": "25554273104008556383483770190457064932",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "25554273104008556383483770190457064932",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "25554273104008556383483770190457064932",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "25554273104008556383483770190457064932",
+    "name": "verify::contract_ensures::kani_force_fn_once::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "65222809445639519327039608050601009981",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "281742532494141071613012348566387603346",
+    "hash": "65222809445639519327039608050601009981",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "281742532494141071613012348566387603346",
+    "hash": "65222809445639519327039608050601009981",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "281742532494141071613012348566387603346",
+    "hash": "65222809445639519327039608050601009981",
     "name": "verify::contract_ensures::kani_register_contract::<u8, {closure@tests/proofs/standard_proofs_with_contracts.rs:11:5: 11:37}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
@@ -1329,7 +1369,7 @@
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "1086504168081877403112533965387040054597",
+    "hash": "154529216921456824094336115596502120052",
     "name": "verify::contract_requires",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
@@ -1339,22 +1379,42 @@
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "149536674912717606724773534680576766231",
+    "hash": "131197352862921662362159723378615447810",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "131197352862921662362159723378615447810",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "131197352862921662362159723378615447810",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "131197352862921662362159723378615447810",
+    "name": "verify::contract_requires::kani_force_fn_once::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
+    "file": "tests/proofs/standard_proofs_with_contracts.rs"
+  },
+  {
+    "hash": "108945695996631719703339187093296181295",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "149536674912717606724773534680576766231",
+    "hash": "108945695996631719703339187093296181295",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "149536674912717606724773534680576766231",
+    "hash": "108945695996631719703339187093296181295",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },
   {
-    "hash": "149536674912717606724773534680576766231",
+    "hash": "108945695996631719703339187093296181295",
     "name": "verify::contract_requires::kani_register_contract::<(), {closure@tests/proofs/standard_proofs_with_contracts.rs:3:5: 3:29}>",
     "file": "tests/proofs/standard_proofs_with_contracts.rs"
   },

--- a/tests/snapshots/stat/gen_contracts_by_macros.json
+++ b/tests/snapshots/stat/gen_contracts_by_macros.json
@@ -2,21 +2,27 @@
   "local": {
     "attrs": {
       "all_tool_attrs": 33,
-      "kanitools": 24
+      "kanitools": 30
     },
     "fn_defs": {
-      "total": 12,
+      "total": 18,
       "kanitools": {
-        "count": 12,
+        "count": 18,
         "names": [
           "verify::contract1",
           "verify::contract1::kani_contract_mode",
+          "verify::contract1::kani_force_fn_once",
+          "verify::contract1::kani_force_fn_once_with_args",
           "verify::contract1::kani_register_contract",
           "verify::contract2",
           "verify::contract2::kani_contract_mode",
+          "verify::contract2::kani_force_fn_once",
+          "verify::contract2::kani_force_fn_once_with_args",
           "verify::contract2::kani_register_contract",
           "verify::contract3",
           "verify::contract3::kani_contract_mode",
+          "verify::contract3::kani_force_fn_once",
+          "verify::contract3::kani_force_fn_once_with_args",
           "verify::contract3::kani_register_contract",
           "verify::proof1",
           "verify::proof2",
@@ -28,7 +34,7 @@
       "count": {
         "kanitool::asserted_with": 3,
         "kanitool::checked_with": 3,
-        "kanitool::fn_marker": 6,
+        "kanitool::fn_marker": 12,
         "kanitool::modifies_wrapper": 3,
         "kanitool::proof_for_contract": 3,
         "kanitool::recursion_check": 3,
@@ -47,10 +53,16 @@
         ],
         "kanitool::fn_marker": [
           "verify::contract1::kani_contract_mode",
+          "verify::contract1::kani_force_fn_once",
+          "verify::contract1::kani_force_fn_once_with_args",
           "verify::contract1::kani_register_contract",
           "verify::contract2::kani_contract_mode",
+          "verify::contract2::kani_force_fn_once",
+          "verify::contract2::kani_force_fn_once_with_args",
           "verify::contract2::kani_register_contract",
           "verify::contract3::kani_contract_mode",
+          "verify::contract3::kani_force_fn_once",
+          "verify::contract3::kani_force_fn_once_with_args",
           "verify::contract3::kani_register_contract"
         ],
         "kanitool::modifies_wrapper": [

--- a/tests/snapshots/stat/proofs_for_contract.json
+++ b/tests/snapshots/stat/proofs_for_contract.json
@@ -2,21 +2,27 @@
   "local": {
     "attrs": {
       "all_tool_attrs": 35,
-      "kanitools": 25
+      "kanitools": 31
     },
     "fn_defs": {
-      "total": 13,
+      "total": 19,
       "kanitools": {
-        "count": 13,
+        "count": 19,
         "names": [
           "verify::contract",
           "verify::contract::kani_contract_mode",
+          "verify::contract::kani_force_fn_once",
+          "verify::contract::kani_force_fn_once_with_args",
           "verify::contract::kani_register_contract",
           "verify::contract_ensures",
           "verify::contract_ensures::kani_contract_mode",
+          "verify::contract_ensures::kani_force_fn_once",
+          "verify::contract_ensures::kani_force_fn_once_with_args",
           "verify::contract_ensures::kani_register_contract",
           "verify::contract_requires",
           "verify::contract_requires::kani_contract_mode",
+          "verify::contract_requires::kani_force_fn_once",
+          "verify::contract_requires::kani_force_fn_once_with_args",
           "verify::contract_requires::kani_register_contract",
           "verify::single_contract",
           "verify::single_contract_requires",
@@ -29,7 +35,7 @@
       "count": {
         "kanitool::asserted_with": 3,
         "kanitool::checked_with": 3,
-        "kanitool::fn_marker": 6,
+        "kanitool::fn_marker": 12,
         "kanitool::modifies_wrapper": 3,
         "kanitool::proof_for_contract": 4,
         "kanitool::recursion_check": 3,
@@ -48,10 +54,16 @@
         ],
         "kanitool::fn_marker": [
           "verify::contract::kani_contract_mode",
+          "verify::contract::kani_force_fn_once",
+          "verify::contract::kani_force_fn_once_with_args",
           "verify::contract::kani_register_contract",
           "verify::contract_ensures::kani_contract_mode",
+          "verify::contract_ensures::kani_force_fn_once",
+          "verify::contract_ensures::kani_force_fn_once_with_args",
           "verify::contract_ensures::kani_register_contract",
           "verify::contract_requires::kani_contract_mode",
+          "verify::contract_requires::kani_force_fn_once",
+          "verify::contract_requires::kani_force_fn_once_with_args",
           "verify::contract_requires::kani_register_contract"
         ],
         "kanitool::modifies_wrapper": [

--- a/tests/snapshots/stat/standard_proofs.json
+++ b/tests/snapshots/stat/standard_proofs.json
@@ -1,7 +1,7 @@
 {
   "local": {
     "attrs": {
-      "all_tool_attrs": 12,
+      "all_tool_attrs": 9,
       "kanitools": 3
     },
     "fn_defs": {

--- a/tests/snapshots/stat/standard_proofs_with_contracts.json
+++ b/tests/snapshots/stat/standard_proofs_with_contracts.json
@@ -2,21 +2,27 @@
   "local": {
     "attrs": {
       "all_tool_attrs": 35,
-      "kanitools": 25
+      "kanitools": 31
     },
     "fn_defs": {
-      "total": 13,
+      "total": 19,
       "kanitools": {
-        "count": 13,
+        "count": 19,
         "names": [
           "verify::contract",
           "verify::contract::kani_contract_mode",
+          "verify::contract::kani_force_fn_once",
+          "verify::contract::kani_force_fn_once_with_args",
           "verify::contract::kani_register_contract",
           "verify::contract_ensures",
           "verify::contract_ensures::kani_contract_mode",
+          "verify::contract_ensures::kani_force_fn_once",
+          "verify::contract_ensures::kani_force_fn_once_with_args",
           "verify::contract_ensures::kani_register_contract",
           "verify::contract_requires",
           "verify::contract_requires::kani_contract_mode",
+          "verify::contract_requires::kani_force_fn_once",
+          "verify::contract_requires::kani_force_fn_once_with_args",
           "verify::contract_requires::kani_register_contract",
           "verify::single_contract",
           "verify::single_contract_requires",
@@ -29,7 +35,7 @@
       "count": {
         "kanitool::asserted_with": 3,
         "kanitool::checked_with": 3,
-        "kanitool::fn_marker": 6,
+        "kanitool::fn_marker": 12,
         "kanitool::modifies_wrapper": 3,
         "kanitool::proof": 4,
         "kanitool::recursion_check": 3,
@@ -48,10 +54,16 @@
         ],
         "kanitool::fn_marker": [
           "verify::contract::kani_contract_mode",
+          "verify::contract::kani_force_fn_once",
+          "verify::contract::kani_force_fn_once_with_args",
           "verify::contract::kani_register_contract",
           "verify::contract_ensures::kani_contract_mode",
+          "verify::contract_ensures::kani_force_fn_once",
+          "verify::contract_ensures::kani_force_fn_once_with_args",
           "verify::contract_ensures::kani_register_contract",
           "verify::contract_requires::kani_contract_mode",
+          "verify::contract_requires::kani_force_fn_once",
+          "verify::contract_requires::kani_force_fn_once_with_args",
           "verify::contract_requires::kani_register_contract"
         ],
         "kanitool::modifies_wrapper": [

--- a/tests/snapshots/verify-rust-std/merge_diff.json
+++ b/tests/snapshots/verify-rust-std/merge_diff.json
@@ -7216,72 +7216,72 @@
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_align",
-    "hash": "159654417990573153734725866837246671872"
+    "hash": "666793203004228412116660937959085719204"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_align_to",
-    "hash": "1436904537003703106216595419990221959855"
+    "hash": "104799209388555663384110756580113401715"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_array_i32",
-    "hash": "92418459731730002416529056874437017797"
+    "hash": "1511919354302091159614840202987278524238"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_dangling",
-    "hash": "657102533770205003512616866942868069150"
+    "hash": "1022615315194456023917640653651305358563"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_extend",
-    "hash": "1667892685343029114610021873566599939957"
+    "hash": "1596907133474496360413106904143665681486"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_extend_packed",
-    "hash": "239459576545903810113958211925785100631"
+    "hash": "611565180666209211514933972472663094137"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_for_value_i32",
-    "hash": "1789932809240919089616713677796947675253"
+    "hash": "1528837429852814111313228353976698026273"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_for_value_raw_i32",
-    "hash": "455036475449044420913266124106742772608"
+    "hash": "229156763025601494811802730018325680904"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_new_i32",
-    "hash": "15495550015990350784723893266515494565"
+    "hash": "125054458990597870784544900675863498727"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_pad_to_align",
-    "hash": "580604143684896389616247285100694851423"
+    "hash": "127086180829424951072647990948478029944"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_padding_needed_for",
-    "hash": "134247373483857726927464308023491319716"
+    "hash": "3497600786632072949720888623071121346"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_repeat",
-    "hash": "144769718059815834632564258018152058874"
+    "hash": "753734184042368905210236933982825163779"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_repeat_packed",
-    "hash": "61205376468902758013743299005483632193"
+    "hash": "144977692475354240605555374936632334080"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_size",
-    "hash": "1657919342209126008510545976869008900488"
+    "hash": "9290482296179649196991471913156075512"
   },
   {
     "file": "core/src/arch.rs",
@@ -7376,12 +7376,12 @@
   {
     "file": "core/src/char/convert.rs",
     "func": "char::convert::<impl convert::TryFrom<char> for u16>::try_from",
-    "hash": "1763133372215299994811039741193767865951"
+    "hash": "96360680809778568503881772540624896178"
   },
   {
     "file": "core/src/char/convert.rs",
     "func": "char::convert::<impl convert::TryFrom<char> for u8>::try_from",
-    "hash": "3192706117688600356296515598093949405"
+    "hash": "423027026614696617411135897157827428457"
   },
   {
     "file": "core/src/char/convert.rs",
@@ -7416,7 +7416,7 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::escape_debug",
-    "hash": "112782073517766017544601255552110479754"
+    "hash": "35373332899400279104491720870149058817"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7446,17 +7446,17 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_alphabetic",
-    "hash": "163519229420003376308706615671414818101"
+    "hash": "149238269231957986762219589860407004099"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_alphanumeric",
-    "hash": "14227116419785781588368591472595892315"
+    "hash": "1080143101362754990915534899806076462257"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_control",
-    "hash": "13163811105512890876903587377216369416"
+    "hash": "20939913548560002085644679327646245659"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7466,7 +7466,7 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_grapheme_extended",
-    "hash": "481185966460977717417038861653696028655"
+    "hash": "33465692390381201671042265624590950327"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7476,7 +7476,7 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_numeric",
-    "hash": "1296705507973385892816589511431256034745"
+    "hash": "119674173681752563867673922848357128313"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7506,12 +7506,12 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::to_lowercase",
-    "hash": "9488563737180875279575393987592525764"
+    "hash": "181222498429811344451706043005003949741"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::to_uppercase",
-    "hash": "129327314940187950013691445649706067440"
+    "hash": "1626054881250292070410373894433826735708"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7526,17 +7526,17 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::verify::check_as_ascii_ascii_char",
-    "hash": "722814962128736158115895801291033770580"
+    "hash": "145106900651037684646094876905148225836"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::verify::check_as_ascii_non_ascii_char",
-    "hash": "217862162805936216612474336981694230972"
+    "hash": "59046214821120751442008930582501848560"
   },
   {
     "file": "core/src/char/mod.rs",
     "func": "char::CaseMappingIter::new",
-    "hash": "156899052544568594745121053209070839173"
+    "hash": "86803484685046564611262439400120805871"
   },
   {
     "file": "core/src/char/mod.rs",
@@ -9416,1127 +9416,1127 @@
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i128::check_float_to_int_unchecked",
-    "hash": "12570106843364395387677813551291003454"
+    "hash": "88530868724279568667690192194845886909"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i16::check_float_to_int_unchecked",
-    "hash": "144804422370670038769732570344245401752"
+    "hash": "34937355308854661236992592332817910784"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i32::check_float_to_int_unchecked",
-    "hash": "440707822097534019715181108618503401979"
+    "hash": "866541447816502054912562032127620832860"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i64::check_float_to_int_unchecked",
-    "hash": "541219272021275384513056688692650584636"
+    "hash": "138373315061481331911912108179999526304"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i8::check_float_to_int_unchecked",
-    "hash": "67748106286716442433269026182390219204"
+    "hash": "9178839463185631346212959247776766673"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::isize::check_float_to_int_unchecked",
-    "hash": "328685150021806691515886936154993254949"
+    "hash": "153087535703317381546148665235596763679"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u128::check_float_to_int_unchecked",
-    "hash": "147210504604342710459480859202346545588"
+    "hash": "1350855398323535927312055908456031659862"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u16::check_float_to_int_unchecked",
-    "hash": "729583415293611945510941923549606580457"
+    "hash": "1053457698283725077411487014210877623165"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u32::check_float_to_int_unchecked",
-    "hash": "840411314119499311712887002660154437327"
+    "hash": "527874524859557861913566566362714989078"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u64::check_float_to_int_unchecked",
-    "hash": "987760641575640599817789309314295892356"
+    "hash": "964798959500214880115376060161869130001"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u8::check_float_to_int_unchecked",
-    "hash": "500799033218852845413642958871284117412"
+    "hash": "35429821651242858315152125474851240011"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::usize::check_float_to_int_unchecked",
-    "hash": "1680956773176821406913242386713968635994"
+    "hash": "183188123196729138387605726561533167824"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i128::check_float_to_int_unchecked",
-    "hash": "44411272530435004799291365764762504263"
+    "hash": "113223270409152893518509518672844447374"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i16::check_float_to_int_unchecked",
-    "hash": "576441992052723345814544581021832409591"
+    "hash": "1533528307502051054413214677737584025110"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i32::check_float_to_int_unchecked",
-    "hash": "62874139895559130703750122926382641346"
+    "hash": "908175138871389675610914728856061593867"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i64::check_float_to_int_unchecked",
-    "hash": "1721075069357525410813026084240274228913"
+    "hash": "992539163780421552917856858738409016597"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i8::check_float_to_int_unchecked",
-    "hash": "797035974649728624016724990522015961830"
+    "hash": "128874261959128961458487827307593671030"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::isize::check_float_to_int_unchecked",
-    "hash": "1497516059630044035716562327286720467408"
+    "hash": "73317654769012584602737184228451032682"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u128::check_float_to_int_unchecked",
-    "hash": "90899523159774280222336224387332024607"
+    "hash": "8982355473561687972977749639660351519"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u16::check_float_to_int_unchecked",
-    "hash": "146754670663784054986985767671757288406"
+    "hash": "80945763592437188410998903105536209660"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u32::check_float_to_int_unchecked",
-    "hash": "124383940522949287234057480686005839172"
+    "hash": "176678704181631845159017129684940753887"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u64::check_float_to_int_unchecked",
-    "hash": "37753891727381295814465178255417158299"
+    "hash": "1660554092039560497817644312880993843729"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u8::check_float_to_int_unchecked",
-    "hash": "1292448579749761997914680977685996698399"
+    "hash": "173407710967318616544491279187982197438"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::usize::check_float_to_int_unchecked",
-    "hash": "69750699019417085254896489862163942893"
+    "hash": "143092465587914219029334990995531049939"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i128::check_float_to_int_unchecked",
-    "hash": "917142034503283031015117020560819873467"
+    "hash": "197966129096194832916869832491042583730"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i16::check_float_to_int_unchecked",
-    "hash": "168516859738585911945204287144124839625"
+    "hash": "508229385435827294913033546054855595534"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i32::check_float_to_int_unchecked",
-    "hash": "1163794436304745714217000459696401291755"
+    "hash": "37651300251186217991254701539855198553"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i64::check_float_to_int_unchecked",
-    "hash": "175162468672550014616011931751277952400"
+    "hash": "848962969435961826110040469863291105593"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i8::check_float_to_int_unchecked",
-    "hash": "936249769412005307118066887158310923950"
+    "hash": "84107363055613053617323532694246893163"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::isize::check_float_to_int_unchecked",
-    "hash": "31376878588647260110298305624460682830"
+    "hash": "716756287195649674712950607459613883280"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u128::check_float_to_int_unchecked",
-    "hash": "102059755348422786519407030974458553222"
+    "hash": "21614938335965082986577398341803308603"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u16::check_float_to_int_unchecked",
-    "hash": "75893547846924626692214577502033701823"
+    "hash": "63190341987848641551201006341949638817"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u32::check_float_to_int_unchecked",
-    "hash": "60490676320791597247098361025422306157"
+    "hash": "43733581848502671836923054706674290194"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u64::check_float_to_int_unchecked",
-    "hash": "156494070981288901638848760788149660874"
+    "hash": "1575194128635146137710813345945610759434"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u8::check_float_to_int_unchecked",
-    "hash": "1505867950587343259716254392000192751973"
+    "hash": "33047794355457212807824452327195256694"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::usize::check_float_to_int_unchecked",
-    "hash": "1400510279347798407210489194955787537139"
+    "hash": "1066725978560580403212699325481029466310"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i128::check_float_to_int_unchecked",
-    "hash": "110403120446564007134605044660806460104"
+    "hash": "52800164587388004312900774711505584488"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i16::check_float_to_int_unchecked",
-    "hash": "11982044575560574875959342499489150149"
+    "hash": "250817743473464570016813864515390769827"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i32::check_float_to_int_unchecked",
-    "hash": "29979426334107561231237052846984928445"
+    "hash": "31267851871438388428778643376736349897"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i64::check_float_to_int_unchecked",
-    "hash": "1536136605406297903117710835990230106488"
+    "hash": "1842258398104253673976819690325217462"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i8::check_float_to_int_unchecked",
-    "hash": "906095837508618040713995647276563809720"
+    "hash": "195569492040264218118366152443981267465"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::isize::check_float_to_int_unchecked",
-    "hash": "928471532281455141017557908349032029294"
+    "hash": "1458177127419950318015846951753921067693"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u128::check_float_to_int_unchecked",
-    "hash": "178583535424970431959908135722835132433"
+    "hash": "1653366236408853068512779978574107249902"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u16::check_float_to_int_unchecked",
-    "hash": "1840028684398577734013211579727453511648"
+    "hash": "134723722253154524317571006801252557484"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u32::check_float_to_int_unchecked",
-    "hash": "162500406643591228034674392853400888800"
+    "hash": "1574548892426867394515069780828494204409"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u64::check_float_to_int_unchecked",
-    "hash": "827245535452180575312360388633401354609"
+    "hash": "8205965162915302766429770821299503552"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u8::check_float_to_int_unchecked",
-    "hash": "1473269455073178883415980694111344658153"
+    "hash": "15911070659092428833546264193462677442"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::usize::check_float_to_int_unchecked",
-    "hash": "1625096206811751443316368645772271656386"
+    "hash": "56126109615173025358359401053540563819"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "40449163879999846926282801496354643305"
+    "hash": "1498803861690751524011363355205315751207"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "716819284212637885112687452753631516511"
+    "hash": "173828987982293429519675204549540160346"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "19126878454937175241208253669313360742"
+    "hash": "1380086860464526104511173865156011167999"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::isize::check_nonzero_int_from_nonzero_int",
-    "hash": "1353731719669146941715680030934635806312"
+    "hash": "52548579295726432042726035819425943867"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i32::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "500192001163028004516846233092702328922"
+    "hash": "85711672231899742286584918785623362178"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i32::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "110097462501957107958759786352280502066"
+    "hash": "42921641033427655768127147042084307394"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i64::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "110473372357271889962668693961447397986"
+    "hash": "305846650038003783111788750940805132620"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "10134764055251013883173399862924367920"
+    "hash": "68419233948588966531974981496251558983"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i16::check_nonzero_int_from_nonzero_int",
-    "hash": "616831409387895957815677820271447194813"
+    "hash": "766910421818120766742382095083346523"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "1655708353191798712110195589671829604380"
+    "hash": "140017128742183212937511365209203651070"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "23478049692240901202291302191734365976"
+    "hash": "84543252492025985513811551389814016868"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::isize::check_nonzero_int_from_nonzero_int",
-    "hash": "63924788796898467613965790388160983918"
+    "hash": "66976535000348210088758593059348348008"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "1595091601885172070816967918401399906880"
+    "hash": "109327272756434010007353484807092270100"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "32416296746130187169611041354141782575"
+    "hash": "797296202572388771617130620061681782248"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "94413317538747980154508366748674189459"
+    "hash": "12350643888228726128873529742700062009"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "603966938570701298215605140824202209447"
+    "hash": "464933043559681385612238354605363015550"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::u32::check_nonzero_int_from_nonzero_int",
-    "hash": "174690491189666546591751939327544930254"
+    "hash": "87357088472070404125898075894096557"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::u64::check_nonzero_int_from_nonzero_int",
-    "hash": "667682458365202457710052860957199519056"
+    "hash": "104561338590463103532495094580591725737"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::usize::check_nonzero_int_from_nonzero_int",
-    "hash": "73987066715863563058188261366780570815"
+    "hash": "11127967812989483325757445509847280422"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "91351681832271918284123341943761570"
+    "hash": "183947856430693338793998816073683778817"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "129294772442453561586565518583240194482"
+    "hash": "1222018056353191709415329565388784456625"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "113445193795833229647888730880242674986"
+    "hash": "1047642869144102671650044943313723161"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::u64::check_nonzero_int_from_nonzero_int",
-    "hash": "771751672716791970117024944942636072060"
+    "hash": "338342713928260505113584097900482463157"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u64::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "80976031425752800777056812473822483223"
+    "hash": "1387777773008593966218235583390126946493"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u64::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "1034906910026855861516444888001298241686"
+    "hash": "1458866589914354783318434352266247893956"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "640271430533095534214903204041580211865"
+    "hash": "1828411956562748040814406531541804314979"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i16::check_nonzero_int_from_nonzero_int",
-    "hash": "119769194545571452727891949397085400846"
+    "hash": "90307045218631486988677736640995831233"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "47388569392930426107246067053703949591"
+    "hash": "739673736476333531515962066899918224418"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "9437647321114846263670039572843549497"
+    "hash": "129202103371628139317860509632388318636"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::isize::check_nonzero_int_from_nonzero_int",
-    "hash": "115431555916596025554386836699723339923"
+    "hash": "1340609313670310690011544826806740825869"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "1373876865099118488118255449102878801823"
+    "hash": "160103706116688542964464990360049165429"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u16::check_nonzero_int_from_nonzero_int",
-    "hash": "11360868470400314962315459985343709955"
+    "hash": "687919215129014736512205960468316270916"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u32::check_nonzero_int_from_nonzero_int",
-    "hash": "95853604660969459266107771598285792206"
+    "hash": "152860779879992494993851300727381541860"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u64::check_nonzero_int_from_nonzero_int",
-    "hash": "1636259254691348849115329975207401760111"
+    "hash": "15475464694164382958914693723759573742"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::usize::check_nonzero_int_from_nonzero_int",
-    "hash": "1054765931475985699110331127746800638846"
+    "hash": "1787763205164412041111318504102285407584"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "175612453424451710602824772229217507671"
+    "hash": "167863530167049084428606856447653075948"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "410673367305114838510986827398837811103"
+    "hash": "509882759855550173215710081660020355073"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "78688405688059959887027530029615167764"
+    "hash": "793865077068849746312390863634841117029"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "624943109680614884912701537186314939234"
+    "hash": "1419207400792403250714850216292369600996"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1335833871685990953615994589161224765876"
+    "hash": "63908409883373467722916460755814924002"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "168824748529368427325213522370277254383"
+    "hash": "182277701132156333476175992815041389809"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1504721215319558403918141731457104279957"
+    "hash": "160994659640058830083153994828496516325"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1243837175110526465510754823527286539249"
+    "hash": "92129124968188909226210770368492105324"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::isize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "532351031685588197118423485917739564412"
+    "hash": "1600173262558599823292031454005529975"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::isize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "692012640145671583118221037929269115679"
+    "hash": "440981366545071294516858976276723952357"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1330790242295050172610785111346566371752"
+    "hash": "891767361960142981913506418054583229254"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "113095486928544702482669641047692337015"
+    "hash": "174985044528843530956752560692753678423"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "90285741425382045284124543392905945645"
+    "hash": "1684762841141883770611285384145713908685"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "29331391646556453363447448186631015311"
+    "hash": "1723981160160979817212557388921336046181"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "696350844329669927410131368711206015146"
+    "hash": "1621895243266173547114453029529160613516"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "32411923195148946355898179700428174917"
+    "hash": "140112412251869050808151200990310817890"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "67689806158992336954278415188153028170"
+    "hash": "70433403315409176377444713908912277080"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "172125109140193832979915074409036932626"
+    "hash": "1812460676869585079714429030180171992591"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "60690941823820151365585179604242696901"
+    "hash": "735875607849638714612281258823240966442"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "138943338157253786286630391254636277480"
+    "hash": "18734766327267145218327158172218514377"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "129316890227340356126554834068875017681"
+    "hash": "275421363655621758415537377844160621109"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "128537726827781461610081464983249559575"
+    "hash": "1471246302000358870813338492905602881169"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "152081828512111729554809672325943762414"
+    "hash": "123513729746306081493716218337345484138"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1647586779467389089914935205714516230874"
+    "hash": "64349876044182482614188459523740142181"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "255361732892522004010494301102150926776"
+    "hash": "637362293039246926515755351724293491966"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "83316122854290216382321805583019311529"
+    "hash": "112153843490872159610928258272232317327"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "67906769714025296910082717883190151172"
+    "hash": "179980765156261513868824089386514475204"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "28266526782282021549588244232906286664"
+    "hash": "507807915317683999318009687310684019081"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1615479432226699409117266088148410751975"
+    "hash": "182566777239946047907646589117337435220"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "218974218576165018710966631887183306312"
+    "hash": "45877944850543814984212990707334909944"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "530133909947150580712640313633580881002"
+    "hash": "1515775864512778570012913265589594680543"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "837554868693008760216490314364163292775"
+    "hash": "1538841257242451168717692391201018022032"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "95385912501232617481743742552339750354"
+    "hash": "802743609706238402916950867808012390884"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "121528367801633667981598080808788884334"
+    "hash": "164072505620590306404723802771193494297"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "125024479390174306352950551446454898407"
+    "hash": "1305002274907545954716047230442584041418"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "52363303404434936391183485814777502852"
+    "hash": "103043026970309235326655005892359333935"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1094512140936682911016577092330415806052"
+    "hash": "67831676176266418141582512031795370635"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "122860433635065201486450560013747013661"
+    "hash": "1593290381167487255916656781694970093411"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "318655672956025963415436522575275490332"
+    "hash": "116065423429644803073847944334852298023"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "448273078513138518415721439015789597180"
+    "hash": "398129562318014661214886998305949300770"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "349507625621530847498927964686965134"
+    "hash": "141328925261243815714157941793947395443"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "16120771873096742216716161063269556914"
+    "hash": "1593219019058104066711179138587900793069"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "80822368861535163934550412461278336494"
+    "hash": "51073630568803480372895095349041196760"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "990626697294504572715231465769000550416"
+    "hash": "1117249177816817677017348425171579603010"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "52033020968688261910752655010586344467"
+    "hash": "38724348749429587444767753340976943784"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "62207060022152817159179581698866038300"
+    "hash": "100427665676518575035801530240506580607"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "342285889648999601711803404354581100783"
+    "hash": "47209032944545583049544278869143201656"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1191548147394097344410103331430554509285"
+    "hash": "112923238294501206172559691966967544870"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "3419699125221038026238479535184699620"
+    "hash": "1467577380973156714211482319851664639450"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "92580449189122757796129795714074948645"
+    "hash": "547611587991698122410844102280190886625"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "180163746343378528617977705409150148782"
+    "hash": "1176683993095146888910936933753272801754"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "7936096387762738835072036818012103864"
+    "hash": "1159997537210892232870879964162739465"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "32083605182900833154086306235594743045"
+    "hash": "18590549862084215503979009259119181702"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "6038397622464639809024631855434245884"
+    "hash": "317791442593858283816481939109174055463"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "92412780102012950039639459672731231296"
+    "hash": "112565765677055229813622358500829320475"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1564870405631101064714286785389108368224"
+    "hash": "125097059904746997802950723331637166051"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "494182649611527991910012578211638652508"
+    "hash": "1331765835878615856712104619258569764723"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "42731605582780041633143751888313520418"
+    "hash": "161740940164852655977142307076893457004"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "698431288400716430310669264037482182031"
+    "hash": "144954514209845127617340148079410624031"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "13483522159944060327257036069345210082"
+    "hash": "117032103277411457721364314175582112583"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "54109080271279491432305598052717504862"
+    "hash": "24884292491309310854103019221140785009"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "746887572424036875215899430313345208426"
+    "hash": "174452422864103082032592420150425365945"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "42975575801685365813190982724266252962"
+    "hash": "111788936478378768657656618924534647876"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "95706576796697127179941402473466433369"
+    "hash": "1505518741679864603516023121199098350263"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "106732374918709542363681848683658926701"
+    "hash": "13665280732001263742329235779982156772"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "35751610570140637738698084269174597021"
+    "hash": "1539081123259105779414934102364656552891"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "108587229368049654556731467717982136351"
+    "hash": "144232860793133280624717096937552368806"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "625773361179750276013758512030032146778"
+    "hash": "240101475004776185117696326510810930247"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "181233011778022334895957036267006572255"
+    "hash": "152618456754425952235849831168037525834"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "336817435041308047116705174874101195835"
+    "hash": "72290972573712864403733910354338145708"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "42705155295422575668044899582331421416"
+    "hash": "149955998202133288408829941610918340856"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "629852498002078942715648530120265751824"
+    "hash": "198333777453521902010917322298554977892"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "638636303940244236213651865722592477850"
+    "hash": "787627909011309150312034659316436881546"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1017091456066027537717468212149797299989"
+    "hash": "23113066556938794664576590470610311052"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1420091586319227820213150511727911135838"
+    "hash": "1595463265437722471714507920948574364770"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "104960897458025337488174398195169923252"
+    "hash": "12421327691065968225604955642908982526"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1673560360802450071310288471654989094825"
+    "hash": "5146870273986599254205384988723123985"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "54106159230242353689779996248628011130"
+    "hash": "35568604725390947259048175048014437188"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "241603944760273585114653994146077477803"
+    "hash": "1244770527212436397711170495754634866362"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "90244826586135079336954737753048413911"
+    "hash": "73289030705870403211230581177394643680"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "9845094037901015505219707293563758865"
+    "hash": "121983795279007181079781412200376980993"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "13588381002981628890318323257219843908"
+    "hash": "1765197404869149539515852918202451738519"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "659773920687559834417129245767952292673"
+    "hash": "110508055154344845127995830112886982494"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1240538538745922999412351952017376556891"
+    "hash": "143480726743850002436113930906900722934"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "95132714731835379149480573137712413029"
+    "hash": "173182256565918692029002150135077997553"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1186246110828032995916086288550682171529"
+    "hash": "99047179907002267398074717714973864067"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "34047567465092881287239286495684897603"
+    "hash": "572536889152389319811820130069610581045"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1294053565553777134516035098347721377699"
+    "hash": "720409031999184417215350735082560323057"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "22906552742002348646185031643506540058"
+    "hash": "6326575109500355407541302159115677430"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "64501851282918469319986757783886815744"
+    "hash": "82558823977849122349305451719034781421"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "150893080908220625106171375150020556624"
+    "hash": "615578499411631465618039218887366176300"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "950119083680680673716926192164226968480"
+    "hash": "69616272368018518061418763059334018105"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "102916545025473719156841817079399843928"
+    "hash": "173020741692950139445149527454787015445"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "58281268640159292523291633162771050388"
+    "hash": "51601496979852913797129294969357247183"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::isize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "4697257143784098540261420841239988916"
+    "hash": "1579560798030362539615334371299398615363"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::isize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1698413023095139585212879564176581803737"
+    "hash": "922103451526309966015216069335275117589"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "218063354083376336113113420315373200105"
+    "hash": "93018871973111381303175292929025358963"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "95672244732469927382995688540173609649"
+    "hash": "10823259171806135275342632442268372979"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "132713699494588416639681895606917319750"
+    "hash": "1743055593611384035617380950780330415556"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "174405405113041265731440742758524445652"
+    "hash": "23733014348893435081757843349963233420"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "176920187331910071936799771542195361570"
+    "hash": "319473677680040765012527022231927212355"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "163898042281882255748970059446743578120"
+    "hash": "1284230925776223916014764875257793978791"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "689303941873361294015589709646539628384"
+    "hash": "1933170207269649714115002409916385691"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "930791792036395123515318198896472925421"
+    "hash": "105537870575954219352764588909800226715"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "13835632781916690304842834560821968689"
+    "hash": "548700984875842486714168609086173721734"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "51755092613715403138254142784511744027"
+    "hash": "21172103212906285522814614428264632139"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "30546426853653084299794501020432284765"
+    "hash": "1460156144866562969910343198229639204728"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1140464778483098224218075142812872943066"
+    "hash": "76436289299345957434498193490187269881"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1732149147193691065011334087403156126904"
+    "hash": "1380246108507545914113366292419178817467"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "11863759348967736959407823821159744570"
+    "hash": "88659376676431159896405862720313433320"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "116582212197189028914967478295614035294"
+    "hash": "145587173272797538591524778829382973587"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "30231336607320045187353534190834971969"
+    "hash": "65600837018888525486753977263006167118"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "110168467648833136823277603031602783497"
+    "hash": "23203877026251207965680306514655696700"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "131902666120833515210080356796749305049"
+    "hash": "161602832646647240527834857872149199708"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1716500011045675291317505631882124996938"
+    "hash": "111369069761955714927122602829454379358"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "11436904518684370250252941949593112169"
+    "hash": "128401869644782486718406782014075402075"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "95230130933538148112830276697618649597"
+    "hash": "1250000140426586736212750794088976729721"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "168040932025120115993084219277736221631"
+    "hash": "683908971115164128612989147754205858498"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "90288115843171719667643035419023154350"
+    "hash": "25769949353085235624168541323527156099"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "140416837262356465643986883571453421477"
+    "hash": "143949827240603448295178736507232408847"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1498750439860108348215637263201738708"
+    "hash": "67706986840353303311623710154527413396"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1697011398988088401114332869682062070224"
+    "hash": "148072755823918461099542311010808677542"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "933856725576814533910289529885176916363"
+    "hash": "1207836399974846443217523914748206315557"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1124806734436718507518065694977125496874"
+    "hash": "182217217852229359365296772885102992118"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::usize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "156878813857011095507318240379586005065"
+    "hash": "68634997358580803062207123542237550457"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "40041519107379044118153916356458995955"
+    "hash": "933443332794624844610784547363448971918"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1032628273019650727114687341613691457675"
+    "hash": "1002755433813041248415728681676652349569"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "87369623460449361476247900362020589561"
+    "hash": "169677476924428649899981020160570979492"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "55871342420522856657010406014345539010"
+    "hash": "18098894874579727109903971268074662503"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "82657103814044883045943293015485363382"
+    "hash": "1462850021912084560213874346738302945702"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "657959562242623404010096293764350607886"
+    "hash": "160044652239403766678415238599515757352"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "52053147848731290961536718286032448641"
+    "hash": "69880916569051831844690508565359598384"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1063764815889933286416050031409622367539"
+    "hash": "1662391869904712420612051550757079242384"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::isize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "99902300206195746743500593215678788779"
+    "hash": "805587235004508171117109247346763463954"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::isize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "165626776133261083245843275606522213070"
+    "hash": "12767710176264674816317510690488346177"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "787731017053874312713918686193614142537"
+    "hash": "107062756289766633579847607683430262626"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "52102298199651940404392495967630093316"
+    "hash": "1679656131215881041217804677334655001869"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "175504254144785772410051401228541687267"
+    "hash": "37155069263654866409804953250765377818"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "617783076415223069312101198542826256215"
+    "hash": "83591994068114521417741697530268334094"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1504336928964384734317244950311738354506"
+    "hash": "11949480510292002933615012298302033378"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "10686834027586206883806441638377732851"
+    "hash": "77050259537074377318948839846575142046"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::usize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "1008023026971308131017238918130726539960"
+    "hash": "1170573726740739897415896020688793032210"
   },
   {
     "file": "core/src/default.rs",
@@ -10651,62 +10651,62 @@
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_as_ptr",
-    "hash": "1005737773232775424011537861850140803635"
+    "hash": "1668536483415561831208054033756593945"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_bytes",
-    "hash": "183709507221698258354847358619705930320"
+    "hash": "29852727657653349481497090967342985635"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_count_bytes",
-    "hash": "1782561976884520703715896351820702106162"
+    "hash": "1455705036513831852711197642096900310603"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_bytes_until_nul",
-    "hash": "3859030188732282614907904060482482485"
+    "hash": "132558817532802772814506894125046621679"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_bytes_with_nul",
-    "hash": "85314328887836552425887759882817772416"
+    "hash": "1762134566566203163414638028955495933308"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_bytes_with_nul_unchecked",
-    "hash": "1627063208763579322416212839407153991313"
+    "hash": "152363027587936228828882123735945463105"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_ptr_contract",
-    "hash": "10963796904382741413080573034712702440"
+    "hash": "1235756292645422477210242321124036019659"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_is_empty",
-    "hash": "86228479985880985263425385775605152162"
+    "hash": "159729346751015565506683133188509600769"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_strlen_contract",
-    "hash": "1537978948734802359313075892497443644361"
+    "hash": "264771923508448919716761425121020509175"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_to_bytes",
-    "hash": "164811967598848879844306277122946919823"
+    "hash": "922871391019833145410819029299661261530"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_to_bytes_with_nul",
-    "hash": "873301063112014476712704450973234604095"
+    "hash": "85894990503989379014978974317823709350"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_to_str",
-    "hash": "1752740417588739807610194177552998548938"
+    "hash": "173453639731594168145057133628959451678"
   },
   {
     "file": "core/src/fmt/builders.rs",
@@ -10741,22 +10741,22 @@
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::Binary as fmt::num::GenericRadix>::digit",
-    "hash": "167805964473331543828322231840352753969"
+    "hash": "54656828559507721555474249308559461375"
   },
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::LowerHex as fmt::num::GenericRadix>::digit",
-    "hash": "242080123789224994214453644503811159479"
+    "hash": "1819320044930233148011820379372356252633"
   },
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::Octal as fmt::num::GenericRadix>::digit",
-    "hash": "42909843583956871977524929806362225071"
+    "hash": "1526603118578937328418332548998107150534"
   },
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::UpperHex as fmt::num::GenericRadix>::digit",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/fmt/num.rs",
@@ -11136,32 +11136,32 @@
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::Assume",
-    "hash": "159876217636128777997238053184447116430"
+    "hash": "80462426220111558147385728798769792647"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::Return",
-    "hash": "127617347754016229741960697334448965792"
+    "hash": "963671311509051311714239059969085537935"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::Unreachable",
-    "hash": "939022033609935605912053307854678669934"
+    "hash": "103258612607140405504461305791108581823"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::UnwindContinue",
-    "hash": "1834807253853936654216167106079166354372"
+    "hash": "924409717289418380912018685441358051117"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::UnwindResume",
-    "hash": "84593103041004796133743235947209857500"
+    "hash": "111865786195385373936207092654720643527"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::UnwindUnreachable",
-    "hash": "113019058793788161892863156641951717554"
+    "hash": "439859689520047162718303977102409029100"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11171,7 +11171,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "char::methods::encode_utf16_raw::do_panic::runtime",
-    "hash": "1072707188431150672216694450913705836092"
+    "hash": "85905003442401298274746688489468417169"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11181,7 +11181,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "char::methods::encode_utf8_raw::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11191,7 +11191,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f128::<impl f128>::clamp::do_panic::runtime",
-    "hash": "70414816962556708501312417167098573119"
+    "hash": "37477924359411098836512345888661426550"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11201,7 +11201,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f16::<impl f16>::clamp::do_panic::runtime",
-    "hash": "85517861577788698702401178925022005364"
+    "hash": "149641901401928124253091120495714928683"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11211,7 +11211,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f32::<impl f32>::clamp::do_panic::runtime",
-    "hash": "81135406048345508319447053781798426202"
+    "hash": "184365894090260783921579835441030046772"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11221,7 +11221,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f64::<impl f64>::clamp::do_panic::runtime",
-    "hash": "11151493258034151214451187101936381621"
+    "hash": "1116795696853849687817088617110399943806"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11301,1572 +11301,1572 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_arr_to_struct",
-    "hash": "13248293318748791366182484231915863621"
+    "hash": "44569125889545126145260230876940158158"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1163900701481358647912539676006912637728"
+    "hash": "1650935973777390599616124140475025887822"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_struct_to_arr",
-    "hash": "5237503072436321651528602027315825766"
+    "hash": "640528775520460352612220242766827359386"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_struct_to_tuple",
-    "hash": "471810001363165698111177484508262329745"
+    "hash": "116160154449315947723610610800111391688"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_tuple_to_arr",
-    "hash": "132312363606072742824555516972435143445"
+    "hash": "7474123538291552868328664896342378516"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_tuple_to_struct",
-    "hash": "53978139399382359904632957520618193882"
+    "hash": "98261023119298773441423312607166435753"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "48868899909216543865450910325374942094"
+    "hash": "173672762519796524074018147194011328412"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "26951453643687293619200869224204075130"
+    "hash": "73556784291181012719169352132900128"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "216242883622705475811760789398293580917"
+    "hash": "107706195453488360168160949661816817403"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "3187146692073425460312699975368439877"
+    "hash": "69022529664357093311395269393270655300"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "135413085772143712661404523197841773076"
+    "hash": "94136760972190875245368731647477361843"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1287295852626105971714239968018500325842"
+    "hash": "177617129200817568585676133619091757219"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_arr_to_struct",
-    "hash": "136757766027878059042794421550018720444"
+    "hash": "1310169166851099738717373990258130580430"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_arr_to_tuple",
-    "hash": "916651903214366398311423281079253019843"
+    "hash": "543713875495574293416837076912053343531"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_struct_to_arr",
-    "hash": "166423821886689425197155798972842769765"
+    "hash": "1493190290683572653110461932586800235924"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_struct_to_tuple",
-    "hash": "702988052336628137116778670550679438181"
+    "hash": "182672765012148936769077991007385677099"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_tuple_to_arr",
-    "hash": "119737714934479238406451844303629136988"
+    "hash": "164329964467819024399949765554904951870"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_tuple_to_struct",
-    "hash": "1447867035813266969616840533087938564366"
+    "hash": "96706940520950090445264677517848558696"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "623139454430470547215074057912935897231"
+    "hash": "123092613973336563578330524049786522839"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "195920957741234148415050589494040631"
+    "hash": "1130361286130292352011282075760894755639"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "1802697736753414398411114999321353748745"
+    "hash": "293107958269608413764086846119512174"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "1163925318987389266418029119331716795960"
+    "hash": "1187050938999602644211067256745721099649"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "248512670678380030214777300626630776803"
+    "hash": "578175429318660494411095041234355604349"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1499684163779842665718444728855936646491"
+    "hash": "121353859384644629095605154397348960697"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_arr_to_struct",
-    "hash": "1806827583500956819417759378681326534381"
+    "hash": "152554245705469865486480138968048730216"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_arr_to_tuple",
-    "hash": "41855591576755519416207314381145252560"
+    "hash": "372413925358458855115734439217791214147"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_struct_to_arr",
-    "hash": "176112358994393932335859311689165723367"
+    "hash": "26269637561235790717003600825227546135"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1822819216806798794915268055819264386449"
+    "hash": "164702713458602662209346646770755162986"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_tuple_to_arr",
-    "hash": "177271968633174896657590237138957215635"
+    "hash": "96245530057736922163846538034025383561"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_tuple_to_struct",
-    "hash": "15152605424012338474262865335536114770"
+    "hash": "100064709399584732987066583713387627528"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "74323925770363510351761025852102269238"
+    "hash": "169993765283258853013264083075641908776"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "138874241880949605019963439190306325753"
+    "hash": "179155751014380566229873440378544228268"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "20306047316866064852610138480721793454"
+    "hash": "7095194972396872612219209694930620475"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "49269054593991501852626456234218665195"
+    "hash": "539300933935109803613245934471992101455"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "1644051099343434409412695338775715541504"
+    "hash": "1560654115512379233110613619926477240886"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "387905968064484398814302004823375942522"
+    "hash": "443544149012828563215283745615880822056"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_ptr_address",
-    "hash": "269336529325160803312777561837739194197"
+    "hash": "32355353719906571489890709385432570584"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_ref_address",
-    "hash": "65570911599995402167339139066957291059"
+    "hash": "1659168321055305236211799603821165704226"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_slice_metadata",
-    "hash": "163306145599921756017071566682876115002"
+    "hash": "1458007826251106173918095246070352560599"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_unchecked_ptr_address",
-    "hash": "116543630117621828928525069854561310485"
+    "hash": "1744861217698745662412427596037485090802"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_unchecked_ref_address",
-    "hash": "694251869748147451310560423886172453351"
+    "hash": "1446401524349668065516803468169176709022"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_unchecked_slice_metadata",
-    "hash": "150363782097130699323817202465069520344"
+    "hash": "6280401421944041006338495349144657908"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_typed_swap_char",
-    "hash": "49410778264991796801321280308419329527"
+    "hash": "1563338564756174921818406329475838177851"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_typed_swap_non_zero",
-    "hash": "391319576546783846918065924556251616593"
+    "hash": "240343050484729600915344921054840450182"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_typed_swap_u8",
-    "hash": "163819056602822067473286112756992207329"
+    "hash": "21342853647494806448879587279256384957"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_arr_to_struct",
-    "hash": "134915628612246779145260544984322773517"
+    "hash": "24597318974969652808082326082391723624"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_arr_to_tuple",
-    "hash": "101802680512194726681132431534812590602"
+    "hash": "802429368142666418411220013100042039749"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_struct_to_arr",
-    "hash": "2462983420171274191328151901391184695"
+    "hash": "15772297371200870768665848444729123354"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_struct_to_tuple",
-    "hash": "178609637136192738772779663315597323859"
+    "hash": "1754846157670625337710298736887904593111"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_tuple_to_arr",
-    "hash": "184250108646340877957549182907815444520"
+    "hash": "812443135711084326616085257639663210525"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_tuple_to_struct",
-    "hash": "18129924147396817703776847452779006884"
+    "hash": "1639726635349362027815370983891751354116"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "146539267481254904269879781678358080847"
+    "hash": "137813651700518802017922833602532941403"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1629303072883594756816686976959182752954"
+    "hash": "1307823549450968602813637777857831469831"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "697331123576528958910348154027294303233"
+    "hash": "102088731710407801152083097508240299318"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "101183523205054469614024633585740442537"
+    "hash": "654563135351998835418278523183978038377"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "95114751544184766675391012464287800679"
+    "hash": "307541677939140450613349551929293225719"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1042374157791819625713355173121291721292"
+    "hash": "876782485459304043717538011045999136171"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_arr_to_struct",
-    "hash": "27096903324296510223663840455414009485"
+    "hash": "107685457936415995632987510076913880572"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_arr_to_tuple",
-    "hash": "164409615727807306152212715949157996496"
+    "hash": "1453437869469541111314627405885350524956"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_struct_to_arr",
-    "hash": "122376420630650374141838573720630162456"
+    "hash": "1682939032875241422115878642923158481884"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_struct_to_tuple",
-    "hash": "106575957760354937473174354932497295406"
+    "hash": "160385835519796804014355241199242699673"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_tuple_to_arr",
-    "hash": "89279028839483997958878682900080734211"
+    "hash": "1483370367442224805910750342311868942610"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_tuple_to_struct",
-    "hash": "137397829091681735225801695820645212595"
+    "hash": "114532685014450561698514780911515646432"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "862896983280864749411624352114511766997"
+    "hash": "178316721353762915495054000132446179920"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1065215283341238361616085326305145102232"
+    "hash": "51367999022937256551849255922734810169"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "1061402018678312503615423538391258142472"
+    "hash": "56413737415596956715498555424080947736"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "651755887455260090317515408413318797235"
+    "hash": "348514653716396781979672137482860418"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "27112284175082759899683952481466461471"
+    "hash": "1036469178138040189317367563687232686449"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "107187454697524039564722429981941982993"
+    "hash": "1130717618106968336416437531681141994941"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_arr_to_struct",
-    "hash": "146147149943226986686571950847580318133"
+    "hash": "252390025955977038615291447074116343212"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1123328495071785584512946568441758412410"
+    "hash": "105147751896258600768889168631657337852"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_struct_to_arr",
-    "hash": "628269419958306087716978405938018081531"
+    "hash": "1094470028327600307517356763675777028812"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_struct_to_tuple",
-    "hash": "78424691907728912394134639825412372772"
+    "hash": "56962175248234341345475937941068929028"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_tuple_to_arr",
-    "hash": "1561547505347056181618000832638872633716"
+    "hash": "72878543223592621452231547144462184724"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_tuple_to_struct",
-    "hash": "943017040620421161711121900201060415908"
+    "hash": "1000481354854575140913832348827792806748"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "158375863784326216084491539950370670115"
+    "hash": "140562676205013236112843327448102361086"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "3302376687321905931942959361283694511"
+    "hash": "622718222567680161518255810477017715924"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "3037347964065867686745439596530778182"
+    "hash": "51196465252896645011129751545039580101"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "1397948992427156395914570091011072633983"
+    "hash": "1531254356685113518816978935635817956245"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "100205917730362927399177835575693140669"
+    "hash": "23642105772838316616066303888549047622"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "171490570582371482845903495683746072788"
+    "hash": "573087581663753659912891651176610496950"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_arr_to_struct",
-    "hash": "1109040433393375080017201699983557175171"
+    "hash": "545897896028009831317360086024221914056"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1755045247700869695915574179057838021621"
+    "hash": "61288906016541883810301104653069393053"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_struct_to_arr",
-    "hash": "435563540182087077712187232107973136376"
+    "hash": "51145076374723729042138468422051451021"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_struct_to_tuple",
-    "hash": "936424835068145113914623519653460922786"
+    "hash": "139154946046469912686173966804140724993"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_tuple_to_arr",
-    "hash": "37489565301126390612636586229640713285"
+    "hash": "44444153150394575233687774198272924300"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_tuple_to_struct",
-    "hash": "289826728458330288215006482355457616640"
+    "hash": "1600835920534112036418405504728364676834"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "272443227015425070318331482113976333912"
+    "hash": "83980497596166617757623541380175985509"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "183724077250086469307356138145387691570"
+    "hash": "14060753912964489728687538377054555277"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "14978242298890806344944303179590623525"
+    "hash": "173824230194132338824233900141801126470"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "16254391547736023908609750938831530106"
+    "hash": "94630805478702040652179085888664813940"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "815290329198514717118381084459787700145"
+    "hash": "72072737031151982584675106208794615527"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "85134813673735595821971428891213429436"
+    "hash": "93719680103898474239507667662148176910"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_arr_to_struct",
-    "hash": "696764862950535249711929613782824718737"
+    "hash": "293450096612153991214323590555141173760"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_arr_to_tuple",
-    "hash": "118625330685287331512682373677396708"
+    "hash": "1004763697399045566012218725135065445"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_struct_to_arr",
-    "hash": "34928772486876841711337441756384325022"
+    "hash": "1351273312697990344811823721382805213635"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_struct_to_tuple",
-    "hash": "130867711320842810084697359209306586579"
+    "hash": "144258282561795579310179287382373443475"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_tuple_to_arr",
-    "hash": "226505007721923030613659221558224349944"
+    "hash": "217712549999757443712477905925003221131"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_tuple_to_struct",
-    "hash": "1451031192224828323517578980619516119581"
+    "hash": "15862716028742405340189402058900463358"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "108135994940136824382403241068119306328"
+    "hash": "2225714045985013931851813542412815494"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "35321115486253398761969133181744285480"
+    "hash": "59022334653930750572966747940806215781"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "106817902771106603113339307886578385771"
+    "hash": "631702073515873004712002574090004153502"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "92655024625060800317921207710815856160"
+    "hash": "50681511270511623327389550111414286128"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "12896234835419953792925192937907918595"
+    "hash": "927388575517509607011145216123532555497"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1831845329041756613216622263014404503060"
+    "hash": "645466028325734713315485251540467450736"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_f32_to_char",
-    "hash": "11972788914022613504512224727905325857"
+    "hash": "140906583300619398211072358042293688741"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_i32_to_char",
-    "hash": "183009218307993035065127616231255126692"
+    "hash": "7499275229267252276734222048237872144"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_i8_to_bool",
-    "hash": "141947526478684504484455533304973582126"
+    "hash": "1807091473613196132017856300370255705198"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_tuple_to_array",
-    "hash": "15124859496964532759416376986684206156"
+    "hash": "88352573943510473602492843554278516661"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_tuple_to_struct",
-    "hash": "13966365381106221134925360082037829754"
+    "hash": "108006519523114540432535069553384320181"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_tuple_to_tuple",
-    "hash": "224229299950751717510813020650838815972"
+    "hash": "32977623595717019234286231648301301352"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_u32_to_char",
-    "hash": "936802995631102935110537338002154751600"
+    "hash": "1317596444549901075717644712273018415003"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_u8_to_bool",
-    "hash": "12801827774048120605987355714471140510"
+    "hash": "40452518471158737082265544006347566849"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_bool_to_i8",
-    "hash": "13437254361587576717902569064044021311"
+    "hash": "7484522945516565163448950845888842350"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_bool_to_u8",
-    "hash": "1036674688877487411716216160279808078456"
+    "hash": "1074704597734323633612077667070881119315"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_char_to_f32",
-    "hash": "84097251556424254879721629117934614696"
+    "hash": "144250244438825397292485872423907389964"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_char_to_i32",
-    "hash": "162146041144241456778592515047157433597"
+    "hash": "1320686980318122530413148691136919955849"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_char_to_u32",
-    "hash": "743401287409270426212218994036364427403"
+    "hash": "6557438463566531201068357703498751462"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f32_to_char",
-    "hash": "137379404782891703424664819078380606014"
+    "hash": "1142719032474819535814632168326682589218"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f32_to_i32",
-    "hash": "155517997269858459842269454257659417064"
+    "hash": "8805239034890122451129887791530205730"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f32_to_u32",
-    "hash": "1407609228626843360613468652319593191461"
+    "hash": "1225966564095818746810997113431697230360"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f64_to_i64",
-    "hash": "19628605499078099014976429462208442829"
+    "hash": "1490337833217060637412279929583293401534"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f64_to_u64",
-    "hash": "1239747852168857350916932505633142351839"
+    "hash": "170302507757241775667413189097694191703"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i128_to_u128",
-    "hash": "131038971337009132969611725027088829324"
+    "hash": "46337359892087720519646717442801618066"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i16_to_u16",
-    "hash": "733752884668148588214411717430725741454"
+    "hash": "116396083519407885159186086306617035425"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i32_to_char",
-    "hash": "632071501719190272714929772185579143273"
+    "hash": "863774453150304800616091108611780688990"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i32_to_f32",
-    "hash": "156388642096667691965022545271619272775"
+    "hash": "64103017797867815481791015100818686992"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i32_to_u32",
-    "hash": "174535098750936998554149725501644221626"
+    "hash": "104924789687708168212445074848167322287"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i64_to_f64",
-    "hash": "1163814820903667546616391091713134102321"
+    "hash": "58463380786465759895875105744371973726"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i64_to_u64",
-    "hash": "22063627417220653095649646057176241894"
+    "hash": "188088180358690281410188566618394104818"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i8_to_bool",
-    "hash": "752646409628139871816394520959139062419"
+    "hash": "22758659408221083697382217835827492302"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i8_to_u8",
-    "hash": "26262006651678747413822532645683866608"
+    "hash": "1397110951263362347213890054237203394212"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_tuple_to_array",
-    "hash": "1837296845162134528714547554385224223311"
+    "hash": "33332760734673652513136549723180083152"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_tuple_to_struct",
-    "hash": "1379031490205205777617280709762611229017"
+    "hash": "91614964969992724283636714556201554759"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_tuple_to_tuple",
-    "hash": "77127992187396274673937561414725766673"
+    "hash": "92023540791246929331714239221885595475"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u128_to_i128",
-    "hash": "133046288916532182199463652787293557156"
+    "hash": "158334884197859806155730418593563218049"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u16_to_i16",
-    "hash": "12549280282256114058983389302235257925"
+    "hash": "1306937743143852112115951685599667922873"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u32_to_char",
-    "hash": "1708493581666015024816000321885326974071"
+    "hash": "880595753718994005414126199299340421758"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u32_to_f32",
-    "hash": "1186212559281687423811465277925530406685"
+    "hash": "1093733521210251256010261542073825322101"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u32_to_i32",
-    "hash": "181080173347664804551515153474533440272"
+    "hash": "160841374390556351263552274219288835235"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u64_to_f64",
-    "hash": "654898867171225496911599187280294732292"
+    "hash": "128444369804722605672754870069248770630"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u64_to_i64",
-    "hash": "41282494317944276661662271816591911438"
+    "hash": "173395629140527825416259835209487636413"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u8_to_bool",
-    "hash": "124532716537700031122974909278454298497"
+    "hash": "104573746883803005388933926502488327543"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u8_to_i8",
-    "hash": "68445340958934852646884103006767116166"
+    "hash": "127643761208084300647227392977042656760"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_arr_to_struct",
-    "hash": "1393693473521873027715904969109623752618"
+    "hash": "175970139447523998871613319466624090605"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_arr_to_tuple",
-    "hash": "173373291662731916638957512269807670615"
+    "hash": "276473352547758650410027744433260707618"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_struct_to_arr",
-    "hash": "131996599422232464082968438409989272591"
+    "hash": "1063611635883242779317906683383654699215"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_struct_to_tuple",
-    "hash": "84522475323039240729985965919576623703"
+    "hash": "716081931756475649716793441601547884217"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_tuple_to_arr",
-    "hash": "107899330845554099412298256042077311244"
+    "hash": "1671641040328344221813404405294552747106"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_tuple_to_struct",
-    "hash": "94980533049475820676920047911127939360"
+    "hash": "20400154684991926435066556405607037973"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "830391920562445304910790223774248707029"
+    "hash": "1533357498317532336216387082799552859976"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "255832612564051690414692970041488088946"
+    "hash": "825777769946045336016991537424678045988"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "19796167532102350792553606433896022581"
+    "hash": "118439629685697997158714497623363202017"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "52413376137219537542864903431709757440"
+    "hash": "1140192870421641020515244311374560554954"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "78550809199846339022909821522374620405"
+    "hash": "1206186357971162067017833206082521643643"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "184215758231183868554002737070636966916"
+    "hash": "1130471892056720534516153246396201366267"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::supported_status",
-    "hash": "652306216325428494210843435710275302324"
+    "hash": "176210567283599110817330099341857896355"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_bool_to_i8",
-    "hash": "35579245934029664749591353693233831332"
+    "hash": "7803038167033946249560725899081911827"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_bool_to_u8",
-    "hash": "1248838216365879320714271895265288669230"
+    "hash": "1077367388785330251314670211076166091520"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_char_to_f32",
-    "hash": "1529442532273747110917233284124682850277"
+    "hash": "32476567006856217489840922375065119643"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_char_to_i32",
-    "hash": "100526788950486281387700227778755996681"
+    "hash": "1717345873446708615316987942301562277068"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_char_to_u32",
-    "hash": "144649608112205923613840823226860285105"
+    "hash": "1368047778365871499413990888124378386986"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f32_to_char",
-    "hash": "51713415348912154838409215659091353798"
+    "hash": "1682361354308782274415621596232174588036"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f32_to_i32",
-    "hash": "42151961709958381599341596006257244287"
+    "hash": "24760763325492678637917370722666938235"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f32_to_u32",
-    "hash": "7163736578214933146967967426672988242"
+    "hash": "359558095388559954111367501247788802345"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f64_to_i64",
-    "hash": "209821095850350980211188401707123570645"
+    "hash": "1057160309753158480310852585279441022155"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f64_to_u64",
-    "hash": "100029452074246585582273339748090714879"
+    "hash": "1824599420003180944013921603592615920348"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i128_to_u128",
-    "hash": "167695553379826925739194124072425968037"
+    "hash": "743587293879211950817440951736797181994"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i16_to_u16",
-    "hash": "711227497683037237212645456905249743929"
+    "hash": "1394929383335954295713822286534785105338"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i32_to_char",
-    "hash": "161733696570706205299832803578261513171"
+    "hash": "148107746449483954304071370866301753962"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i32_to_f32",
-    "hash": "1247452141023291059214939651250338432867"
+    "hash": "51956922435423853946534627349183779006"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i32_to_u32",
-    "hash": "7627613076683126890193378222591738686"
+    "hash": "24995348647024155782610958596290214952"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i64_to_f64",
-    "hash": "1137486477872710043914952805433836179002"
+    "hash": "1635806931752244743318135708180658830019"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i64_to_u64",
-    "hash": "182996090044071408894408084618336998632"
+    "hash": "430506396941725233114497682132734380353"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i8_to_bool",
-    "hash": "1825186359109900727915925802818160872694"
+    "hash": "59025498954790523558454609232456230399"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i8_to_u8",
-    "hash": "438756001199482362818185721271958403098"
+    "hash": "55795134079747533417018187121805047639"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u128_to_i128",
-    "hash": "1282023412583613091715826508186518590629"
+    "hash": "63599031650807848163005584753409618908"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u16_to_i16",
-    "hash": "143557574993388697306726008297666920890"
+    "hash": "149940807080223545924972181685537926751"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u32_to_char",
-    "hash": "7091256019282908760656494509762450772"
+    "hash": "24000000317960677613619516020269152055"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u32_to_f32",
-    "hash": "1039053865592583173191731549305752303"
+    "hash": "109888500961959673143525830223128708695"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u32_to_i32",
-    "hash": "731099969925691723494159062227946685"
+    "hash": "61235706191679274103025117207140036533"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u64_to_f64",
-    "hash": "704178529910814507111963094200351836713"
+    "hash": "1038643481818073871915390537803004328866"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u64_to_i64",
-    "hash": "9392059493865588657770687764471652823"
+    "hash": "157232091396871914678901077240604146162"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u8_to_bool",
-    "hash": "43359695930846486411313203511638616757"
+    "hash": "716515509267472772216743731123586231609"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u8_to_i8",
-    "hash": "114128519066251327898071527985721734523"
+    "hash": "106347591898181620428935527996997411220"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_bool_to_i8",
-    "hash": "69685967925669211344235506275776506522"
+    "hash": "460607062302778615015018552655071677222"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_bool_to_u8",
-    "hash": "49997263120663512281979067924647927464"
+    "hash": "562906173826815780612049412991261900889"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_char_to_f32",
-    "hash": "1049461926105003983714594731044104289518"
+    "hash": "63974031557943865512036568900635245916"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_char_to_i32",
-    "hash": "160548376782164542818425533440139462989"
+    "hash": "1060469107840222074311326458966128413001"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_char_to_u32",
-    "hash": "108798975128578856057407094768701364428"
+    "hash": "73291436420913961731524070396786849623"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f32_to_char",
-    "hash": "279053842410403866415392666488436785055"
+    "hash": "38814079630353494654866997540882688436"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f32_to_i32",
-    "hash": "101509702414623113364621380681114850443"
+    "hash": "28982657480402774671414348869893151960"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f32_to_u32",
-    "hash": "105148290008859542347044026620189603346"
+    "hash": "914926030277221935517430117380649299034"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f64_to_i64",
-    "hash": "541993045212804489010172102105486813012"
+    "hash": "188526931730342563314467174294190649294"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f64_to_u64",
-    "hash": "26448439970135323392078810749226995485"
+    "hash": "972350434781797568514083630042109725531"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i128_to_u128",
-    "hash": "1813431925834908615413122965850350233748"
+    "hash": "80758717044549722858470481517914304038"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i16_to_u16",
-    "hash": "16522480201089085855007158322708721925"
+    "hash": "3191534991989960488995488038868757131"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i32_to_char",
-    "hash": "172219949975573053246507663779522075861"
+    "hash": "31017810217440822557857276514730230445"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i32_to_f32",
-    "hash": "93437120299983707986322379532478246673"
+    "hash": "181435577113556083005390165153170012912"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i32_to_u32",
-    "hash": "115240346548036293041550251685295839786"
+    "hash": "13928594720605952668208501997092415713"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i64_to_f64",
-    "hash": "47227452276491509192361932012517035124"
+    "hash": "164452083897616354247703110077256380213"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i64_to_u64",
-    "hash": "262596102109654346706399458749135554"
+    "hash": "171432845103958780229236800384344893285"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i8_to_bool",
-    "hash": "533742211447964728711572541023369852041"
+    "hash": "90967580176222302951307545077749566635"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i8_to_u8",
-    "hash": "710005524313267084712972906886410666575"
+    "hash": "306005297419514145012296582573767372391"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u128_to_i128",
-    "hash": "14730433835424978990867920374924590632"
+    "hash": "98012503510385937147194796412240500392"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u16_to_i16",
-    "hash": "247352863263322650016873101910041811997"
+    "hash": "35381324470640860253475376990831874815"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u32_to_char",
-    "hash": "31805302947362972159813743456694075907"
+    "hash": "61525275732514773241268181490815915222"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u32_to_f32",
-    "hash": "1467560049720444138016057764334994834280"
+    "hash": "395776834924101650611275237152382322635"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u32_to_i32",
-    "hash": "64656489632266919012086406175916155458"
+    "hash": "16436321000473981242264740181521142566"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u64_to_f64",
-    "hash": "1166136745496660811916334544242857659138"
+    "hash": "141503738022527906210678656054330869275"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u64_to_i64",
-    "hash": "142257722401827607367163443715166478314"
+    "hash": "64363582169024897402779438503863065301"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u8_to_bool",
-    "hash": "356242690992899236251407276902058472"
+    "hash": "28052398809382905773652673033240099999"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u8_to_i8",
-    "hash": "110497638763598660612729067213023826583"
+    "hash": "154998292509770305397488068849462127279"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_bool_to_i8",
-    "hash": "40571579524698430387086537325640298370"
+    "hash": "39203700899440265917400988704985247030"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_bool_to_u8",
-    "hash": "1775591543980087589215315424094924804218"
+    "hash": "1328322431176515248111217608179330832622"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_char_to_f32",
-    "hash": "177139623738008497695853902807120689049"
+    "hash": "1333890996293065603316681353101584142375"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_char_to_i32",
-    "hash": "174276956716299923301076473950890704302"
+    "hash": "17780157183772669921504144962980565071"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_char_to_u32",
-    "hash": "1799567746277363425216106955802785348034"
+    "hash": "1786382183564610409914617647513986469323"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f32_to_char",
-    "hash": "50743283851099475104739055859366888389"
+    "hash": "397677672020361461813389590420128063435"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f32_to_i32",
-    "hash": "84518791777509346395179572784757730962"
+    "hash": "471489478375305200314399649058520043389"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f32_to_u32",
-    "hash": "1501079994757302346510385981513059757366"
+    "hash": "87499970972966097741050693380752103765"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f64_to_i64",
-    "hash": "589581261955707399318420404624126798652"
+    "hash": "1757286875861455595961788563704209399"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f64_to_u64",
-    "hash": "42766365128279153521618304796815784391"
+    "hash": "608087901346814287715515078879775951314"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i128_to_u128",
-    "hash": "174274986468377306414730781832164688761"
+    "hash": "186794990443526797316535734874460985972"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i16_to_u16",
-    "hash": "524073745828649617211518028619573411938"
+    "hash": "112712733727129411387298199480036600765"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i32_to_char",
-    "hash": "1643862032976969642013662408187349411099"
+    "hash": "1088585154132639452010170750555012003474"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i32_to_f32",
-    "hash": "70530107434988156832300109308895397726"
+    "hash": "470116501538655423812735279125062926247"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i32_to_u32",
-    "hash": "135058437817578607868311711810828150092"
+    "hash": "77042960179458751515430033852317922613"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i64_to_f64",
-    "hash": "60649827606860866191132754128291331024"
+    "hash": "383013820168509871613268882013974685449"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i64_to_u64",
-    "hash": "131646533596745016708207583188300414861"
+    "hash": "172317501345473276432125342110539786268"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i8_to_bool",
-    "hash": "1838346132269797411010422713578965205699"
+    "hash": "67556597945921850162536870036321551828"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i8_to_u8",
-    "hash": "106667555771206196981258209043689752281"
+    "hash": "480461923696496213010615688926525618078"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u128_to_i128",
-    "hash": "158397684791320462935671247663460484335"
+    "hash": "1694901948628501264414856731769966419305"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u16_to_i16",
-    "hash": "104045080215578638026379125725669233200"
+    "hash": "5762704782027590712971158976976347294"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u32_to_char",
-    "hash": "181267809824376906879981013654159777232"
+    "hash": "767373897084728104513874884705539342878"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u32_to_f32",
-    "hash": "80344282304707684566457116616434038815"
+    "hash": "1766928874225674123013253975587316276661"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u32_to_i32",
-    "hash": "1841514990413977653111084869772279111640"
+    "hash": "411666566584893805013643366047274028279"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u64_to_f64",
-    "hash": "135472670910851948152976097386670490751"
+    "hash": "114770409388146779833994854775126609920"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u64_to_i64",
-    "hash": "122337735156644273472426175594335932962"
+    "hash": "421887076808131971013307193852329609377"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u8_to_bool",
-    "hash": "150358031962858492953668125965430113332"
+    "hash": "969749409976288813711823671769941967183"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u8_to_i8",
-    "hash": "15416710319949202021834867917907567882"
+    "hash": "1401366778904823521212037998935931500286"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_zero_size",
-    "hash": "1688595152874343380718088245850655928251"
+    "hash": "499620493798060932310788748314603745263"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_arr_to_struct",
-    "hash": "1242949800376913500011724981220200922013"
+    "hash": "941253467692189555415119967480748210402"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_arr_to_tuple",
-    "hash": "6451869781767694869804877125603087923"
+    "hash": "73192188090626938897841815496032941087"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_struct_to_arr",
-    "hash": "182529845188673921756093299657876947142"
+    "hash": "1466183784157681664210365205932630928284"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1620259353822693536711727230643866603693"
+    "hash": "1399343070618708880617155774749814825371"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_tuple_to_arr",
-    "hash": "1480018346818938489413859529412373367113"
+    "hash": "598659216587485298415512167419975392100"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_tuple_to_struct",
-    "hash": "559168905688288478014312564999259109015"
+    "hash": "457268697072278421614932835125838153521"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "6311225056220231200361745354661468797"
+    "hash": "146515658176943791961203440113321469278"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1158873978894551434213527000470898031579"
+    "hash": "115173235070657408634940433242723785551"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "80757242519582470191616488329052454026"
+    "hash": "678191375821788441210805984348159624374"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "34768440520632385354805272716725155903"
+    "hash": "47423823707329831139825605923793738159"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "105877637475590325094181243572074883127"
+    "hash": "121058813025174967551125287178131583316"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "64529574663391420139447806965852690783"
+    "hash": "81128718632068810981403107706594330594"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_arr_to_struct",
-    "hash": "87560304681309063284628654302484437552"
+    "hash": "6147682608914230193183969265257446810"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_arr_to_tuple",
-    "hash": "896991178947151963714293181847144325364"
+    "hash": "172093645190810031307965417103015663859"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_struct_to_arr",
-    "hash": "57572667908953354163252681501313342718"
+    "hash": "12733944326069406851408957682278333489"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1219314550987626750417320441573752636860"
+    "hash": "154579043935092572009891513008217319628"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_tuple_to_arr",
-    "hash": "248019648420538384511893110021188584414"
+    "hash": "60543047892402497685831736045156357717"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_tuple_to_struct",
-    "hash": "408836984793484945614170725774218345500"
+    "hash": "118150950244375543466072330756634262867"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "1620822783167990148211637666479410727601"
+    "hash": "1554348320500651746813237272563451148469"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "713128504018382238015769212604365956249"
+    "hash": "79308899115356149243247578727240040227"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "173250042814265476281046339078296031632"
+    "hash": "1505042777210719993710107443870890154085"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "15142138272567327329518077857942770155"
+    "hash": "133861970629973675054549247214350830833"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "107431300450262689069177052316108312671"
+    "hash": "924813039965508305110318395442395653139"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1185972420294812275113132290095068741985"
+    "hash": "104480564037026185114573493720882129075"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_arr_to_struct",
-    "hash": "1400426107303116286916146221633257955244"
+    "hash": "114163356432579276016383281717982833767"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_arr_to_tuple",
-    "hash": "95729408462414267554363324225561031436"
+    "hash": "48861987586188574593927542320161276063"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_struct_to_arr",
-    "hash": "944086809461181108616332609118361121164"
+    "hash": "182464465074586406716241442285501423677"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1596595056946706132213224090016971129098"
+    "hash": "68839938751831832658958013738687955863"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_tuple_to_arr",
-    "hash": "69360557044774908866612556606067313762"
+    "hash": "214620408434228363812301839171769111954"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_tuple_to_struct",
-    "hash": "107728647604726859029349929987554804997"
+    "hash": "27346462861338733895394429731495709725"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "1339244457647116339014232702395648146488"
+    "hash": "1793092421061952957912604426762338059007"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1693441605001390291459947713724680660"
+    "hash": "63507605800288153407077009887841396697"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "158852642210891080967591261141470186997"
+    "hash": "565997117188039027411543864095678215966"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "142644099852661110626271220888045116770"
+    "hash": "151513945171440174947316417371758361678"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "160949526281391937551323383773067349613"
+    "hash": "439924013339821610915846078009272766258"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "9964025946777040518656440953604030752"
+    "hash": "149292572481523640877974316176992104155"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_arr_to_struct",
-    "hash": "697252897426514195711804326219498174155"
+    "hash": "668941744489585285814433634927243741280"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1441884191000259280710415640499289469189"
+    "hash": "23888516328993999055330400968185768605"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_struct_to_arr",
-    "hash": "1340457831517701267816674789855469343027"
+    "hash": "69309176953551968187401127218241465939"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1095560391771752729615002400098732919245"
+    "hash": "762737358127493661111879842055939497438"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_tuple_to_arr",
-    "hash": "75253019969858946118839644459115831703"
+    "hash": "500818771297247874016984734901846704561"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_tuple_to_struct",
-    "hash": "181107419785328940426134490123612242155"
+    "hash": "1164336934777370260312467339236724069107"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "55394153973757147814696552265358051830"
+    "hash": "72363292510866287415109858993223727770"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "766971170826575242812499046223726891578"
+    "hash": "1687114987564127243512879412316718808835"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "151341235129625187866207036438455327527"
+    "hash": "121882558234065522327312433604287342808"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "136733214397715396268921968303411363732"
+    "hash": "168720922162367677128852133707669492712"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "822845920155144511211108026657145946680"
+    "hash": "29329396205169077416996702572830912141"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "89207015235671720815837245581370944855"
+    "hash": "88729583703553559596782457843320444473"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_arr_to_struct",
-    "hash": "691061749589234294017032963883506587679"
+    "hash": "20231151165990813207021819428837037271"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_arr_to_tuple",
-    "hash": "141308975431550224281443470628416571753"
+    "hash": "152569399462298904737740663479274494072"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_struct_to_arr",
-    "hash": "1494227107700885727315077150335863750627"
+    "hash": "1006295602695234140115874893523866687525"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_struct_to_tuple",
-    "hash": "156556465767750394819787953690071065633"
+    "hash": "311924515547707351913486042638477638371"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_tuple_to_arr",
-    "hash": "516235745431427379517798844118732137749"
+    "hash": "14191430902925138061792977846512846885"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_tuple_to_struct",
-    "hash": "100580129071289671814921725797679701991"
+    "hash": "81195997563156969639194343561468521099"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "95415916296551072928561459585115114529"
+    "hash": "9356645719260393021647692465914326731"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "29259843842929338565852124902496737846"
+    "hash": "934756421805699541716227349430796526225"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "78712815343326167313823974800067149658"
+    "hash": "346519692692135629117282383947811102817"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "44002218499606348787115458247460668661"
+    "hash": "30736919165201671234874992590979915335"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "27259564758987610157639144868756409156"
+    "hash": "1373685961298648135613012510264985461296"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "720372444301103004317073957650329399761"
+    "hash": "181732097020031339207230778803848350554"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_arr_to_struct",
-    "hash": "111855566886697997176708295030499335313"
+    "hash": "1224459017493261935113909496448479134571"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_arr_to_tuple",
-    "hash": "169951859459787285713480151847238105883"
+    "hash": "155758320693798435431251088685433257993"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_struct_to_arr",
-    "hash": "1605285197485675838612351897663879703177"
+    "hash": "1179091152129235859018050543439998760705"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1508479806861026300912034470411722778063"
+    "hash": "72279860681301787359940202072319019707"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_tuple_to_arr",
-    "hash": "8842853494882443339997473325092810066"
+    "hash": "457212396308489680515673619659956079151"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_tuple_to_struct",
-    "hash": "1233468274084216617016472471726357231216"
+    "hash": "76801601819871806562621702531038455938"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "1644979239444676853215033476853774174129"
+    "hash": "356619604960476256612530900536844548017"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1670080810392953386816426317610138621757"
+    "hash": "134188854215328695513334055466375180783"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "83177126884486105078595478124648925791"
+    "hash": "132353983149677870847809273491871615386"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "623647152302300431311674913020226196753"
+    "hash": "668329820840504282816227986213749058821"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "105672149854026198252573575766054222845"
+    "hash": "11877487420956021211506557124079752603"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "58395005556061348573615230311429036947"
+    "hash": "1631190164247486557617246320202048379308"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12876,7 +12876,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "num::from_ascii_radix_panic::do_panic::runtime",
-    "hash": "572222327024561109410458886622292987798"
+    "hash": "8085340008954982436007559992596241522"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12886,7 +12886,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime",
-    "hash": "164918453571405400974074030407238101404"
+    "hash": "42705179931592161279303093456354038844"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12896,7 +12896,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::index::slice_end_index_len_fail::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12906,7 +12906,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::index::slice_index_order_fail::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12916,7 +12916,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::index::slice_start_index_len_fail::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -13381,12 +13381,12 @@
   {
     "file": "core/src/mem/mod.rs",
     "func": "mem::verify::check_swap_adt_no_drop",
-    "hash": "153356910755839419144111258713658110160"
+    "hash": "1468458490891763406918132998733463594442"
   },
   {
     "file": "core/src/mem/mod.rs",
     "func": "mem::verify::check_swap_primitive",
-    "hash": "249109524093011347315364397622148827717"
+    "hash": "713263532860424991916659848523870537330"
   },
   {
     "file": "core/src/net/ip_addr.rs",
@@ -13711,7 +13711,7 @@
   {
     "file": "core/src/num/f128.rs",
     "func": "f128::<impl f128>::clamp",
-    "hash": "6479907919745990292693314104600846808"
+    "hash": "27305651964845757727810448081293979420"
   },
   {
     "file": "core/src/num/f128.rs",
@@ -13946,7 +13946,7 @@
   {
     "file": "core/src/num/f16.rs",
     "func": "f16::<impl f16>::clamp",
-    "hash": "8889720973201245612464821855150462729"
+    "hash": "1431444161292499658414512782103964732057"
   },
   {
     "file": "core/src/num/f16.rs",
@@ -14171,7 +14171,7 @@
   {
     "file": "core/src/num/f32.rs",
     "func": "f32::<impl f32>::clamp",
-    "hash": "82766645379776897966239759618439045427"
+    "hash": "77221412034397648712824431664785264328"
   },
   {
     "file": "core/src/num/f32.rs",
@@ -14411,7 +14411,7 @@
   {
     "file": "core/src/num/f64.rs",
     "func": "f64::<impl f64>::clamp",
-    "hash": "89832384597360019478181443658524137375"
+    "hash": "794722660488271877317009445203348662254"
   },
   {
     "file": "core/src/num/f64.rs",
@@ -18711,907 +18711,907 @@
   {
     "file": "core/src/num/mod.rs",
     "func": "num::from_ascii_radix_panic",
-    "hash": "391082212406587225615191173387750669490"
+    "hash": "13189432535515488536873851371539412776"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u16_full_range",
-    "hash": "824628260284943159661864229279646158"
+    "hash": "1249970043808570860317208847725935472889"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u32_large",
-    "hash": "1537717584335698134815958902221569048999"
+    "hash": "15677168672440338312576232817343167077"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u32_mid_edge",
-    "hash": "1231006054060451778612406292321293406329"
+    "hash": "1825211785563604627410744615275765637933"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u32_small",
-    "hash": "1684631527349743180113767378997354970239"
+    "hash": "148692753183044410817258175559846756085"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u64_large",
-    "hash": "1444724056709609981215893737491316997909"
+    "hash": "105923509920519685076890321905079120657"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u64_mid_edge",
-    "hash": "51511843706619116041937035720055873316"
+    "hash": "44081710051214180281950997476103837116"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u64_small",
-    "hash": "1167706481219390876316904382412795577214"
+    "hash": "176244195594976667092012720858218163506"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u8_full_range",
-    "hash": "77204947959524010759750302151599803035"
+    "hash": "582422087515056604216954804889906048167"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i128",
-    "hash": "978833740622283457516115635011276547198"
+    "hash": "1427121081446288910812457302507550201832"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i16",
-    "hash": "165025970505183203888632612070084635719"
+    "hash": "1120195155360170544615788382573529081459"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i32",
-    "hash": "67208186192814049426603048684633079861"
+    "hash": "539219750828522020314664655659667419151"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i64",
-    "hash": "181814194332437231856813280762660367357"
+    "hash": "569149059890359527110196704991047816956"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i8",
-    "hash": "13289186881960258629535192605372747562"
+    "hash": "16386006143532718080760915406259169411"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_isize",
-    "hash": "509522786876887671111345602043300979545"
+    "hash": "143465316349671465367294923723976236214"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u128",
-    "hash": "1578891110741218895414547426550640773724"
+    "hash": "113136942798462332852764443691716519858"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u16",
-    "hash": "972827549486141945516540996624744681089"
+    "hash": "4431123422129033779879029470076876463"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u32",
-    "hash": "136733980166841358631676887036254619891"
+    "hash": "94855926932657844495320540933247464721"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u64",
-    "hash": "121721698910113458941693400347132581484"
+    "hash": "1154660679985782807117243961429810655167"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u8",
-    "hash": "104357400557413262993392073430034069657"
+    "hash": "96104954434258988205131699201574357984"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_usize",
-    "hash": "100278967968299061324789627308948841620"
+    "hash": "899143831861790824118002783431830718725"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i128",
-    "hash": "1809943478706381391913543221244102017462"
+    "hash": "25618759601579960233224702829128999391"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i16",
-    "hash": "81455061771093914614885399807833001494"
+    "hash": "711171067815315271914661939719395123317"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i32",
-    "hash": "60350607535333797731996611704849531277"
+    "hash": "166164085090087049118010379127065817301"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i64",
-    "hash": "45297729115281622141877331296117398778"
+    "hash": "459687332953291487713345144651158057640"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i8",
-    "hash": "118640510470281325301189978847001192229"
+    "hash": "78173140075082294624690686931277209118"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_isize",
-    "hash": "138253949981659901564922972569970803774"
+    "hash": "70153806396777524241885698588895951319"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u128",
-    "hash": "1142101599089743921115665209010670147270"
+    "hash": "42489223951048354751250718346230449429"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u16",
-    "hash": "182003076907233379391611144576903167654"
+    "hash": "1351418380822822663517457112662970896693"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u32",
-    "hash": "176318586690812083264927965698025394428"
+    "hash": "1801675442878868772618073516676050505139"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u64",
-    "hash": "1153495259199985728017829707080925477766"
+    "hash": "340560467303470010611307726335567733866"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u8",
-    "hash": "568579686153963626018126439718224994292"
+    "hash": "141035523441698554605814415208621026237"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_usize",
-    "hash": "61061756280514368874263876872288983386"
+    "hash": "160481115415766642147632970425696968082"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i128",
-    "hash": "45357257229266360107344815124811337105"
+    "hash": "87891480747840847332792612348948666863"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i16",
-    "hash": "26720902508876026521487255241634334685"
+    "hash": "6033542213948200091233455438458472731"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i32",
-    "hash": "575117114856083829917089652314281511611"
+    "hash": "1760809139270516711411270937313992251344"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i64",
-    "hash": "144717455733977927178506009406330805854"
+    "hash": "11314030918308705189512141645972224591"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i8",
-    "hash": "142525668462189657745628625747056223075"
+    "hash": "154911708468826220783471096608196161524"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_isize",
-    "hash": "26769873060670325132006587962307792436"
+    "hash": "176858216053879295617766601709794521045"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u128",
-    "hash": "30429546156342235217057216666524613351"
+    "hash": "177725548623570635396993522303694692348"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u16",
-    "hash": "171150320748512275307985984488975127086"
+    "hash": "438376315556943000912840761799358000830"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u32",
-    "hash": "778733836873987871015119875853292943701"
+    "hash": "85408314372831429447709174279437964149"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u64",
-    "hash": "7870493490896907177919728719339650051"
+    "hash": "133908411226501873031931364229980993362"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u8",
-    "hash": "780060622397445683711180101230876206359"
+    "hash": "71690170847017857551752941904374667654"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_usize",
-    "hash": "500314036342640390516053247229102276750"
+    "hash": "470324279820042948910581703009464219741"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i128",
-    "hash": "139746171745786259815306889069760264764"
+    "hash": "129154598739992662024567025457777225952"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i16",
-    "hash": "968771360047422231617270713981680815628"
+    "hash": "9992083971599404354617334490968748174"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i32",
-    "hash": "1380492010288310026218263251514318783832"
+    "hash": "1505219830832851680311000114520788344667"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i64",
-    "hash": "71495237411121913075517062970673771238"
+    "hash": "164716888645406967967907471614242293495"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i8",
-    "hash": "393264293021864474713301782429787389078"
+    "hash": "14023418333411500139032212042811510225"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_isize",
-    "hash": "1189197566463440098410561009393550501259"
+    "hash": "23005549026323547513211374555943155970"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u128",
-    "hash": "863730285618653365759420896261699572"
+    "hash": "166207288291360243335327665960841018696"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u16",
-    "hash": "4151403074920531953537633784330789477"
+    "hash": "42893981240816423734052863674230672900"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u32",
-    "hash": "44599729353139647352420618256456099215"
+    "hash": "752765932701607724112222637230628299842"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u64",
-    "hash": "148359323500883670353934317873394417370"
+    "hash": "350143591732336880511584783057824979397"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u8",
-    "hash": "1783426526883664248811186363314377628045"
+    "hash": "2478015978056717617311820088422551623"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_usize",
-    "hash": "21091782126443760321300332088195618819"
+    "hash": "1354891357029701344414470810227137469102"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i128",
-    "hash": "140421870867521079443646924908157155951"
+    "hash": "1013749186596726768713012152501494832141"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i16",
-    "hash": "15804324394481603994855176087374193447"
+    "hash": "68343789891555817243142200253569360134"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i32",
-    "hash": "8238632730041472982332733985428641015"
+    "hash": "1701047075570715911217364379954437613552"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i64",
-    "hash": "1175985131879755791814159135291734478011"
+    "hash": "886045156360048873112760555304345418472"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i8",
-    "hash": "96220362529995047469534002713346645201"
+    "hash": "214409874265393497511623345821340821176"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_isize",
-    "hash": "91153463015061057823475896129739242779"
+    "hash": "9923857861951517974897975818493487160"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u128",
-    "hash": "47116055130375835651628713500473870966"
+    "hash": "119961033539435008010082081546902233502"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u16",
-    "hash": "827758921188068592714063842495843552189"
+    "hash": "6107685982318083178425082532491552593"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u32",
-    "hash": "11374754300323795711726285988993546029"
+    "hash": "110438353523333858910657418880158370630"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u64",
-    "hash": "1446295761027461846315987624412670347536"
+    "hash": "1200448108486391431312301260975809195309"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u8",
-    "hash": "7264010339901700965741002536646612431"
+    "hash": "800817383691493688414615751163426988002"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_usize",
-    "hash": "139542109014261973004490748287665537319"
+    "hash": "108530574253469523643838248653581919537"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_i16",
-    "hash": "909440523705038587018143410324582422085"
+    "hash": "1387905891481403345511259874807665344245"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_i8",
-    "hash": "57108695913641384271185418307563114466"
+    "hash": "1492170100879605530510578173094822546497"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_u16",
-    "hash": "122746193386374189899973501097539819385"
+    "hash": "942700659256999177513956430969055562140"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_u8",
-    "hash": "3752173014653082815407013514643546398"
+    "hash": "51126573755411395689630491929625371561"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i128",
-    "hash": "26232306569782581089911815586829987307"
+    "hash": "1238515567443510577511031396571533205025"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i16",
-    "hash": "29456679265823307441659930142281511481"
+    "hash": "42271907767383313302828168913515368388"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i32",
-    "hash": "53717516097476101283170957265935548227"
+    "hash": "1063627082037733943216357538470152850694"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i64",
-    "hash": "306160513162314186616064739900562474697"
+    "hash": "1689178359101401992211127643102361763569"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i8",
-    "hash": "1521686720167345094913751368793024500183"
+    "hash": "1436022730384850965610347102492139437879"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_isize",
-    "hash": "907678476538512923612754483983141650096"
+    "hash": "1573287251293698691411299920878380615939"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i128",
-    "hash": "95318338442787312186065867512430690716"
+    "hash": "130816155578122745365384605679474628696"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i16",
-    "hash": "1467578668439080352813460441133071150073"
+    "hash": "135338504328137606616332517051991950563"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i32",
-    "hash": "152073267818902179804130642921123883908"
+    "hash": "161651709658220517861059375003837612990"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i64",
-    "hash": "1117958921169778258517361013222365512493"
+    "hash": "1631559893009888129111899306849316400665"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i8",
-    "hash": "1196975807458080743711208556230896327992"
+    "hash": "281719662670971816318362051691814169326"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_isize",
-    "hash": "1101975348372065642816512288743683404474"
+    "hash": "18113317400600305127352701070190740488"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u128",
-    "hash": "169653152085358931256691298857610020332"
+    "hash": "151567894333574530388563038928218233515"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u16",
-    "hash": "82550117494484070222399250299787363447"
+    "hash": "67353996127582813564527446535932950089"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u32",
-    "hash": "20142923965630186639142474056572355419"
+    "hash": "281424207740908059412242870558515094382"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u64",
-    "hash": "177157500111898294108537584680329356474"
+    "hash": "817077741114136821616161799179845331107"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u8",
-    "hash": "11837744337220533109413713715514285037"
+    "hash": "161826768988739874616847001547576078030"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_usize",
-    "hash": "864557628653698813113521344400510984167"
+    "hash": "15802612868932521715425074614467106239"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i128",
-    "hash": "173818362017632185451460595662633984656"
+    "hash": "56075537140702143111707294896304206526"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i16",
-    "hash": "5200261361814415823285668822916347326"
+    "hash": "50141855081288800175616535445391715721"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i32",
-    "hash": "620357452829611802514461438333603766803"
+    "hash": "112005351312926100871225631021904796206"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i64",
-    "hash": "906698639802172375413475337653390308113"
+    "hash": "51044092430462539511019274434642397090"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i8",
-    "hash": "62085936530038912439427412643619960148"
+    "hash": "83676608362567567896840210612731659188"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_isize",
-    "hash": "380984251563493647316593266211807286354"
+    "hash": "33285410351229324262572316007475913386"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u128",
-    "hash": "40163674990049989317479389687622790657"
+    "hash": "17102167891828213005432191165783539702"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u16",
-    "hash": "926902178425755096415702446890175213354"
+    "hash": "175205519590150987186500876090169072387"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u32",
-    "hash": "13245944577964542386680779331048797442"
+    "hash": "101725624277884246734637766575774587772"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u64",
-    "hash": "1119011750916484234213701536125658310943"
+    "hash": "38574545195994965073828693117216512537"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u8",
-    "hash": "72025485340112840216032276476095375336"
+    "hash": "11501172996550724381923517564431320492"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_usize",
-    "hash": "12830372244145678881656180054611698849"
+    "hash": "1220350965462862334936560843198554765"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i128",
-    "hash": "997495286932748723015367246098436168838"
+    "hash": "15661733668056662697879643813940425946"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i16",
-    "hash": "433579036773151637617251397718191472994"
+    "hash": "79069296674750979983536088144962550807"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i32",
-    "hash": "6218254432116676014777687830241390746"
+    "hash": "1343776545600935849113571546718272635600"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i64",
-    "hash": "56766550051106056523022955140889142363"
+    "hash": "1793383479287264573411447327679782260784"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i8",
-    "hash": "179768235135932966307085773462330601480"
+    "hash": "744255408706100368316655043775792094824"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_isize",
-    "hash": "156236746725080190393886819001348922557"
+    "hash": "722190847034914777111862276935748077088"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u128",
-    "hash": "126358604668963378512074268101315521808"
+    "hash": "99251608325879286446892061833741379090"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u16",
-    "hash": "17829158232833270880838378421706420082"
+    "hash": "140209811954626366314873662605736231329"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u32",
-    "hash": "7840254206304867086193735156615167081"
+    "hash": "20406708838384393278573529601480800573"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u64",
-    "hash": "922027693234233903220882374001745577"
+    "hash": "98399071874282285238680318179210988155"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u8",
-    "hash": "9190182936490854723060582928396211227"
+    "hash": "12363779816884001937302513559058965584"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_usize",
-    "hash": "14900079129916834897547582967888715558"
+    "hash": "1597878910533096408314295105970152316309"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i128",
-    "hash": "163905743074246763003081779152158428196"
+    "hash": "291770625548891802312036118488487737806"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i16",
-    "hash": "166117821613177295249643325491475810962"
+    "hash": "796046107288115407710411382406332182461"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i32",
-    "hash": "606631281348003327411167055238475545103"
+    "hash": "160724595098070243818371734809327314205"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i64",
-    "hash": "1649652616229135673217797458848320050477"
+    "hash": "1183050073542647139417135983135443288549"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i8",
-    "hash": "174240888478006126793927810018725545821"
+    "hash": "589064955558552596816426659742629147323"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_isize",
-    "hash": "108858793842611213181389648118155045231"
+    "hash": "147883250817865286274506805453381697578"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u128",
-    "hash": "176307721224129773547873211542893623928"
+    "hash": "152175983159793938622099356494349715483"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u16",
-    "hash": "1814501156679227602010759610558929102226"
+    "hash": "135031922537543658856856453724735907445"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u32",
-    "hash": "141540853946179869275689912917388699725"
+    "hash": "860644457052785433216289491924276940132"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u64",
-    "hash": "25208251457935250498880796196354940620"
+    "hash": "1254969146998978004111906339476421320990"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u8",
-    "hash": "96335570293831535814462038442648955736"
+    "hash": "665002851525094953713880803929540086950"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_usize",
-    "hash": "21428347190932051063206881635457924000"
+    "hash": "1507214355554830747315061708678188416319"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i128",
-    "hash": "1660603540427905272214908671928964514784"
+    "hash": "58960001368002692057703816013096625520"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i16",
-    "hash": "1398115521861912169116835342872464910231"
+    "hash": "169860511738603974479890648747705775087"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i32",
-    "hash": "62015263569223281236953346704742732694"
+    "hash": "1181897753367418400918126677090764543207"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i64",
-    "hash": "181943994971741449842646270402023626432"
+    "hash": "18292700657620554299702320975636703531"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i8",
-    "hash": "114241434323583883816315073205367459711"
+    "hash": "44394187250689369145888942848145883071"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_isize",
-    "hash": "32507398557777333152511136389539566365"
+    "hash": "847910514765788008516952794162664083288"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u128",
-    "hash": "1719585067799424107517563635092904268701"
+    "hash": "204637962994250387311162431976073540535"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u16",
-    "hash": "1121811557254221748512196453219622201152"
+    "hash": "1463680007244058972910391829916043253047"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u32",
-    "hash": "153153909918833406741076139070773333930"
+    "hash": "828500877657173471011347920534509775313"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u64",
-    "hash": "126135795132087687828521208785405403789"
+    "hash": "140727148594991800939139522075932578007"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u8",
-    "hash": "1809137496327017738410051520152087475745"
+    "hash": "1807803657704834837712980372993461351657"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_usize",
-    "hash": "71962498628975341342522853599387533458"
+    "hash": "307639422562486222815427675628741435058"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_edge_neg",
-    "hash": "181028627897073060205562212240246609369"
+    "hash": "733483128992203573811349661401873164531"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_edge_pos",
-    "hash": "90564796992807741216514298942216248607"
+    "hash": "1646611039044622108912715269796509117544"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_large_neg",
-    "hash": "1178884306892636538816185549293126688138"
+    "hash": "47948165602340441234242918943600433045"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_large_pos",
-    "hash": "634562276727068660016030116426699955094"
+    "hash": "121724881926455918987488858668725653265"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_small",
-    "hash": "1754400765320494769915871750915272792660"
+    "hash": "51825711364671454006635959386503080011"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_edge_neg",
-    "hash": "88721800021910781748261693495513882106"
+    "hash": "821054039508505409117381486996388544317"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_edge_pos",
-    "hash": "177136490273364937464667540781870492149"
+    "hash": "4987615825332353055098735419323298107"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_large_neg",
-    "hash": "1789228387515935376014623022293187081628"
+    "hash": "45334897280937202805833457717076686239"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_large_pos",
-    "hash": "159007315204723416596339248315860926486"
+    "hash": "275320056442928788367002140976877859"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_small",
-    "hash": "1691617297211389100110345169579456743516"
+    "hash": "123727308858597111618064317424149186684"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_edge_neg",
-    "hash": "44575141401344217714243047119617592240"
+    "hash": "17416554860753083991098846876662533302"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_edge_pos",
-    "hash": "91124527090015212246046164618731181423"
+    "hash": "179367510777195083419808533001597276832"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_large_neg",
-    "hash": "472915196007257210812864355961737605541"
+    "hash": "67571053480756536126931535797288104836"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_large_pos",
-    "hash": "585703463520876223116427844160337253747"
+    "hash": "1579608339928725331313607553569843492018"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_small",
-    "hash": "14801253290943900366128891287508098601"
+    "hash": "99923852101650002733351137108294650604"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_edge_neg",
-    "hash": "209962094439989699214074681567636389220"
+    "hash": "41795348871453971473513185627809110155"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_edge_pos",
-    "hash": "42938962094926901471426033679886550855"
+    "hash": "1192996701334529366413269442256741211900"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_large_neg",
-    "hash": "676160450159951055224526363026397983"
+    "hash": "328086369763562153716839943300740900733"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_large_pos",
-    "hash": "561210702612501728913533135990538025866"
+    "hash": "28826166932437098464879480946243399780"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_small",
-    "hash": "125875074041845656618776397708476168504"
+    "hash": "1841656020665546093813117190082667121106"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u128_edge",
-    "hash": "1200915612411021894816766821042939506882"
+    "hash": "178773728087264777023704633492806996053"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u128_large",
-    "hash": "98497934617570775036463983993753102228"
+    "hash": "1441273291239288240317499922030371307676"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u128_small",
-    "hash": "1244022527117567168017647527463412320302"
+    "hash": "129887996626158186945101773713168875503"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u32_edge",
-    "hash": "3884002936295768704602664430489303290"
+    "hash": "1574759844985881208615856467258328065674"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u32_large",
-    "hash": "80664823815821781165918499663937068776"
+    "hash": "46342281599269840038522698536670101327"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u32_small",
-    "hash": "15833245755650818592438632780370917970"
+    "hash": "12414035624332303707435666225615879148"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u64_edge",
-    "hash": "1811235923209422316010501832586199508285"
+    "hash": "18101713586988318774349239061897775433"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u64_large",
-    "hash": "184204516272526672915700590612056236840"
+    "hash": "142813824249079413891123085800477317467"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u64_small",
-    "hash": "7017747722996444193266469555937018512"
+    "hash": "1762818972982369980813818296160828840061"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_usize_edge",
-    "hash": "51017123691936637189460005465894826292"
+    "hash": "9412589549068802717605923784944996017"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_usize_large",
-    "hash": "68447599651681355112069600132405107537"
+    "hash": "67664687108034576133628049324915134504"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_usize_small",
-    "hash": "16017432234036677608650065958024043992"
+    "hash": "1477831419004945322717519845194733673140"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u16_large",
-    "hash": "52661343262781590767691498984147775102"
+    "hash": "50068605144568914433934545903642756744"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u16_mid_edge",
-    "hash": "120665964001343227044199005357765682480"
+    "hash": "98492860636491075564140208850058056095"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u16_small",
-    "hash": "148206783586962667812751408533000425768"
+    "hash": "103374553300674810197153430454733509894"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u32_large",
-    "hash": "1617538316488461132116815318090266740646"
+    "hash": "251530385105120101914530088484864406771"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u32_mid_edge",
-    "hash": "54117699716891695188019537006871189258"
+    "hash": "115833906427772198341326892416864012683"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u32_small",
-    "hash": "109552123566196504381418384779378218422"
+    "hash": "1440287539449244552412004359381825043729"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u64_large",
-    "hash": "128804927339672601745390628831931191478"
+    "hash": "113398313014780273651209470183644678774"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u64_mid_edge",
-    "hash": "44642181510217098278703826082786802296"
+    "hash": "834410229287065825810339209139561780208"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u64_small",
-    "hash": "1373397704607730042210011199034834277694"
+    "hash": "336829030257804530812555155089460812645"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u8",
-    "hash": "969726315231982244111001762348180540520"
+    "hash": "959263565493464236811407511942375624205"
   },
   {
     "file": "core/src/num/niche_types.rs",
@@ -21796,572 +21796,572 @@
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_edge_neg",
-    "hash": "1350954067009605647517304967874444315200"
+    "hash": "126572793536358400019218629183701727927"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_edge_pos",
-    "hash": "821079974239472848813390198456140512526"
+    "hash": "617152071739997730714832266048864152196"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_large_neg",
-    "hash": "1331169959360005897717937909889823126399"
+    "hash": "704748448655807552717769005428419601573"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_large_pos",
-    "hash": "5427161078347573529442678979205270010"
+    "hash": "92277720174285082725156688912912126737"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_small",
-    "hash": "54075949015745521431025894055876620359"
+    "hash": "108176305069058275692667682465754456323"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_edge_neg",
-    "hash": "69547579302224818798990089875839095649"
+    "hash": "1461070617189157915613615872352069367060"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_edge_pos",
-    "hash": "116860872666182731556887621523252528425"
+    "hash": "1601299044791821897814374118106569033877"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_large_neg",
-    "hash": "603258445035072655410160366751647842016"
+    "hash": "1596908716003316406631802725969931013"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_large_pos",
-    "hash": "97657254800942132368633156622708559125"
+    "hash": "121276882178520233097968780928995728841"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_small",
-    "hash": "47895841336973867095709096090728525747"
+    "hash": "31833373228380865315903831266610214925"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_edge_neg",
-    "hash": "328925778130286881817728294671966576"
+    "hash": "85823485034441710989014628044021459486"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_edge_pos",
-    "hash": "356246848510348848411458863579405386066"
+    "hash": "166550564275675197026790305540979740786"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_large_neg",
-    "hash": "1614572249627657434611221907902610339415"
+    "hash": "327901659613034652513665598284695758896"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_large_pos",
-    "hash": "1183839190922589559212689910659774511006"
+    "hash": "1380825610344678785012080380502518213022"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_small",
-    "hash": "166496139797835000483207362115872787888"
+    "hash": "685016366446277010516992771972832618646"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_edge_neg",
-    "hash": "50769394231845448891613623037117688816"
+    "hash": "19980427794151860184731835472423081487"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_edge_pos",
-    "hash": "126424965318127359166305227084244956704"
+    "hash": "101436316626006148022177233618847696542"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_large_neg",
-    "hash": "1134912025711687114918353452394662781479"
+    "hash": "166250470237382669692132937381019748823"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_large_pos",
-    "hash": "83542034851892431072428885042846916833"
+    "hash": "1772588611697117897412715865787409827890"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_small",
-    "hash": "1362279185159837897017257448221240767377"
+    "hash": "639116529229422822811475098480299763444"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u128_edge",
-    "hash": "900673762467540125516417236160418981184"
+    "hash": "61168995301618123754567642490735366239"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u128_large",
-    "hash": "412112989576125776810996455877757780652"
+    "hash": "112952566492483858838634345755624760616"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u128_small",
-    "hash": "788351824859520995914671530639060037774"
+    "hash": "1519964195343615618010736892424085798859"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u32_edge",
-    "hash": "146624649357762962949324252775425554884"
+    "hash": "159487785064608153229138797105090897539"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u32_large",
-    "hash": "181225162059182766541530555644444346311"
+    "hash": "1143699339291646571613815460692899519375"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u32_small",
-    "hash": "93031915036229791089613860563284128816"
+    "hash": "26223064567492145357322101272651782808"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u64_edge",
-    "hash": "175933572343254428407977735170683856120"
+    "hash": "97678371302315629375030598889507837339"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u64_large",
-    "hash": "541551602129878394410276815110642298146"
+    "hash": "108959077315092336286853079520427189059"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u64_small",
-    "hash": "178979525440224735676421275699047740346"
+    "hash": "70177827549721850489952549761567362824"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_usize_edge",
-    "hash": "5589282360428875754285944419233750608"
+    "hash": "67268602030065140479105180656400331057"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_usize_large",
-    "hash": "403085430226758524914029130865904750460"
+    "hash": "365034312439451527915486963416187506191"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_usize_small",
-    "hash": "1716814606849695420714384414650362457282"
+    "hash": "8653486808193501437469764754577587877"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_128",
-    "hash": "93703547081561170416454620886126796235"
+    "hash": "148827628993622428037983243069587473278"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_16",
-    "hash": "123344103509599540442311968629930726306"
+    "hash": "1033369380621472120517067278467459242156"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_32",
-    "hash": "148770954170871136034828279495189165005"
+    "hash": "1240451548243773341015864219946584576351"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_64",
-    "hash": "93154856975983741245105565295569747231"
+    "hash": "1152855587663765360810494232739092875384"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_i8",
-    "hash": "1333894560838712118317964640214647774937"
+    "hash": "1588971185174003914613680862082031755129"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_isize",
-    "hash": "468650370462332952113176431786491811495"
+    "hash": "55874472397056396349911388959153266720"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u128",
-    "hash": "165042360902948802153874056886638234188"
+    "hash": "116886748051959823708577380828969143484"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u16",
-    "hash": "1463620064932788598116251137361366309971"
+    "hash": "1258676861928892533510350395489504380252"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u32",
-    "hash": "4905819915468732525616698018301012660"
+    "hash": "1762146383009082999017067639265957444227"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u64",
-    "hash": "255662359416667329017166319385072947421"
+    "hash": "1416292783755576593416521939285071313242"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u8",
-    "hash": "1458300693283128348116113920851531683683"
+    "hash": "19598661848323572313870618746243516038"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_usize",
-    "hash": "29450036314912462939620196311946707262"
+    "hash": "85184058513992240001968145105781025119"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_128",
-    "hash": "156718071009335255736046900612345617375"
+    "hash": "1071273289518460988315606908391941573309"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_16",
-    "hash": "564443458170849765613143197215699072892"
+    "hash": "806214682809580249814233692663246638991"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_32",
-    "hash": "12022051867484936212961144523756267650"
+    "hash": "1413867615654356819513202394661631875654"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_64",
-    "hash": "161577732571473163629044092186295118911"
+    "hash": "157651531916639452149198597179486494592"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_i8",
-    "hash": "148613928287448639187328615253307708692"
+    "hash": "1360269077762570390315361633620274033505"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_isize",
-    "hash": "127723862426250906742535460070834797727"
+    "hash": "1820032885601911880916357674684660463665"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u128",
-    "hash": "1417644278807031499469260523203498749"
+    "hash": "24843930075952661510550849333537225"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u16",
-    "hash": "678119320457297862111714912565448822747"
+    "hash": "62560979100836699844011304375225026795"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u32",
-    "hash": "50648294182048318641780486478443258186"
+    "hash": "156855911831732783399118586235009662476"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u64",
-    "hash": "82794497349078554456591483166829338074"
+    "hash": "75149804409756581833716332101361873"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u8",
-    "hash": "10737208447664048987261958690251210605"
+    "hash": "171130382060420492758419850466734550207"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_usize",
-    "hash": "97053545153964482032675896643828554741"
+    "hash": "1265427547096133333412165861730323277437"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i128",
-    "hash": "171602560502813700918541631830610901910"
+    "hash": "1142190084957549322016821841248653949565"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i16",
-    "hash": "709841195968631465111645189713636405120"
+    "hash": "1351996178002149021967629992628631852"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i32",
-    "hash": "876165373641999284813584835101943932573"
+    "hash": "366488170376604632217901966363000030292"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i64",
-    "hash": "179048859016107488845645093824519383109"
+    "hash": "694473826870531435716969018660428392413"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i8",
-    "hash": "48454321201879367509137379907559104893"
+    "hash": "1458143571361305462613119623973060571581"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_isize",
-    "hash": "58970843558256445613125646072095163242"
+    "hash": "134795168582998640116726225514319457256"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u128",
-    "hash": "1620792998246326460518352796310350345470"
+    "hash": "107906159493707829148008339860219047015"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u16",
-    "hash": "963130695582906220614128067839225404218"
+    "hash": "1116044549999028858212171070422562368877"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u32",
-    "hash": "76405854881770126747866801063147677780"
+    "hash": "165833707814918794307530798797250027753"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u64",
-    "hash": "1192836152912340199729513595150993442"
+    "hash": "112143737582213996239182831328173823712"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u8",
-    "hash": "138742408411770792412940459591925718458"
+    "hash": "97244155574088017189292497322963056843"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_usize",
-    "hash": "102292901466821942735010997332886363913"
+    "hash": "75773609675560790301519188078393582058"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i128",
-    "hash": "111895509296480139584431442350385690551"
+    "hash": "125100165903453613723624293687099466866"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i16",
-    "hash": "1314926580729558330715654979605831926684"
+    "hash": "956425013463182958914445965777864294819"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i32",
-    "hash": "34713624473996998410648814942171696786"
+    "hash": "875785127692585433417666585604318171914"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i64",
-    "hash": "114829921325802499247597591242406265748"
+    "hash": "101112735023125182828083437479258953162"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i8",
-    "hash": "1134724542287344373816561742445974394034"
+    "hash": "433159241283405752714917389395904245345"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_isize",
-    "hash": "43173692857136623626793739017857958740"
+    "hash": "142153200590953289686011202219604109582"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u128",
-    "hash": "1797843702538038564811457596358500581897"
+    "hash": "1465544347262659686817430655948364568979"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u16",
-    "hash": "170478216540836815309756193264938605497"
+    "hash": "978701429429958124610550223224255037156"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u32",
-    "hash": "244189639995031240112363087964612982489"
+    "hash": "108523388519138631772544677158247080502"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u64",
-    "hash": "24064828247112562185009267445263760684"
+    "hash": "109993947215179179612783338614841588208"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u8",
-    "hash": "11921740825991565228375103332060215069"
+    "hash": "389471774718321328118283170389221621291"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_usize",
-    "hash": "13471894792879500992963849969586223816"
+    "hash": "1237821082295203048113601427434151949017"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i128",
-    "hash": "158364411273152863937463428313326900515"
+    "hash": "467114298025684440110647745719967486253"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i16",
-    "hash": "136827000357795164725426242920105835197"
+    "hash": "810166223417308658613148128368555965084"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i32",
-    "hash": "518595974904743187011802887721782409378"
+    "hash": "433896238705981500413766902439739385883"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i64",
-    "hash": "565177157498069140211221763833905624456"
+    "hash": "1130007588884761194515280262759336947495"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i8",
-    "hash": "128561647959480434092886125645748639572"
+    "hash": "313382336979393079115949474262324141454"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_isize",
-    "hash": "143035899639135214992391414528033905631"
+    "hash": "841649463175008620513088696965136933460"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u128",
-    "hash": "121273281285295588152508760555133088106"
+    "hash": "1274710458107499084017728309538213211176"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u16",
-    "hash": "166457411783348146346994375797733636130"
+    "hash": "36118681092228264461782820900702565210"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u32",
-    "hash": "174667946499198254527144666079156543828"
+    "hash": "259267171635009254414191881059146437764"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u64",
-    "hash": "56228065763088115331930725407075142094"
+    "hash": "88366255159477156945329911588193680148"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u8",
-    "hash": "124799195535724833384912094574249608865"
+    "hash": "31126541783676949423561256904696637496"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_usize",
-    "hash": "554098070407523095016840191500154881777"
+    "hash": "1701239896403110668713102698816011169367"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_i16",
-    "hash": "989784028223651178017670382041086109547"
+    "hash": "10181687469926978084284913614101041021"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_i8",
-    "hash": "830636895734763671214460520518412267655"
+    "hash": "1495378042250256632410279754473748418603"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_u16",
-    "hash": "3246857731262710648680268843223213850"
+    "hash": "692268469113344924815698081271285271187"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_u8",
-    "hash": "115045582071978069653185272721079780899"
+    "hash": "57953653706289436234834051140338909995"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_128",
-    "hash": "111823965925400256346673723375611418773"
+    "hash": "445853215792059395110251101186523986208"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_16",
-    "hash": "57817106200364795716687389429490421916"
+    "hash": "56546286116300241018661663726763427987"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_32",
-    "hash": "1444563538815844291912900556631268340711"
+    "hash": "138807076179372949102243520434197802875"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_64",
-    "hash": "145696145489837912322598565253019362335"
+    "hash": "178872807692031589952638315495526503594"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_i8",
-    "hash": "758970127450832711712980906665861905583"
+    "hash": "159344654434324176047190481520393620520"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_isize",
-    "hash": "1032334883430711099318357368064015120102"
+    "hash": "55058942940701148416499963893142888573"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u128",
-    "hash": "114227113218568552775771536086325516343"
+    "hash": "46786509084595455829297256196323367521"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u16",
-    "hash": "800783131654730056115273772208589968495"
+    "hash": "552141313641700394413466234730798541138"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u32",
-    "hash": "440650114246587385039294480306892909"
+    "hash": "872194708805187081116117231978692974050"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u64",
-    "hash": "525424813797222241510418586376615607577"
+    "hash": "35379678474858636555394827343526638476"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u8",
-    "hash": "1589700077731176770815132359667464801930"
+    "hash": "150881200035106929856032592087661076134"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_usize",
-    "hash": "776696460693720054913802362790795303606"
+    "hash": "73737342874226011418240508903573582600"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u128",
-    "hash": "8322738316348135993914219719954651675"
+    "hash": "7350962699169980749108932519733899743"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u16",
-    "hash": "1702852809589886706811527962565532591120"
+    "hash": "102001836482366565771352898561365646772"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u32",
-    "hash": "1836922876913974174416783553164007606877"
+    "hash": "84067376623469444111881105737898593750"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u64",
-    "hash": "295912849927524569414851088417845368699"
+    "hash": "703022352900920811310850089457477412485"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u8",
-    "hash": "107909910375087589373592168030557191319"
+    "hash": "2431053769179215447755123439908122219"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_usize",
-    "hash": "654795364473028349312566988002281319005"
+    "hash": "1730505042061272679015339707434431364041"
   },
   {
     "file": "core/src/num/overflow_panic.rs",
@@ -31421,227 +31421,227 @@
   {
     "file": "core/src/option.rs",
     "func": "option::verify::verify_as_slice",
-    "hash": "12590488003543174799032829518901954477"
+    "hash": "30623443313714622491198686362172983418"
   },
   {
     "file": "core/src/panic.rs",
     "func": "char::methods::encode_utf16_raw::do_panic",
-    "hash": "159375648412719567188404552784823910522"
+    "hash": "72285810534221413553557916636646788719"
   },
   {
     "file": "core/src/panic.rs",
     "func": "char::methods::encode_utf8_raw::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f128::<impl f128>::clamp::do_panic",
-    "hash": "50807735889621473026858823970825922467"
+    "hash": "1020313098020682086813525449733387508679"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f16::<impl f16>::clamp::do_panic",
-    "hash": "80863658359543196131499440355492894153"
+    "hash": "45365173242766850069784469000113513917"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f32::<impl f32>::clamp::do_panic",
-    "hash": "40152032105393575334041670605428032388"
+    "hash": "1645263290791078191515586862813480023162"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f64::<impl f64>::clamp::do_panic",
-    "hash": "1471803332684985989614176870595548450117"
+    "hash": "139095771090594133195310116661061414295"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Assume::panic_cold_explicit",
-    "hash": "1789421038053706123710098356680448714467"
+    "hash": "1506070533374096704814809185562537688310"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Call::panic_cold_explicit",
-    "hash": "295371150684177085715081702501752032999"
+    "hash": "1408509860728327854813604341673682330237"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::CastPtrToPtr::panic_cold_explicit",
-    "hash": "73965070712856596836659199303475017123"
+    "hash": "742034857866235252890557226018016225"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::CastTransmute::panic_cold_explicit",
-    "hash": "378090514985406829710584467808735149809"
+    "hash": "7339847188062706127315228104164504393"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Checked::panic_cold_explicit",
-    "hash": "128333664918770274261688271437565845126"
+    "hash": "199595456589912283717119169739543279589"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::CopyForDeref::panic_cold_explicit",
-    "hash": "609013470521849315718255485813152183234"
+    "hash": "16341918568529364625569996928746873855"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Deinit::panic_cold_explicit",
-    "hash": "938266443487077680616217634212307852190"
+    "hash": "1785894418650424903312553870546663027229"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Discriminant::panic_cold_explicit",
-    "hash": "137467938365592260787386096045701623459"
+    "hash": "81775534530354112179176337429753666459"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Drop::panic_cold_explicit",
-    "hash": "257090290858865617710102565418972576465"
+    "hash": "746894880889946677716721807334842959746"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Field::panic_cold_explicit",
-    "hash": "92123714177881913146242159589196169699"
+    "hash": "1352686515516519169015975493904529932948"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Goto::panic_cold_explicit",
-    "hash": "22175953128656401297064148711324782239"
+    "hash": "110580338041328369781090380259251041043"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Len::panic_cold_explicit",
-    "hash": "142105944693957838316714814489638057672"
+    "hash": "67888286006198805673134511088851130781"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Move::panic_cold_explicit",
-    "hash": "162200283992099129796115303197233248390"
+    "hash": "116872287033605475914577365623793020996"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Offset::panic_cold_explicit",
-    "hash": "54669212364655385098584674346110640579"
+    "hash": "27433262809085370077456906019314442711"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::PtrMetadata::panic_cold_explicit",
-    "hash": "1732213299668300100016463945423008504618"
+    "hash": "640508737116014266214915361687054852237"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Retag::panic_cold_explicit",
-    "hash": "81683014888037235312929999747273983636"
+    "hash": "44196892434186067144751017255323691562"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Return::panic_cold_explicit",
-    "hash": "182523880797771197678575232574645162553"
+    "hash": "1714561766591072987917816672675188169767"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::ReturnTo::panic_cold_explicit",
-    "hash": "11055829247994603801577073293495183146"
+    "hash": "110028352069935417698345215215892531421"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::SetDiscriminant::panic_cold_explicit",
-    "hash": "1437804766786886914716964473913122252335"
+    "hash": "6882202771299132285026028051294774747"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Static::panic_cold_explicit",
-    "hash": "132282081316497259936789638503357535133"
+    "hash": "53909762353665015863351408718183585641"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::StaticMut::panic_cold_explicit",
-    "hash": "102168648871423887676573611284817397588"
+    "hash": "40158843098427337614883186002032292478"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::StorageDead::panic_cold_explicit",
-    "hash": "61898601481286946277560821448816298933"
+    "hash": "155440065820628926766575326473112163534"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::StorageLive::panic_cold_explicit",
-    "hash": "531133218987953098411257973601662260294"
+    "hash": "13116672398544422041899866916247458343"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::TailCall::panic_cold_explicit",
-    "hash": "1390938607515588769214155221053412363837"
+    "hash": "509007597409936015910660996704624363310"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Unreachable::panic_cold_explicit",
-    "hash": "17776026680420953293605614192341237686"
+    "hash": "140879367068072058054130032519836693740"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindCleanup::panic_cold_explicit",
-    "hash": "105298623447639116667200042160659264771"
+    "hash": "416918189149504071416765804788610114263"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindContinue::panic_cold_explicit",
-    "hash": "170155754333316407057806419910809023230"
+    "hash": "79608751687191560358775722279105186137"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindResume::panic_cold_explicit",
-    "hash": "376070249658287840016726757098145634780"
+    "hash": "199598609119397467513821283132744601752"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindTerminate::panic_cold_explicit",
-    "hash": "140667877420609903763612146134059076493"
+    "hash": "170041468465096593219413700318026119921"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindUnreachable::panic_cold_explicit",
-    "hash": "38393966172403297278872444492342160729"
+    "hash": "66427127608056022851739916628221250547"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Variant::panic_cold_explicit",
-    "hash": "1006711043700819926215509686585437110462"
+    "hash": "176587880980367410773945757592236123649"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::__debuginfo::panic_cold_explicit",
-    "hash": "112398654373845065568746064311615959684"
+    "hash": "94982048625337666317982282310540275109"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::__internal_make_place::panic_cold_explicit",
-    "hash": "1330778076631843542615879765226573522070"
+    "hash": "1513064912916396068515466653650527505112"
   },
   {
     "file": "core/src/panic.rs",
     "func": "num::from_ascii_radix_panic::do_panic",
-    "hash": "149310366229237893685348743334776059449"
+    "hash": "31929417444213691761029989375105527760"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic",
-    "hash": "1072304849003159545015693768884188491165"
+    "hash": "166743082214890768219807743374638619288"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::index::slice_end_index_len_fail::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::index::slice_index_order_fail::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::index::slice_start_index_len_fail::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic/location.rs",
@@ -31651,7 +31651,7 @@
   {
     "file": "core/src/panicking.rs",
     "func": "panicking::panic_bounds_check",
-    "hash": "7830816113357828502135153638694178379"
+    "hash": "728911593736298613413879175387058038540"
   },
   {
     "file": "core/src/panicking.rs",
@@ -31771,7 +31771,7 @@
   {
     "file": "core/src/panicking.rs",
     "func": "panicking::panic_explicit",
-    "hash": "1035356066328463027311434339410608402400"
+    "hash": "954011670273584559413724775235663875825"
   },
   {
     "file": "core/src/panicking.rs",
@@ -31781,7 +31781,7 @@
   {
     "file": "core/src/panicking.rs",
     "func": "panicking::panic_misaligned_pointer_dereference",
-    "hash": "65985693830680293206686160255696941099"
+    "hash": "47382073969818256606302523105374584012"
   },
   {
     "file": "core/src/panicking.rs",
@@ -31926,1357 +31926,1357 @@
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i128",
-    "hash": "1675705772848578006012122842517236949438"
+    "hash": "60858223530108041165382953724370511678"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i16",
-    "hash": "158019816037067336052060524014389705044"
+    "hash": "1700594662779370165710997422476225882343"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i32",
-    "hash": "175622485947600819306850155388232188452"
+    "hash": "1582268101519906451912333594027823404987"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i64",
-    "hash": "1535601636895935336517432153270259880211"
+    "hash": "1530151676285471606917784762602662921937"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i8",
-    "hash": "1326421231673630846511186048968762563034"
+    "hash": "5331966539103015199427715264974376575"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_isize",
-    "hash": "98268662194605619319264586816774107506"
+    "hash": "100479855850961491065885317426128135712"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i128",
-    "hash": "1288464093744360586917437556604803731794"
+    "hash": "911749843056547691014421567799287347362"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i16",
-    "hash": "1065614515751518032618116125308197312999"
+    "hash": "1326985231377037481512096818320511151032"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i32",
-    "hash": "1475271473206254815418139518127611254139"
+    "hash": "142749506251787481472065680235390414388"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i64",
-    "hash": "11780758094000997453755757787824158319"
+    "hash": "111249837707824545957034908715536218904"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i8",
-    "hash": "1088879519007081508411056833457883347112"
+    "hash": "1648825481873716646615010022527157036005"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_isize",
-    "hash": "97446613950649675423128484265760192374"
+    "hash": "157234193152601134732596554879293127470"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_1",
-    "hash": "31831563380506493298518152828194622840"
+    "hash": "77563719578222075998953677232495168109"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_2",
-    "hash": "798942511580911814714232623324299276295"
+    "hash": "84231358747275479802311825873780952263"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_3",
-    "hash": "654896720285272890716242512526168963212"
+    "hash": "89321674429661413872996681185676466430"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_4",
-    "hash": "146812293645287162917849522425499570085"
+    "hash": "1341971715727661064011211781537992334521"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u128",
-    "hash": "116649844444831082649672303746280858974"
+    "hash": "77382190606528931345412534385254317167"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u16",
-    "hash": "1415334025285463115514711125358401010831"
+    "hash": "507437000842772472217887909195719347285"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u32",
-    "hash": "829922200088720480618407605432995096153"
+    "hash": "51730753738409967919086110292066789013"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u64",
-    "hash": "1344479149315698220910380289392101731816"
+    "hash": "167497376656540354922877995537748996078"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u8",
-    "hash": "512435068594202981210189991312296084467"
+    "hash": "15931814740699644328547247307671858149"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_usize",
-    "hash": "88034442136784715753415482033134537694"
+    "hash": "151050995820701234382234671723830366177"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_1",
-    "hash": "665710712657287981311149793860063170697"
+    "hash": "121759491499969142105324580910721384423"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_2",
-    "hash": "14788332205287806624165356299335259237"
+    "hash": "1112506924183269669612628605903843260608"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_3",
-    "hash": "88880446153189492243710736877055795336"
+    "hash": "3243218657587253501689045316239093562"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_4",
-    "hash": "831372783451512859816414343573620430786"
+    "hash": "594570578185067340117368375157296478429"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u128",
-    "hash": "698277290155717208781013276270694779"
+    "hash": "170001868107598165034020918386023004859"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u16",
-    "hash": "1833842786489157868310248451321103580471"
+    "hash": "170643026358802232048433720691888991614"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u32",
-    "hash": "1609675285421099079317331884296123990318"
+    "hash": "1487985062332698951913045619143734639384"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u64",
-    "hash": "1662797914628800144615579834711429194648"
+    "hash": "11691222712691410362929927353146781066"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u8",
-    "hash": "790088443678981285717442013285497577086"
+    "hash": "1697463570029668961810860823629955150449"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_unit",
-    "hash": "1401007401102257300316537842469832927174"
+    "hash": "176720649170840493764138047418834677612"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_usize",
-    "hash": "1798573077240762536713390140088504274596"
+    "hash": "1542148791568968585716339548091419356903"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_dyn",
-    "hash": "79761632330825712301934196451561294376"
+    "hash": "1780201231807408733117667568540184151781"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i128",
-    "hash": "1078263186806924628710316170638792003298"
+    "hash": "1543346732854776912812428776625228854264"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i128_slice",
-    "hash": "1019481656079838767414261407433444457277"
+    "hash": "132012397416362308712590838754686302702"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i16",
-    "hash": "1508464630561425882413581394789221770694"
+    "hash": "424370766340670561618406829996047044269"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i16_slice",
-    "hash": "115306421891758824994435506718793699826"
+    "hash": "171357506014746520769527867030185336508"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i32",
-    "hash": "64573943806622376555518346088736492051"
+    "hash": "72421349288104198459522967807234036814"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i32_slice",
-    "hash": "179671283709616507237189850734661000688"
+    "hash": "248861842452637352210104103915777815238"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i64",
-    "hash": "1455080676235601625012841677101482569780"
+    "hash": "1147486888178754201116329520501271936138"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i64_slice",
-    "hash": "137410277259891236314809702825594861656"
+    "hash": "19951687458320497684172429937017536281"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i8",
-    "hash": "166498650700478157781319064338239039600"
+    "hash": "887288045858584317914995258581540179575"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i8_slice",
-    "hash": "1552950265331809409114529939810725630899"
+    "hash": "272744950132597254911360020743809864118"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_isize",
-    "hash": "108914495536680298917298348089638193467"
+    "hash": "99122289237441761267611851478378944644"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_isize_slice",
-    "hash": "882997220283147291114322805008018110107"
+    "hash": "68834488028471120272320701181374031263"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_1",
-    "hash": "621834688544712464533363748914816689"
+    "hash": "72849725960850029756714174308581867033"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_2",
-    "hash": "868423451879432281811008128101122828173"
+    "hash": "42566001926501421519983798935769122393"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_3",
-    "hash": "126235737103951137988853591215446631316"
+    "hash": "452891248071879725411213937392287759683"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_4",
-    "hash": "5986215934792710317207018615617405899"
+    "hash": "160133261048311428005394393869453396585"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u128",
-    "hash": "429747602224698080512293036533128972362"
+    "hash": "86684378560462401881052008726440830451"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u128_slice",
-    "hash": "79017586312499993776523324185025657189"
+    "hash": "1091999322440121821311751918017766506537"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u16",
-    "hash": "78238390672365434597873610003242068813"
+    "hash": "100902534974805568571800676326961628913"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u16_slice",
-    "hash": "669305334046988472214124455716867740742"
+    "hash": "1735027461068621184418160305871302214690"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u32",
-    "hash": "687919097717870300710899732458696960105"
+    "hash": "1645329164305644888112230893808947986"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u32_slice",
-    "hash": "722380556302857156615849650782698653401"
+    "hash": "23425179039299441535661160535752733447"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u64",
-    "hash": "1079942161950497456811775505511965186080"
+    "hash": "566545122637606111916843730057753339205"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u64_slice",
-    "hash": "14183821838572736251755376811339774391"
+    "hash": "1438400072150383099015379081523232338839"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u8",
-    "hash": "1739260375824962430317405337740660977696"
+    "hash": "799223897673115665316354021158070546960"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u8_slice",
-    "hash": "1814666946233095251615373594359471233251"
+    "hash": "23324201006595292533174832926971631763"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_unit",
-    "hash": "38515986439544837923572248300193269726"
+    "hash": "44114477907647897972858815262310458055"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_usize",
-    "hash": "46542658444842084054840590461983606619"
+    "hash": "182864633573887237715754065931537836783"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_usize_slice",
-    "hash": "1295391538573182368418093677420380882387"
+    "hash": "236472749687946268311385032823888332941"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_cast_unit",
-    "hash": "1047383007193929699311682981357278609930"
+    "hash": "68114178015446238968348476424768499083"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_dyn",
-    "hash": "1008233644147352524312260245725571746044"
+    "hash": "64684734920831411282730928544649991911"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_dyn",
-    "hash": "289580119021279912416450780334189701292"
+    "hash": "1124452668317072695210550794823973934462"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_fixed_offset",
-    "hash": "35212817648223289761482256676121656325"
+    "hash": "1309406905859399879214131897351420987476"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i128",
-    "hash": "74654854567413375287251934100872097197"
+    "hash": "23116773570954884885341464717039870409"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i128_arr",
-    "hash": "87267168993771030810820591921430534504"
+    "hash": "1396645968274699898512364061126156110667"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i128_slice",
-    "hash": "179687424450291177726900577464191461412"
+    "hash": "35613058035615018728601918553568490492"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i16",
-    "hash": "21185782532481910712564080151844107912"
+    "hash": "8253084154241523438675389720908703349"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i16_arr",
-    "hash": "98573560498905638484042032460506496817"
+    "hash": "3137308913633839143876393403627062627"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i16_slice",
-    "hash": "43685657259451647315810057190860822861"
+    "hash": "71386591587124280261093988783255615940"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i32",
-    "hash": "51740290118865502613542678101889122609"
+    "hash": "1092122742428271631017013905340255873563"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i32_arr",
-    "hash": "536115960201607606713577918516730672288"
+    "hash": "159555922340426364018108387956641347962"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i32_slice",
-    "hash": "659136438267344261415681456956317291523"
+    "hash": "40133619235364598899197011405688126466"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i64",
-    "hash": "1219344560402077156813108040887062706472"
+    "hash": "160177163503939286011386120757655700729"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i64_arr",
-    "hash": "130665130894017309231070956181545627930"
+    "hash": "1830397428240347997117576936057076085993"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i64_slice",
-    "hash": "281215302440365460012049833284565118215"
+    "hash": "1264915220574990044710117491719103932466"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i8",
-    "hash": "1341180107210783982613637232558144151226"
+    "hash": "113642004154439751937158508459289017092"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i8_arr",
-    "hash": "80458894332632495961491854629354698741"
+    "hash": "870931739691936156314874304431103688892"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i8_slice",
-    "hash": "598967865190244095716864531129479545169"
+    "hash": "1445322861380947419411210559529086632990"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_isize",
-    "hash": "342033566847217272460692502014948166"
+    "hash": "376106286448650826011478940444084820451"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_isize_arr",
-    "hash": "990734353379656860818013238126538014684"
+    "hash": "438336769525675828717713692484869328983"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_isize_slice",
-    "hash": "65681938942466744867871772972622955468"
+    "hash": "593389438977863623318445941714127257495"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_1",
-    "hash": "19139401910267346127811120295531135332"
+    "hash": "1143332942015344547713406317151206422043"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_1_arr",
-    "hash": "1320867064749074359714985182305243797627"
+    "hash": "154458954424250650245090080116564205975"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_2",
-    "hash": "80683965295780001581016194279684856194"
+    "hash": "685710497040508708414863458092070840983"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_2_arr",
-    "hash": "5889664753945953613427851572555379808"
+    "hash": "156573650084038038082376411534416695005"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_3",
-    "hash": "583833227024408096316623133715837083885"
+    "hash": "46641355979915589108320492439890914954"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_3_arr",
-    "hash": "73624341087623857392122789520343523565"
+    "hash": "1426877732365177052710200246567677526323"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_4",
-    "hash": "598442334794389501813450340439641927979"
+    "hash": "71365759431641990793369852389015687690"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_4_arr",
-    "hash": "616770451975320295814059298429579879037"
+    "hash": "869805857737615859411012015690873458863"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u128",
-    "hash": "138338376326138499212897027212461880560"
+    "hash": "161509731004469493357091358910159669537"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u128_arr",
-    "hash": "94349057099750275639707135499879467350"
+    "hash": "767156721878879206356713798281727780"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u128_slice",
-    "hash": "1188332589982159247515492276691538905706"
+    "hash": "154247496924798991636696080739304929834"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u16",
-    "hash": "87830105271067518101647786869539025173"
+    "hash": "94100600798694583116617339900629916210"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u16_arr",
-    "hash": "374461324399075728417233025639937309989"
+    "hash": "100935500677866942857325463282048306394"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u16_slice",
-    "hash": "112427217039767335567579840068196601498"
+    "hash": "139815517706237190276117683876921593990"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u32",
-    "hash": "21273389758772047928011304444624671097"
+    "hash": "16348480229302742718756201885290291697"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u32_arr",
-    "hash": "97410155648642854595097731219694990509"
+    "hash": "1574461712456706128711239743299975614932"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u32_slice",
-    "hash": "76000447706575158025967254412658606649"
+    "hash": "90174721923693289624151675107749455207"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u64",
-    "hash": "16508880365925511856157193153203508732"
+    "hash": "748541701818152516710590830364041880711"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u64_arr",
-    "hash": "708431291951265881569127386509168499"
+    "hash": "71136287099781648713453277419047958985"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u64_slice",
-    "hash": "33359008310300659128035841845078510224"
+    "hash": "176673816624700950286115243668379898926"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u8",
-    "hash": "56993902104751495977109429732412798850"
+    "hash": "58294556438688452323570231687344157658"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u8_arr",
-    "hash": "37361769259474275582553314820945748310"
+    "hash": "17098551446732662878178792026480129357"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u8_slice",
-    "hash": "80818347659445675219912046401639601048"
+    "hash": "10305660181398399625540712354046459705"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_unit",
-    "hash": "1417971053370825704212047619502559597002"
+    "hash": "10090816483824009571626631271945438326"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_usize",
-    "hash": "1327853728464915162411494575886608773782"
+    "hash": "126833283541367083352356579740277719501"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_usize_arr",
-    "hash": "341464485672486093116750437984660470588"
+    "hash": "389262848541777494413551381828979140213"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_usize_slice",
-    "hash": "35062883797703853847316594100877442888"
+    "hash": "7711333462077729392958530554587406531"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i128",
-    "hash": "451895114652309469315948818781560206099"
+    "hash": "164403283934624981233214523100047021208"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i128_slice",
-    "hash": "2557599467702423959621538119868131239"
+    "hash": "460619193316654237114823687445647214421"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i16",
-    "hash": "9938220754346994975136538227000480389"
+    "hash": "50018336614034480293351279767041268865"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i16_slice",
-    "hash": "107056356979673444556449971108343986532"
+    "hash": "1842238213503626794018080695557995881255"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i32",
-    "hash": "142935136103748045208028011565931976153"
+    "hash": "8282259866361304858208843399231271275"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i32_slice",
-    "hash": "1148554035384277595010258202263414558811"
+    "hash": "8848390093042735116116360264890908652"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i64",
-    "hash": "1348395943137395944412376972511731000248"
+    "hash": "310555797639214418318002419877635594812"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i64_slice",
-    "hash": "115938835546675496937172903229170943275"
+    "hash": "138318366059517004523335024115852160536"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i8",
-    "hash": "1568674383346685148611950215320619469622"
+    "hash": "12265986759610681379662326721738698818"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i8_slice",
-    "hash": "1305885116912999876912630522627935775"
+    "hash": "60531043796741172715426399816419465075"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_isize",
-    "hash": "81433089637092787014616810431987785744"
+    "hash": "556144776216280440017596805544177123734"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_isize_slice",
-    "hash": "47729387727170309063558702806298440215"
+    "hash": "1172723334404222332413376659160342800175"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_1",
-    "hash": "42712194188520431586707711448309151490"
+    "hash": "8834181101754870321654076350345846257"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_2",
-    "hash": "113291205129780090705070574087903435759"
+    "hash": "165185913945608124083029610514826190263"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_3",
-    "hash": "6428028018296655794355191156503563160"
+    "hash": "1084397283305033126185265358298210990"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_4",
-    "hash": "14920577636067050782290711998797814014"
+    "hash": "12045614411895583767866000521178305915"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u128",
-    "hash": "511440286209044155915145310481585129580"
+    "hash": "21284489962333748604423364409652295073"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u128_slice",
-    "hash": "78543572495541892365354839775190273786"
+    "hash": "85855428887748186936389178537848610577"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u16",
-    "hash": "102991877399622504414381474406613261689"
+    "hash": "90171841417812934318961552590186314007"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u16_slice",
-    "hash": "1119149407151896458510454036727287755430"
+    "hash": "1620603028079807836716891639751486159652"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u32",
-    "hash": "103632180471615403127179279644695401"
+    "hash": "130109495817176595106520067056477064035"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u32_slice",
-    "hash": "26041931951136025246387510049486069889"
+    "hash": "39236970320722419298442150176143746"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u64",
-    "hash": "834820166650836811317352124897614556761"
+    "hash": "1687260658808925589111398757107456575159"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u64_slice",
-    "hash": "111708122987495936759434394764267897058"
+    "hash": "14361207061781990175496130207101891511"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u8",
-    "hash": "1194098582749068184218070753333157670617"
+    "hash": "11031285797781391853823488494155690122"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u8_slice",
-    "hash": "117971258771325561183046212204339337200"
+    "hash": "158800882340301497427817000481314540079"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_unit",
-    "hash": "126874029539991483693640238971011346920"
+    "hash": "136337743180868214718117768876095456085"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_unit_invalid_count",
-    "hash": "159128080768811755148486848261949120722"
+    "hash": "141097209605609755431724933214126626835"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_usize",
-    "hash": "73327354559361693642280825646559213492"
+    "hash": "46299565563072724572193226011275551612"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_usize_slice",
-    "hash": "28143271605856875725664022099342681297"
+    "hash": "94789239343485082438148012143662091522"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_dyn",
-    "hash": "1812994354060132743615719395965604750088"
+    "hash": "1626995826193404953013122887118167554833"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i128",
-    "hash": "1121480458840785407712615131746880925644"
+    "hash": "413051490592170675613275038323720055056"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i128_slice",
-    "hash": "574206817935040407810323164890562882208"
+    "hash": "1454571748056056243910662376034836443450"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i16",
-    "hash": "201287070311259175417227135976243384398"
+    "hash": "163284620777495987125702646726795363910"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i16_slice",
-    "hash": "1806319481580721108581480019015017139"
+    "hash": "792984682473527778411528926290954629471"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i32",
-    "hash": "11121767801645073845453624627504137917"
+    "hash": "1120554874859575922911663038879435588761"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i32_slice",
-    "hash": "13654725482620480279483163045786777390"
+    "hash": "1587959036882938376016065280412377680446"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i64",
-    "hash": "1648161563700071369111400858462580063364"
+    "hash": "136605759072929530307168425309869092779"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i64_slice",
-    "hash": "1651378816575645003910461559804988270417"
+    "hash": "1583507444926715812718132612011335582779"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i8",
-    "hash": "1450896249803630297414020987967480667032"
+    "hash": "99174944652758210251935721806980960537"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i8_slice",
-    "hash": "84980218599433640571997866192663855208"
+    "hash": "1340644958589426856715886172417863171117"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_isize",
-    "hash": "97419650160701479116703899483809354699"
+    "hash": "115827513914791228724233722849702404134"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_isize_slice",
-    "hash": "39569547492285158695760695059960843238"
+    "hash": "84281292207670495615752780868050359336"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_1",
-    "hash": "175669555708694925617334113410889842806"
+    "hash": "529158419265158644315042796482893349106"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_2",
-    "hash": "182071469560089583552434494777531802895"
+    "hash": "1704553040599643431315670977889802881294"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_3",
-    "hash": "299965681416033649311173985863701360607"
+    "hash": "1136679286398730462511827503960163585890"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_4",
-    "hash": "1283888510658721288912800611339613813035"
+    "hash": "158860487433421637314463752536315587436"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u128",
-    "hash": "13125639273314167214693555138627448871"
+    "hash": "275921801992549314311993508962901925664"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u128_slice",
-    "hash": "1376682593246683294516879016125372429759"
+    "hash": "146452391179489655910752825705807150627"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u16",
-    "hash": "1138152128352006496713774639672476749836"
+    "hash": "161573396601560368077899615293233072380"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u16_slice",
-    "hash": "181721726149665544009618344111707432944"
+    "hash": "110652873058106374916833234868377387367"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u32",
-    "hash": "9218849613565215527327272268984375975"
+    "hash": "645798319254540151117950992006588095954"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u32_slice",
-    "hash": "111680522428090080095390397353062337580"
+    "hash": "165505259933721890391265740730907410086"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u64",
-    "hash": "10573026302503300923585216842138088984"
+    "hash": "1722024686963515707210649284449162261515"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u64_slice",
-    "hash": "26693568884845139693752924999924265925"
+    "hash": "53965863801406444139691707257082670072"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u8",
-    "hash": "570947863903416492110361515458418761953"
+    "hash": "109777281422297354653703453065284802969"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u8_slice",
-    "hash": "1557981753444780104115658949803965243792"
+    "hash": "13069463362136787157592795159058464921"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_unit",
-    "hash": "6087126018391411602801695102913782302"
+    "hash": "131616326176797115122147197959092463656"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_usize",
-    "hash": "80092237702771395517878274762057902280"
+    "hash": "109659824592201626407026520798065290787"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_usize_slice",
-    "hash": "1174837468976277915614383804345590439399"
+    "hash": "893785166472521153115273900461091310315"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i128",
-    "hash": "472219666716204953118329882794579196780"
+    "hash": "1437850998366812597712493670884014335487"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i128_arr",
-    "hash": "288377658155836914914614654264596699249"
+    "hash": "98192996814307625891608956456267508467"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i16",
-    "hash": "118498202001543917367169914997867023152"
+    "hash": "104515085715011320065415481399407747265"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i16_arr",
-    "hash": "150270248427846618741624843579827331624"
+    "hash": "877108355045505242116955618327268552416"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i32",
-    "hash": "25153902227134409912252073956710760190"
+    "hash": "2512504928801610786625111735702583198"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i32_arr",
-    "hash": "439996988580530741714853752197143724976"
+    "hash": "97910416353960023539508368640576793780"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i64",
-    "hash": "8374888333889680531387692054454282345"
+    "hash": "469411172217937826217845851265195892252"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i64_arr",
-    "hash": "8347506717841862874266106746727971825"
+    "hash": "63324902774967402256786598701027415858"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i8",
-    "hash": "569519914456023945811266067636775543166"
+    "hash": "406546662405406181312541917630724655179"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i8_arr",
-    "hash": "94636851797734253139437969894032125575"
+    "hash": "43261119243112205568801815664895881067"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_isize",
-    "hash": "208344316486867282511030592441986247317"
+    "hash": "75260241161240470814911453331948565208"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_isize_arr",
-    "hash": "866586616819744548418410839748151247035"
+    "hash": "64571548560819449917985590011865217952"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_1",
-    "hash": "1362756556694918791014122709441933145854"
+    "hash": "176784038219161327723181485602217688653"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_1_arr",
-    "hash": "10080428147009318347865968312800991547"
+    "hash": "838530231319277928814834112763624074635"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_2",
-    "hash": "175098307539381993548565678140050927970"
+    "hash": "103523956108807879964608692191528129700"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_2_arr",
-    "hash": "385705521841403352515529554018548571364"
+    "hash": "79706343261875245468196147286074734610"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_3",
-    "hash": "177377161871871659313023914441286361409"
+    "hash": "109027822570856603566601100604712954507"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_3_arr",
-    "hash": "202164090399252924913033418523223377344"
+    "hash": "1733083991802640733110689278216871349785"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_4",
-    "hash": "1510508234434818609116155858111384073518"
+    "hash": "175152637975535883818324558173525666431"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_4_arr",
-    "hash": "577591262279765943516814488502268118099"
+    "hash": "567970039843195995511459312066410099827"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u128",
-    "hash": "62156059734923927397555768726309116934"
+    "hash": "87057421084040114833144126618581435127"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u128_arr",
-    "hash": "1842595737264081260117514996267120754714"
+    "hash": "14746448396065016759153901361109537383"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u16",
-    "hash": "100905623595191210074323490041450509984"
+    "hash": "162684892327153937055457502531700522117"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u16_arr",
-    "hash": "19283529930768770484793617112355605781"
+    "hash": "176654090469178257518103908751229912539"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u32",
-    "hash": "90639154274991633227965670424369105951"
+    "hash": "175937908891157490083542712275985536049"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u32_arr",
-    "hash": "130690225653150376614772921571547860226"
+    "hash": "72217174540538308295852138249863549284"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u64",
-    "hash": "546748148048224515112215182823478823287"
+    "hash": "6324486854523244696160832314053035240"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u64_arr",
-    "hash": "1667617807485727194818288866328527317250"
+    "hash": "117455081622708917807358425328661760105"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u8",
-    "hash": "120780894567022577695058926754439910306"
+    "hash": "110833847472057472994061891753049311472"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u8_arr",
-    "hash": "522806875194353642416716135090805828016"
+    "hash": "1117910412059884627312601761226398308279"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_unit",
-    "hash": "719824541380511394311810273535856086446"
+    "hash": "1746885794916172025514248005589568700518"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_usize",
-    "hash": "956781494720496291314324687505454249879"
+    "hash": "143537263553009158959882184670384122192"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_usize_arr",
-    "hash": "84430369208869625762243513625787882360"
+    "hash": "163879690693067488547853575872911961762"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i128",
-    "hash": "122004476253990483317416928985731644632"
+    "hash": "1750527981242507078710985512948241249487"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i16",
-    "hash": "11965354067041791201118007911009050654"
+    "hash": "119144638013715850025740121730615485987"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i32",
-    "hash": "57543717407503070910423424914316229629"
+    "hash": "1539669213611342558315432840220082663598"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i64",
-    "hash": "920066735690559450616587922608245144356"
+    "hash": "518997772468700682312143033999346780600"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i8",
-    "hash": "1531979543669462096015358431510531007338"
+    "hash": "59271252744212637632907255923361208046"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_isize",
-    "hash": "1043419738490289675014864404629455113886"
+    "hash": "6361497774529477561023648807569534303"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i128",
-    "hash": "178038112329690445505076567563347164179"
+    "hash": "1666643398880310900010024216849441223156"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i16",
-    "hash": "925506715150229543417849720419285772114"
+    "hash": "158828635034733745811073971754690595082"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i32",
-    "hash": "27992325736726713338629862547889741364"
+    "hash": "1007654829118360798810765486359956736874"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i64",
-    "hash": "1208999982444379166815531478849461196755"
+    "hash": "119106625052967492728950497316547346267"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i8",
-    "hash": "59934114324912149562198614999319370442"
+    "hash": "865470280654489946916198624398613077685"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_isize",
-    "hash": "90586864661989260053028127418085094082"
+    "hash": "1501592901520183396851108108054346303"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_1",
-    "hash": "110928183313520005612702371755217019394"
+    "hash": "99582751613571698413435829424655939704"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_2",
-    "hash": "65065107191958147571741411883045026850"
+    "hash": "1005582644702551253515551925501620900212"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_3",
-    "hash": "45311939867936492197227095831494760717"
+    "hash": "1475671936023102861213555931870454810614"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_4",
-    "hash": "101117009675522693451636842050511067880"
+    "hash": "8675589154535740815532430673651217730"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u128",
-    "hash": "171194023872495346305876108595793779421"
+    "hash": "1490299186760241627115170488806169327649"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u16",
-    "hash": "49269745719928883676241945905604922941"
+    "hash": "268427809540739878113639616934620050547"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u32",
-    "hash": "746492192624084253614391160893970276636"
+    "hash": "956555378289247584311859503997052275935"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u64",
-    "hash": "161452662729691991552889790747474201542"
+    "hash": "9532856893165980675707998720778269145"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u8",
-    "hash": "1791262004604193815517265490629921333067"
+    "hash": "1427873646098768785616724469234712403073"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_usize",
-    "hash": "185877031120637136214670619395408055748"
+    "hash": "20230027330766022886559680701513749255"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_1",
-    "hash": "177661163162752846014405259603061588740"
+    "hash": "587976968072122502210777705878449023007"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_2",
-    "hash": "64033545580824589782840264936655174741"
+    "hash": "54400943963624751707643341163408096467"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_3",
-    "hash": "186911077219001242912956587424386802574"
+    "hash": "1841782170479504082610226103771571862908"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_4",
-    "hash": "17637395960335649463547779001484635729"
+    "hash": "3893868398317680470658608038358943589"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u128",
-    "hash": "117973746778909006672923085132004800692"
+    "hash": "19078229677276319486168513978384105919"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u16",
-    "hash": "732749291300133548316988329538448518154"
+    "hash": "1277740768450182653918050340454324492123"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u32",
-    "hash": "1098491752663744127611424150510284683861"
+    "hash": "1367695589514563734315421004730068954241"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u64",
-    "hash": "98849152767190181314004881076560335840"
+    "hash": "92287708792845714523595211073177056988"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u8",
-    "hash": "979038893475871840518377559335748203908"
+    "hash": "1306943541994335093410060093392184598770"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_unit",
-    "hash": "15698210495126260452647604312001687176"
+    "hash": "683800591672017374515153092319383761782"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_usize",
-    "hash": "1830002907016331594011674226636805373440"
+    "hash": "945134435774068472112242202094810397626"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i128",
-    "hash": "49254660711153849433185836093167493674"
+    "hash": "64970701707556018186137413589242763782"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i16",
-    "hash": "14988882972424978645556622177077564817"
+    "hash": "928716145195139971012220985040172712868"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i32",
-    "hash": "580861804768852435718145419362815744413"
+    "hash": "179212760192176579031921043792363489678"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i64",
-    "hash": "208051860861712264111006533068113882099"
+    "hash": "1290567948950226846317894208943429569949"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i8",
-    "hash": "172206705828268718629282443645494307656"
+    "hash": "817918246180111547610402478801706734275"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_isize",
-    "hash": "238439586507323491715212087047454002092"
+    "hash": "209821932946902901917205749001679534526"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i128",
-    "hash": "2104053532182841641105060350359732680"
+    "hash": "62431613292860005109640168446751786920"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i16",
-    "hash": "233749521958306698115140418229144076542"
+    "hash": "889721553524316978314193163324513240438"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i32",
-    "hash": "24314431646321856196793420899932372158"
+    "hash": "1330307712698804280712939151122542716129"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i64",
-    "hash": "1620411869365577892018193087498294181804"
+    "hash": "123130757228560573715222085887756750933"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i8",
-    "hash": "1269956253029455997423517128216531541"
+    "hash": "429158520220108561918027385948699117986"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_isize",
-    "hash": "1133558984324236120611606783801881223982"
+    "hash": "67335231625590530194987768026024090411"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_1",
-    "hash": "171053748437195686815972006832337630147"
+    "hash": "1706558125675512610916368111344652161078"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_2",
-    "hash": "173626677153391551802069498018276031910"
+    "hash": "3204711849912592633535116455555778419"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_3",
-    "hash": "106627616189233343392128468998482391722"
+    "hash": "1351253823026856387713712764200568725055"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_4",
-    "hash": "1598518960662702764814685770303878296305"
+    "hash": "78957158461245734297794105073557208919"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u128",
-    "hash": "1076511468184034720116326563211838137974"
+    "hash": "1101556762099782431118348502028576815205"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u16",
-    "hash": "105078473831761913514855291186971095412"
+    "hash": "987146268447762393017713117417935477342"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u32",
-    "hash": "234838166953896927615744143125906396780"
+    "hash": "4262415564093585172426311049147657211"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u64",
-    "hash": "58448523359073680032312582944904227333"
+    "hash": "903950039837668673515985567820568279558"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u8",
-    "hash": "91751971442353936486773990741041069827"
+    "hash": "522115948517064748013521995510428903283"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_usize",
-    "hash": "77266605695682358929644834629705565644"
+    "hash": "85597461673088689211894875470429992581"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_1",
-    "hash": "119674128215927276946207078874725618757"
+    "hash": "1641662756362859944514766965614968862976"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_2",
-    "hash": "121660820807266003396776614592508016785"
+    "hash": "556825650589376353817712829370144619044"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_3",
-    "hash": "1309772320460063487813911355070237778542"
+    "hash": "1316795999130236992718305460424125898663"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_4",
-    "hash": "42716025420146425142163403698165794364"
+    "hash": "4002509576834855086548224379654209457"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u128",
-    "hash": "1521843207198973116516050521621873811369"
+    "hash": "45681924968481936811777837701238915048"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u16",
-    "hash": "14758845796115916773391688849440754283"
+    "hash": "1050807993326796068817649764266859832266"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u32",
-    "hash": "117202759263659309931602787879770322809"
+    "hash": "186510571757235907814036891776729063575"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u64",
-    "hash": "135739319989353689438885740126854031276"
+    "hash": "63355644152291227594811164026422755977"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u8",
-    "hash": "1333281973101712998212614646973439045348"
+    "hash": "19633126472895621559055555103656236149"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_unit",
-    "hash": "171653299350641130317143143511196658390"
+    "hash": "63732522620500339159579557680326216017"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_usize",
-    "hash": "759582235954607046515644544027258869504"
+    "hash": "134955529402641917304597117243300514615"
   },
   {
     "file": "core/src/ptr/mod.rs",
@@ -33298,1917 +33298,1917 @@
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_4096",
-    "hash": "90580971551785484262903858766032665283"
+    "hash": "27210167019335885145126709725503461580"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_5",
-    "hash": "1716409006842852835512687451507775196626"
+    "hash": "118639409502828256631365001682399913376"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u128",
-    "hash": "65387033735383670537678689671927865951"
+    "hash": "448658740373620053517009358012158424236"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u16",
-    "hash": "1027278213332400092314212141461060313473"
+    "hash": "14262417160000836994397441868687009562"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u32",
-    "hash": "1038703713919702057916097470002928117221"
+    "hash": "115198702321938779319658820017072441352"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u64",
-    "hash": "1746441396084642892017626416337083184944"
+    "hash": "62996711778246971314336706121145762885"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u8",
-    "hash": "696153836315223482517525328932886681728"
+    "hash": "18214484434072388762867970799719987843"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_zst",
-    "hash": "192401122231118509618270768714800638863"
+    "hash": "27293493752970312534739509639834365672"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_read_u128",
-    "hash": "985543799374433816413372072181637283900"
+    "hash": "41017799793716564823708299119812729220"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i128",
-    "hash": "117834836575589103349607342957345363250"
+    "hash": "1092328107318589713315215439982757469438"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i16",
-    "hash": "174084438623062774661296301400592742054"
+    "hash": "132679317788737105359067741545663126670"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i32",
-    "hash": "117277318419166798898367408354748571317"
+    "hash": "12002823718736893016602510381270613547"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i64",
-    "hash": "36490625346505404474696449921723109368"
+    "hash": "687660885033898283511790638772128834719"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i8",
-    "hash": "171629084390931774793617845913565950559"
+    "hash": "2946401450121008356593267731512074413"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_isize",
-    "hash": "49131374700181315018264021891047116120"
+    "hash": "15656459630214173187499554190758097133"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i128",
-    "hash": "1239441682663062626211646013130298593327"
+    "hash": "129326657858099733041692928663237737798"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i16",
-    "hash": "89893151827804664279487863485438387982"
+    "hash": "87136810932111239536897985904686665948"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i32",
-    "hash": "10865926068954529999206920703095481600"
+    "hash": "133920717003817186872378402868880194680"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i64",
-    "hash": "1525407528789745582612973850166795190294"
+    "hash": "362514198787586023512201700093342718438"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i8",
-    "hash": "54761887413533017366101730613649697723"
+    "hash": "975901305855187770314196179616018722318"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_isize",
-    "hash": "1517394310388826587416073311009200824226"
+    "hash": "314939679113719007817419464436803768857"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_1",
-    "hash": "82985991324477583929655100866087983486"
+    "hash": "961891772753272164712781970598828212000"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_2",
-    "hash": "162726851305841783985815239903377592783"
+    "hash": "36577919485404247554741479807703084575"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_3",
-    "hash": "1060170079602788975512730501105841841946"
+    "hash": "1109857783056848673117595641448856915972"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_4",
-    "hash": "1566672658616445213110182683726000250276"
+    "hash": "1219555435910688070313609530564791596842"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u128",
-    "hash": "122504711331920169022878569374230046708"
+    "hash": "1228270509384227103413065447637928928442"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u16",
-    "hash": "204685388669080082211781423177989343881"
+    "hash": "1044060362314478823010589030915875420611"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u32",
-    "hash": "761705436142542646918240820588354223800"
+    "hash": "3137723825901976909553331763727199535"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u64",
-    "hash": "28866300148657568316239240023706418652"
+    "hash": "118456111872325916773211502211752389588"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u8",
-    "hash": "83903325607289626412664917484877494073"
+    "hash": "619057555595036643117510477168458260631"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_usize",
-    "hash": "138821919149553380603070120029940879240"
+    "hash": "915909779621102734214437492298768412027"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_1",
-    "hash": "1042589576211222071516026521952960442698"
+    "hash": "1704633372390547588317516911311573213832"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_2",
-    "hash": "2372336022457717091540624865944728339"
+    "hash": "95099189832357658066153512696484589019"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_3",
-    "hash": "181403813975887663219040672972319518404"
+    "hash": "40104805873228075212947983793283133978"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_4",
-    "hash": "937724437268103989313298553889229388635"
+    "hash": "1433017281997360095510848528232615862363"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u128",
-    "hash": "1667501585244324986715104119530067448183"
+    "hash": "1509028426371248804110326995520843142903"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u16",
-    "hash": "748643156528898692914738512517163523524"
+    "hash": "107698783833583302627700243672105969225"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u32",
-    "hash": "809970372559516043718379171401672962500"
+    "hash": "1043375095402232003913262453366574169142"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u64",
-    "hash": "1311664334953043018144313503347055456"
+    "hash": "1517480877337586552215357359370433637083"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_unit",
-    "hash": "138227945904891724291488211928650706705"
+    "hash": "1169118382758069657914493187408276011603"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_usize",
-    "hash": "66430204223624441854749663637696829447"
+    "hash": "1633193950926913141317059915075527012264"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_dyn",
-    "hash": "7803749238591855475726324941793228533"
+    "hash": "33644326858376294599414844248407311578"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i128",
-    "hash": "7959971405020777058054615018877122657"
+    "hash": "553749931800084187810410956881843653048"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i128_slice",
-    "hash": "523978279720973640816643526986968441579"
+    "hash": "156709675836867096314763743669015649376"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i16",
-    "hash": "93375526010341226914610724740735332956"
+    "hash": "126991876012935866928941901679953975286"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i16_slice",
-    "hash": "1292860274323687841615329432082662308509"
+    "hash": "83035750116784736447597136626600397668"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i32",
-    "hash": "1429956675008049258417449592744460081672"
+    "hash": "68945032074119594021806211677647304435"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i32_slice",
-    "hash": "9913455033853243523982905164526070510"
+    "hash": "1482319397526960590310118462174035975152"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i64",
-    "hash": "21294506692910796966235151371761458975"
+    "hash": "1313412821230813709610447312687364151455"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i64_slice",
-    "hash": "333279542896813285113439173234883439626"
+    "hash": "12527410345013991918921149743876132966"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i8",
-    "hash": "1775443931642475301617659063588079174267"
+    "hash": "180535814676790268710709294758474149801"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i8_slice",
-    "hash": "1130887348509768030415626921220741576153"
+    "hash": "136553433470734213846187936300268959603"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_isize",
-    "hash": "64671752130018187199115081215770826518"
+    "hash": "133869558897277811513384172302846686980"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_isize_slice",
-    "hash": "430000569675276231917395314037697915947"
+    "hash": "145611731341323054923574599536545801886"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_1",
-    "hash": "31450904619616326959750500829271166125"
+    "hash": "1126864421819433023416590870260860426508"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_2",
-    "hash": "134858451431796254812487051016806619293"
+    "hash": "640038229976308588716859323478038563813"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_3",
-    "hash": "1017055626959845577311911143730839206511"
+    "hash": "133316388441112562613721696948788182582"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_4",
-    "hash": "1607290822605224042715978907090601569728"
+    "hash": "16360431835182626351077311320716792035"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u128",
-    "hash": "376280426045472480017461796399163654441"
+    "hash": "1846461453155705499483088735002710961"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u128_slice",
-    "hash": "142904147110440140382371508210584710250"
+    "hash": "12919948715888755654003773996066082169"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u16",
-    "hash": "189306332556682082313810488315456031822"
+    "hash": "1563804127774067158715370171125999654731"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u16_slice",
-    "hash": "443334778298374210612780126360521930261"
+    "hash": "142186458445319615918853857663170536350"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u32",
-    "hash": "166683938939168448823723813880479002474"
+    "hash": "488903940943785014014909800688570702771"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u32_slice",
-    "hash": "1141109251371258719518150901468110049893"
+    "hash": "523719750247674573716756083305369684102"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u64",
-    "hash": "953108137971526991316970136591365453289"
+    "hash": "1208526509658323825572486734485265328"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u64_slice",
-    "hash": "60101527556627396089972012388302351098"
+    "hash": "258977265444447680518328616662913869862"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u8",
-    "hash": "783392222791828678717886677497209191088"
+    "hash": "45906627679052990812223475143960040222"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u8_slice",
-    "hash": "339919658640172275518069446552849815766"
+    "hash": "944906917096743308718411926111846286015"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_unit",
-    "hash": "104268905733119846525120193697400299738"
+    "hash": "1207300024410842280217524321813629389570"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_usize",
-    "hash": "12763337541174542385663017195468360618"
+    "hash": "155011682756778884712754229304721564840"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_usize_slice",
-    "hash": "926660397466653154117171879137181941792"
+    "hash": "157111091647613146868926855852633376572"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_cast_unit",
-    "hash": "72679433664304965910037016317421381802"
+    "hash": "28478568544649681599836889796705183089"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_dyn",
-    "hash": "40109375984461863131946764651169832155"
+    "hash": "1835058917417551263010754329110216464106"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_dyn",
-    "hash": "121346300789475636561207885541643122662"
+    "hash": "4906062050927098689917698203352900675"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_fixed_offset",
-    "hash": "86042762092653700713576906930935038082"
+    "hash": "1551630612805190232010147968108927369606"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i128",
-    "hash": "53248487735086434711357569095973294968"
+    "hash": "773810933942820959314835887217808837426"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i128_arr",
-    "hash": "49008075453693233352988149037724470064"
+    "hash": "125063428547612043689309526511430138039"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i128_slice",
-    "hash": "136895748299023794666709439541180895217"
+    "hash": "80223564512711038294317750865998730182"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i16",
-    "hash": "119446623548266856707244925103191928788"
+    "hash": "1457955831293470741216170682454339668830"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i16_arr",
-    "hash": "894507300465843276214180381811796603239"
+    "hash": "596590458125162300311553079272015797676"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i16_slice",
-    "hash": "1197639240487100715015218095983614466634"
+    "hash": "1272487943177778607017165711260323282087"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i32",
-    "hash": "102555548327468646971306992801013232392"
+    "hash": "906765415368293307816308137356490893356"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i32_arr",
-    "hash": "1122545148513966440713074632776670784953"
+    "hash": "28950829728835720316628604590829414402"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i32_slice",
-    "hash": "17591358447729644713322981758042862485"
+    "hash": "66161310415961208032023596242747228601"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i64",
-    "hash": "1739311261132231535154594698936762515"
+    "hash": "593087626995658673211682002602489979201"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i64_arr",
-    "hash": "3791104449404982339109291074276444393"
+    "hash": "1460726440485716476813667388363860990388"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i64_slice",
-    "hash": "934510236137214110418142349091641346800"
+    "hash": "48381501621481187017900992593974890691"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i8",
-    "hash": "52556049259833840612525568879412974393"
+    "hash": "180591460056434020778345262995057190833"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i8_arr",
-    "hash": "50388699140277276392040260327835305022"
+    "hash": "649228195785470731517733531884611284298"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i8_slice",
-    "hash": "665023023313478959611365238578652252479"
+    "hash": "1083742636386536370917275455363967945875"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_isize",
-    "hash": "113328196949881191836255687627553712354"
+    "hash": "108499785470531989162275671783251699314"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_isize_arr",
-    "hash": "162835621402383805116664775077224111768"
+    "hash": "1230094214205434849711184149018189314054"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_isize_slice",
-    "hash": "80417396837266613167033338875329914220"
+    "hash": "47955991063541865231508319219645985205"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_1",
-    "hash": "87574890931237950617753701139683137158"
+    "hash": "117813417602418952688806188019676385725"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_1_arr",
-    "hash": "67130541617817303044604626871381974563"
+    "hash": "132640293410324597588002821909435561320"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_2",
-    "hash": "124848756233338661115317919016791591894"
+    "hash": "1116251429364132508418373479365929917559"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_2_arr",
-    "hash": "148371786174045930272564359394642540455"
+    "hash": "554577578789205438611043453099967299968"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_3",
-    "hash": "76978277129044061639218017540571271039"
+    "hash": "105986825419462071646303644009878133905"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_3_arr",
-    "hash": "84782725157261381336347655037473532124"
+    "hash": "103243424484260032659235256203355038019"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_4",
-    "hash": "793557815986676956014572936229372059636"
+    "hash": "163883526145883047593380605546680146410"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_4_arr",
-    "hash": "1543516562768406995111271452320850582192"
+    "hash": "352006421110553064813003216492333656870"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u128",
-    "hash": "1372051797861326714663754467307104999"
+    "hash": "135619572731870267993027842624065766237"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u128_arr",
-    "hash": "6927362728319685519823952981896420177"
+    "hash": "1691232697121156622917895783751255301461"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u128_slice",
-    "hash": "177806543362526129619800873540376030947"
+    "hash": "176676570853450642283393797865118495208"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u16",
-    "hash": "92827774699949403698686861968249620927"
+    "hash": "1087076667242374655517327469520461870431"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u16_arr",
-    "hash": "44591165107676435659598892535891939492"
+    "hash": "448684070389875908210952198320177559940"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u16_slice",
-    "hash": "1703279426144374087415520094247924957829"
+    "hash": "566546874377286997716926219085016929696"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u32",
-    "hash": "36439214747960939826232859219629655478"
+    "hash": "1026560116735330114318236597746252203872"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u32_arr",
-    "hash": "184281469519399659792401799740020358484"
+    "hash": "92099506293022408252816003983231775844"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u32_slice",
-    "hash": "180289699031288650374491836304570662236"
+    "hash": "1308169265360620359711264606404317766323"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u64",
-    "hash": "724795515084080854016773156646655367464"
+    "hash": "58310225020683835655557336817624774758"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u64_arr",
-    "hash": "934426316301556350918382064150158837335"
+    "hash": "1333986093766900210810718495950299311174"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u64_slice",
-    "hash": "176154456308286077597393735356557289102"
+    "hash": "18023445917333222800361905004951951554"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u8",
-    "hash": "157494340762137603393295061976345970388"
+    "hash": "112352224093955504716941066644030021469"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u8_arr",
-    "hash": "5568289483562380903331917751499994900"
+    "hash": "125212181432941857658782468278419647390"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u8_slice",
-    "hash": "1463089805995044200917743169769473892255"
+    "hash": "1030962623015336635010665022901837103494"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_unit",
-    "hash": "102432282612520547583200950098303684487"
+    "hash": "56741440795001704683005549319303930732"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_usize",
-    "hash": "62710078182043370114913883805769982215"
+    "hash": "1473629308985840539817680236216656267722"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_usize_arr",
-    "hash": "216164551535881389015727265480956737900"
+    "hash": "137458818875369985209052947247905862112"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_usize_slice",
-    "hash": "6080792642595631748650954982055379796"
+    "hash": "96015555635929856182068620297039687276"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i128",
-    "hash": "454131717359372835811693493765943701931"
+    "hash": "1910330331926052916828389682967832380"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i128_slice",
-    "hash": "114684554212813750583127302168618931167"
+    "hash": "129031611576925560251966061767479696531"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i16",
-    "hash": "127341729045954790715457672629503672817"
+    "hash": "155782980783901851581441734508951074734"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i16_slice",
-    "hash": "8736554062049458499914036613142431838"
+    "hash": "228793104886810141113999610691937853151"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i32",
-    "hash": "450498847782472301710583156506992649767"
+    "hash": "21663825259583796899009136752067207193"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i32_slice",
-    "hash": "1309697691443808238714693776794607164687"
+    "hash": "46074851496994633232952085978508747390"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i64",
-    "hash": "21927460298032175147643728055614374783"
+    "hash": "820142145608203744615249611030587596989"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i64_slice",
-    "hash": "581648473891084257511531235591359881754"
+    "hash": "52337851546867762196619885992909618052"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i8",
-    "hash": "95758815325064901038058854643170093415"
+    "hash": "433846513877232044912834959351008426376"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i8_slice",
-    "hash": "1357485938052032401910181783362239229998"
+    "hash": "1636771846880150689311892342491634384682"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_isize",
-    "hash": "6575241154557537694412693981599880274"
+    "hash": "13480201492507363951190825856854697380"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_isize_slice",
-    "hash": "98343184570553121091313744070836329764"
+    "hash": "1702985597226491730555608818970817197"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_1",
-    "hash": "24620011161540116398919672931937637529"
+    "hash": "2329751326812624158999165343367774491"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_2",
-    "hash": "43942161010382635279009669348680678166"
+    "hash": "941058816964801151417261630491075883498"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_3",
-    "hash": "672246196723218528914702736793713075658"
+    "hash": "65943116074395230139049357317079071934"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_4",
-    "hash": "1502924923678749485910362119972055496469"
+    "hash": "1576704497289968190415915609754627248157"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u128",
-    "hash": "105639172785129663804219869990989668410"
+    "hash": "32177357125168474802807922652531491385"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u128_slice",
-    "hash": "29084144641832115058777247363945394591"
+    "hash": "131075692591483309242295552546326448701"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u16",
-    "hash": "135452323624709616413124417796549578018"
+    "hash": "142950817786484130608710475451369688314"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u16_slice",
-    "hash": "18779809690410943413589593046653088128"
+    "hash": "4749325290539070450833041482529914994"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u32",
-    "hash": "1741344153480102745212932670127002312776"
+    "hash": "926827913134031611217076026170267660805"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u32_slice",
-    "hash": "157784278016234339086795023402810522877"
+    "hash": "114790759205998243913762138274317811631"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u64",
-    "hash": "12325661335996963207053572713933332229"
+    "hash": "646997786206240982916235780542756061768"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u64_slice",
-    "hash": "130887298470579432411135356026019851331"
+    "hash": "1398703184371098096316343772329021451218"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u8",
-    "hash": "78594647127364731372032063570121040429"
+    "hash": "1509342001293340141817698622083449497718"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u8_slice",
-    "hash": "104196611985598767873124401960092430022"
+    "hash": "150790693171954153687493086528819773691"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_unit",
-    "hash": "56422243238568459396939997079496025912"
+    "hash": "1723629025495896085912811545360423108134"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_unit_invalid_count",
-    "hash": "329818862583333159216745648847028231354"
+    "hash": "199393505885455949367757821260279202"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_usize",
-    "hash": "444049558116081275212661906629890657973"
+    "hash": "1825310201233115310111507980843608481139"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_usize_slice",
-    "hash": "1515561819749321575013507412201550578746"
+    "hash": "1020803234580360337212713001547399844561"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_dyn",
-    "hash": "62163144194216857402720029388064333408"
+    "hash": "685499241201413299014279389924740293593"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i128",
-    "hash": "335866384141074556510768482553929118587"
+    "hash": "83604550640178848089956772279027965848"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i128_slice",
-    "hash": "1272709509453437402413655174223862784601"
+    "hash": "1165224262270679206717335208861136059655"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i16",
-    "hash": "1834737111203416726312344928493007125532"
+    "hash": "108463181042920253316360602960857423922"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i16_slice",
-    "hash": "1157450651537014636110210569142402638734"
+    "hash": "81595698048129681949411320313068702877"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i32",
-    "hash": "86185297137116787126546325256588841560"
+    "hash": "143974620856651237477985265226193924775"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i32_slice",
-    "hash": "142382702112499467506449811647263392064"
+    "hash": "66817998669704091141599728397343326930"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i64",
-    "hash": "152690289695794186975008903113650483445"
+    "hash": "11449230639520295205570285654377029269"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i64_slice",
-    "hash": "108879466860163261081788904314322777513"
+    "hash": "91562201282436633541462256845460852585"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i8",
-    "hash": "130400700939603778815419371270293866497"
+    "hash": "155588123127870753703576965879687464415"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i8_slice",
-    "hash": "1388766461772571065212565705961371868772"
+    "hash": "79245413885804041948254209423716335976"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_isize",
-    "hash": "83795140216574369704707694915005872251"
+    "hash": "1340648806503170068318164292662838149392"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_isize_slice",
-    "hash": "805419656682353809314950803784257463712"
+    "hash": "63756406089363154914337182629998304028"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_1",
-    "hash": "1661692600724467351010522731220070637198"
+    "hash": "107834115247428803878992653933478160694"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_2",
-    "hash": "179785851543915821742506699667089309540"
+    "hash": "1154007723717721260817132116036508418656"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_3",
-    "hash": "1784875982872086567211575071731553797748"
+    "hash": "169955309878546801391529479940081275896"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_4",
-    "hash": "17754108342010230412920869484544326530"
+    "hash": "1457426870049344943118049717761291888213"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u128",
-    "hash": "122359974852417625328824796914879049414"
+    "hash": "72121784230212368089810156915195956082"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u128_slice",
-    "hash": "807129096864775184410741761507488487631"
+    "hash": "5341746813015391941791096873640329252"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u16",
-    "hash": "1803989804728501715211530540489200940576"
+    "hash": "156008023474602482086828738113289952993"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u16_slice",
-    "hash": "42967478929081058393263715837834891844"
+    "hash": "26229656160457705094742015135488887690"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u32",
-    "hash": "175697470240320147214313845433282838374"
+    "hash": "549541522723793237917475515325557797030"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u32_slice",
-    "hash": "181593430042015998773394229276948461919"
+    "hash": "81682673775017842135820659741987199599"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u64",
-    "hash": "657394553962587845912613405109275179027"
+    "hash": "98270155466324263413192210241768655573"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u64_slice",
-    "hash": "93546504414135550416319293771510446731"
+    "hash": "63944416734581842110500530764467277455"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u8",
-    "hash": "18804186772860826068890466451219588102"
+    "hash": "744029502985405753911884368139070963937"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u8_slice",
-    "hash": "17495571747323468616923393770914744523"
+    "hash": "581615646397329590913586718629668549085"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_unit",
-    "hash": "657092135948639082412761214202685750597"
+    "hash": "989434848373370956713437013889901852484"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_usize",
-    "hash": "54182611523797391643286971384532957395"
+    "hash": "161979279841183529427197669781397380404"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_usize_slice",
-    "hash": "2413643927284753662169917047484514505"
+    "hash": "167113946419389663476318225502277710308"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i128",
-    "hash": "88877851959119872683325496227993798334"
+    "hash": "696330027754939415610973163619045301856"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i128_array",
-    "hash": "78844825596471269886641008542805107885"
+    "hash": "320046556803928865415240636144773120077"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i16",
-    "hash": "481032140060310773713474973687865728740"
+    "hash": "150606427166329197797895759708103637254"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i16_array",
-    "hash": "698578439128549941016722498924209206265"
+    "hash": "20397655445667446785771780278628742492"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i32",
-    "hash": "585758978641009299417863445189723379255"
+    "hash": "65856155161561582171095734428860020503"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i32_array",
-    "hash": "1302787617493865871511277635616361084436"
+    "hash": "30079548507387035617337894992899228944"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i64",
-    "hash": "1714994365811903060517270279872026419846"
+    "hash": "23540607517088129467122533754865787245"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i64_array",
-    "hash": "176494832326003514501548294724549063666"
+    "hash": "63055882321720892384647439101507307499"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i8",
-    "hash": "146895324508417870971865801588979059768"
+    "hash": "137907942831238196613889307241347315989"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i8_array",
-    "hash": "857849120599855269514941424056884585183"
+    "hash": "1563695798627120356610677362867898119808"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_isize",
-    "hash": "68306791852743917296077456685335864782"
+    "hash": "771834964383278062313076878891557114524"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_isize_array",
-    "hash": "45607934530354105315410050186369032403"
+    "hash": "22210192262208719015301226477131810739"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_1",
-    "hash": "77720282134694234297263165939769047365"
+    "hash": "100131432203728521725087474597045316748"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_1_array",
-    "hash": "668262908442825412312275248984583861278"
+    "hash": "267886848787388445217033830866192295424"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_2",
-    "hash": "62489879601054675855858870882349270772"
+    "hash": "81362249798990447267426899046078815531"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_2_array",
-    "hash": "237706028039931232613898826959332314562"
+    "hash": "6939101351419100211851390575594450982"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_3",
-    "hash": "934493123050304370912019451717172864966"
+    "hash": "84995588211998038412858284209320709609"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_3_array",
-    "hash": "115735363330376889943330801591689117096"
+    "hash": "1156158038373211064912532679233850792198"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_4",
-    "hash": "137502461968767924231169231791461375274"
+    "hash": "121988653635646154485197541456002255483"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_4_array",
-    "hash": "33710139911346370571154067611413434055"
+    "hash": "1408107114683912708417045376472953107633"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u128",
-    "hash": "229346494923256319817305675350834296821"
+    "hash": "138758222218124490928363292866016394059"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u128_array",
-    "hash": "70936551213287971763712925279344262257"
+    "hash": "12284458368572986965809734534483035892"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u16",
-    "hash": "78950729562529615622768970282430817318"
+    "hash": "25681143599162751987519049878934121912"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u16_array",
-    "hash": "705486316655619288014403321880647104715"
+    "hash": "38041309770090316718574509880847518222"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u32",
-    "hash": "765393315126086176611441037139591534266"
+    "hash": "7174848411798694731859142735107059733"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u32_array",
-    "hash": "1074690491714079624215851346142255997292"
+    "hash": "13906670009720986705907170232984858699"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u64",
-    "hash": "10392892426136338104990723193413363238"
+    "hash": "144038172703939731065440722233071241084"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u64_array",
-    "hash": "160788960388425286248683034632333253648"
+    "hash": "28161698278387946905387260813669003135"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u8",
-    "hash": "144132621553293764617067815214068604299"
+    "hash": "9450172207666873852812715370360718465"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u8_array",
-    "hash": "1824781798770686997606129081765319192"
+    "hash": "1160234633774975056014082442722115523905"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_unit",
-    "hash": "389435815582681361218120354073453159932"
+    "hash": "937138538081775379910592330601517320431"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_usize",
-    "hash": "1696963768541727100918115778766531982274"
+    "hash": "155850881876130710638577990712673459632"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_usize_array",
-    "hash": "130921406778700730231927693270944881243"
+    "hash": "49995078997867405197939686001821891290"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i128",
-    "hash": "34176213537842957814439550225174964302"
+    "hash": "342297942028408888614426175389179468375"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i16",
-    "hash": "198423755668160197411632055481549512953"
+    "hash": "131170885190113449154612935636619492156"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i32",
-    "hash": "155675214849733935707950547923039337069"
+    "hash": "151234693796664654109208671075843736025"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i64",
-    "hash": "31936714096094526515740399568581821119"
+    "hash": "44987024146370819526821790460913703318"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i8",
-    "hash": "63031679161014359132993224700757945165"
+    "hash": "143036525782206426462550036788768746085"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_isize",
-    "hash": "10511275438415517086807574380262679421"
+    "hash": "23588512857460175112975557656485165236"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i128",
-    "hash": "157652756192003225366566707289406449167"
+    "hash": "1829644626460140164712446958817622255190"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i16",
-    "hash": "949427345742438400418120822823440110332"
+    "hash": "161165455145932633312171030194730753563"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i32",
-    "hash": "110839555540109883581248127228736085051"
+    "hash": "38146875261490773272460783063837140559"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i64",
-    "hash": "32227542606150810685806035679235357426"
+    "hash": "144247344730558130672417280294647136993"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i8",
-    "hash": "540095076610041761916169922480133347802"
+    "hash": "666257739913538417514440259874473640717"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_isize",
-    "hash": "1518868431082337523015255103141803595491"
+    "hash": "942132168032893925810502590614237644270"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_1",
-    "hash": "16724054122296093606124649726759586979"
+    "hash": "33031491353698206727018722972964413146"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_2",
-    "hash": "41629929209814401876386847388370543162"
+    "hash": "641747281272355769714405609866831979408"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_3",
-    "hash": "161202864113092848123709346586611639219"
+    "hash": "561676556624499788311616801984046741952"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_4",
-    "hash": "41327381205890663224526759226402389713"
+    "hash": "100772350851368504809679870021583735591"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u128",
-    "hash": "119989811314778445052828940373004436468"
+    "hash": "841590687930190866710615284243430953440"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u16",
-    "hash": "1266004043685367220712988147043930065995"
+    "hash": "478941332451605578211236748745517833810"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u32",
-    "hash": "137454801878025648914651963543523785654"
+    "hash": "332898925731662075315036006947789339179"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u64",
-    "hash": "141540139310910335517336662841698981491"
+    "hash": "65533855003569914921311214969805518014"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u8",
-    "hash": "357865219362546065514013606194565609150"
+    "hash": "1544286333619572567814652059518607937057"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_usize",
-    "hash": "40387199117608303189208154010921805259"
+    "hash": "360851794473655393510973221611910750737"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_1",
-    "hash": "10529911052758982216247476843061773865"
+    "hash": "43335879533910215869965959583301153136"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_2",
-    "hash": "157287007359659382254551602317722049895"
+    "hash": "112317403894261351334569252659277526505"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_3",
-    "hash": "35726856699162475134144920114343932998"
+    "hash": "241883408283601034214594377984433021616"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_4",
-    "hash": "182439896619015366513152599822641379750"
+    "hash": "7008214705175512396151918896898952314"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u128",
-    "hash": "6442793723563713828955550294309758797"
+    "hash": "564697472954438498040905650870305465"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u16",
-    "hash": "1160367840163600043115073922749875484407"
+    "hash": "1284034644309072776513543653864590702721"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u32",
-    "hash": "1162130782304978194813981706431862336590"
+    "hash": "1038019907179383920910767445894761965860"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u64",
-    "hash": "573177967650711070716906444976510692110"
+    "hash": "601534251925469966017230420898098136817"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_unit",
-    "hash": "188868274262120573712869464707927741472"
+    "hash": "1343499633561958719216312093127935499377"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_usize",
-    "hash": "818701120752323608618061751262758239071"
+    "hash": "1311633000986359466510844268511730382407"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i128",
-    "hash": "341627976428751505217108013742730714171"
+    "hash": "53515973524772126099809813663984316182"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i16",
-    "hash": "145958809671978417741796555322743872781"
+    "hash": "102731795500303462884662222854933067687"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i32",
-    "hash": "92437944048307452085859428575062584497"
+    "hash": "1047904007183775896917977155463355742015"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i64",
-    "hash": "15938229365298027913493691509589598681"
+    "hash": "6078851829207035068012998111768316169"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i8",
-    "hash": "1746796774868030296214109603810663411253"
+    "hash": "154614750220985907048027616304357126952"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_isize",
-    "hash": "913178227069576976513501173723279644587"
+    "hash": "96117709829946262573914095391152566019"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i128",
-    "hash": "180101527294625984148758618638639746835"
+    "hash": "871304017093762009018116702986368762378"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i16",
-    "hash": "127080766779991542712704050872249092329"
+    "hash": "1246520703659192194915786681091136905211"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i32",
-    "hash": "879368742341422893418254324789155947037"
+    "hash": "323568299347352418212714880423520279779"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i64",
-    "hash": "3644772464759090577658637723771986821"
+    "hash": "81195297590536281096553452827892190225"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i8",
-    "hash": "8588818133964134668070416555090580328"
+    "hash": "27567117371593721988910965939891564342"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_isize",
-    "hash": "41930633413595137895387460614146574914"
+    "hash": "37538580242024948001760762929801132953"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_1",
-    "hash": "781441124919869554416502189132605279844"
+    "hash": "1036849070921420154425286441590850762"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_2",
-    "hash": "61132976871941369104591310354676192835"
+    "hash": "76524844457558993275757415700711152381"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_3",
-    "hash": "92710387544780106501133015214626088140"
+    "hash": "132245124082063489842699929864920591991"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_4",
-    "hash": "96302013474733976217822527100873564280"
+    "hash": "246824732937089328118210926653494998810"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u128",
-    "hash": "81622547885180210229772679766098623960"
+    "hash": "22256670217093282455593958890864417657"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u16",
-    "hash": "19944365617265444641235592071625836321"
+    "hash": "155568371230529961942778040329780186932"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u32",
-    "hash": "16915764259506228428020641737851528130"
+    "hash": "1810142310043796914211793807887989025773"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u64",
-    "hash": "1694174951488200727670769355079432817"
+    "hash": "949557835961934931111658023066847504564"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u8",
-    "hash": "1736751304106843223716931371578427299615"
+    "hash": "459647931013415320816189434738065836126"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_usize",
-    "hash": "1632063388415339290211855231845129212627"
+    "hash": "621497648495597624313404973672577869674"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_1",
-    "hash": "68779461610473718578176483796119262064"
+    "hash": "121069607916912823268076390633255771343"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_2",
-    "hash": "1567955632154993140914762349094981139635"
+    "hash": "147885621044826007742982464454731519290"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_3",
-    "hash": "1801224950679635015517885629536356276538"
+    "hash": "11388766935340300958722031783404127462"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_4",
-    "hash": "1263671002415910184812995388235590456204"
+    "hash": "86474300757032917911193537949585957096"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u128",
-    "hash": "98676360285596856122893252365742821878"
+    "hash": "17225502781240651991333716840023576463"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u16",
-    "hash": "632503239863003576011089365060925551304"
+    "hash": "183920116284916685544544522612898172481"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u32",
-    "hash": "12624980082881436920571132781402339701"
+    "hash": "924897042041410971413047136540409708212"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u64",
-    "hash": "81956476375626376201529993607137271305"
+    "hash": "122075905858217951714800812011605116990"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_unit",
-    "hash": "982021487992632128389586496515652292"
+    "hash": "121050462169381801815491316251320942315"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_usize",
-    "hash": "1812235887773585394216190575095297600349"
+    "hash": "161953534078468840428887386176312359328"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_add_dangling_proof",
-    "hash": "1747298681486910475816726743755067658898"
+    "hash": "17444228336824189752462070142785648621"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_add_proof",
-    "hash": "1579887565423392023912766034399471615858"
+    "hash": "688322228492094239816178455094697432491"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_offset_from_dangling_proof",
-    "hash": "348717468479167218713843361344884722064"
+    "hash": "19580315731511462611427111561444119966"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_offset_from_proof",
-    "hash": "1098922922670129613214590088607032461213"
+    "hash": "1649526097990842950717454622885167174503"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_offset_proof",
-    "hash": "1603514863278245643415125165189311626919"
+    "hash": "1143363275365724994317774081066302298418"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_add",
-    "hash": "107157012980315669817514695998874878698"
+    "hash": "16290436647856014989817137363585617253"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_addr",
-    "hash": "73749130171920277746895880475102142147"
+    "hash": "130100253621390112181785825687195458913"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_align_offset",
-    "hash": "9718814348386585608996232064151130741"
+    "hash": "899711308647752674210289638917477681096"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_align_offset_negative",
-    "hash": "40761669962769985826884235235170685339"
+    "hash": "9462321022686435794067035520796360821"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_mut",
-    "hash": "61832168037305662226151216037272025262"
+    "hash": "13813496740395743749445444418474008631"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_mut_ptr",
-    "hash": "45158695316660810675881326582926885559"
+    "hash": "857360611764458586316400947437482018742"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_non_null_ptr",
-    "hash": "1430875310159020512510747736760781895804"
+    "hash": "10371168902957988945924414347535950406"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_ptr",
-    "hash": "54303012363649167618320663668216943270"
+    "hash": "406211520990736106713608909895640994528"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_ref",
-    "hash": "70471356695599362813179690735992408029"
+    "hash": "619531733527696458413551874090283331066"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_mut",
-    "hash": "1747131982949722268314734395930541090813"
+    "hash": "1652300581698948207218103258133122044626"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_ref",
-    "hash": "40778229744204218142977567990097323398"
+    "hash": "110928428641917351463649959873205781374"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_slice",
-    "hash": "6155879628434304465225367274103505255"
+    "hash": "777032401298734572013591599564925974407"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_slice_mut",
-    "hash": "1526326320573611530510845467282402783903"
+    "hash": "152269218973942662159375054821869651851"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_byte_sub",
-    "hash": "51935963327726248642342784902589865795"
+    "hash": "462026359248805334511098533231595459357"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_cast",
-    "hash": "342796496168384324312428470851097519583"
+    "hash": "66796354811321158495112179015015031606"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_from",
-    "hash": "1044284009250301634515113316838429765962"
+    "hash": "54733754020344580596252035163308027248"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_from_nonoverlapping",
-    "hash": "251463311196613623611201956951013921811"
+    "hash": "149353816556169971149326628926616715752"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_to",
-    "hash": "372285907565593037710677712597518060347"
+    "hash": "1655044573647971024013783701378533294810"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_to_nonoverlapping",
-    "hash": "1600953319613678393114813525235320289637"
+    "hash": "79797449618343173524788375028097738719"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_drop_in_place",
-    "hash": "833119382969450938414885940204520736379"
+    "hash": "132526314002287367942726372009918337399"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_from_raw_part_trait",
-    "hash": "720928737188636636814545206971351089656"
+    "hash": "62719145474213895231309511448133981929"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_get_unchecked_mut",
-    "hash": "117486130024486173049454652198656781666"
+    "hash": "106963626207943753082859438296894253071"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_is_aligned_to",
-    "hash": "119866710655772248174294157214312042051"
+    "hash": "51915470283033776771254875377328973860"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_is_aligned_to_no_power_two",
-    "hash": "177665352612592310238447279524841092379"
+    "hash": "1193426965199182770513267545627407449155"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_is_empty",
-    "hash": "64992349610206906493972609669430293672"
+    "hash": "650993329988601024316868010019321568689"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_len",
-    "hash": "57244469530576191003984485934283563932"
+    "hash": "587575833008383151814788621552248117934"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_map_addr",
-    "hash": "122402408817049489017569871722363203417"
+    "hash": "53223000933562797711415405765070791107"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_new",
-    "hash": "13499313909562794569050386619764562768"
+    "hash": "17521120372762346568515825715402127334"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_new_unchecked",
-    "hash": "64184252177853553687165725130196342524"
+    "hash": "908166559499485195815456486536707007835"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_offset",
-    "hash": "1430799571502227858214068548952047478138"
+    "hash": "1764019790125179662215336128208067258029"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_offset_from",
-    "hash": "692636254821948565615536593488076397385"
+    "hash": "95324036043828150932077367757957872696"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_read",
-    "hash": "851755023256382660111384685700353402341"
+    "hash": "115000884303785821355970415659381405684"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_read_unaligned",
-    "hash": "166297787229119087874584936186230752436"
+    "hash": "725090587249524681813448623708682126364"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_read_volatile",
-    "hash": "854490041449606109115330206530653654003"
+    "hash": "1599875538626405725311715573862035875608"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_replace",
-    "hash": "12181502269707053472181624239566552065"
+    "hash": "144112023863817061998145523039525579167"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_slice_from_raw_parts",
-    "hash": "134779604878960724428885797167447727063"
+    "hash": "74565718190414701195564310526915324843"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_sub",
-    "hash": "107511771081490894503899211715429222877"
+    "hash": "1157769923303971431911864449214761345412"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_sub_ptr",
-    "hash": "1679634702483926906113785645270600412418"
+    "hash": "103963999094906981114552715994221120536"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_swap",
-    "hash": "1584325256965804149516102277019228176548"
+    "hash": "627299795047352134412446865530311703884"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_to_raw_parts",
-    "hash": "333386655064828718114345860663805163521"
+    "hash": "115538306409906544082055894187275012032"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_with_addr",
-    "hash": "1260418369259312175413835785129909860466"
+    "hash": "127140607740334852803137579698959963243"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i128",
-    "hash": "32134058635352782931866765010946807685"
+    "hash": "91575577108022156916268791278579950556"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i16",
-    "hash": "296859307844560924116780550673909048904"
+    "hash": "103568027113157008827999270500042765037"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i32",
-    "hash": "57071385859858181898463833311451810780"
+    "hash": "20661108709668732256293801414653003764"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i64",
-    "hash": "1254583894498796787934402120685081129"
+    "hash": "293901113092381325210927600960169238794"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i8",
-    "hash": "1376397961654530514710188956824610611921"
+    "hash": "153061836221569423856873460427559615720"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_isize",
-    "hash": "1026068410662060630313772539566432512952"
+    "hash": "180448014908894164434758409061384629888"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u128",
-    "hash": "17932086107077254426181753444098387203"
+    "hash": "21805169767628883947481310890595666888"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u16",
-    "hash": "8422488275800112025831466780014806728"
+    "hash": "82443077272052247846951813109381783468"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u32",
-    "hash": "9139453833036456836350178314384186960"
+    "hash": "507432105738532318512436752528878551826"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u64",
-    "hash": "638268871256266049313305943232860351226"
+    "hash": "1431237536933348024511746759760755141"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u8",
-    "hash": "348611778153520057114744393324966825616"
+    "hash": "1079952583824377863215712760609827153860"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_unit",
-    "hash": "67091213483378712634923995303548131700"
+    "hash": "49519980084043249510379016134201604358"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_usize",
-    "hash": "59268293925322015822070410127716314099"
+    "hash": "28260867926805741748709533083639929975"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i128",
-    "hash": "180467279781298655727177085399030198562"
+    "hash": "627497896926534675911786564102703592370"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i16",
-    "hash": "1430476498542536689214724281062428978806"
+    "hash": "510685557569134157413474083430223772366"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i32",
-    "hash": "1332871670278172055918013401422897437373"
+    "hash": "160688257063881335105110729760506197269"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i64",
-    "hash": "59535126947856545917815076042086058939"
+    "hash": "89188822709348200109568438550846431327"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i8",
-    "hash": "138830679896852037269858826665506679596"
+    "hash": "90854812953061008936232673928105088144"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_isize",
-    "hash": "10328200052592827512867520615350185469"
+    "hash": "873687152640555328014131108511130757201"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u128",
-    "hash": "1268682461100987917957169479927943402"
+    "hash": "1247573117722118737217428406871960870474"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u16",
-    "hash": "166237685685537748367906308768232129843"
+    "hash": "8882961879931188168043518158103491452"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u32",
-    "hash": "78225775701922819363925440995856837037"
+    "hash": "178637850681288067503018430366170158444"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u64",
-    "hash": "62621594732464581416564918563724275442"
+    "hash": "115186980366116065665164491637128764872"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u8",
-    "hash": "170557890060617080135350622761273930062"
+    "hash": "1630010274961526850411528747005978082826"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i128",
-    "hash": "95982496510494095811360893493241944512"
+    "hash": "11954152142164409841190183283971885701"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i16",
-    "hash": "1329541734850133912814961814113369895703"
+    "hash": "871085769247702071017079140238082168775"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i32",
-    "hash": "5003943964297149222709546678963714000"
+    "hash": "153060554615101494609090688107958964838"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i64",
-    "hash": "166843234667500978567563125999510491671"
+    "hash": "1700984225148229216217459680770160883687"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i8",
-    "hash": "621682731602593580016321504711699906354"
+    "hash": "181053913874059441179839838122752939112"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_isize",
-    "hash": "129615871933134743014745173520838036829"
+    "hash": "240150359145394492513370403914282032158"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u128",
-    "hash": "868448858850195715412134944073697606388"
+    "hash": "1827406137713049807614524741067234695419"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u16",
-    "hash": "652370322423207672414287470446105805855"
+    "hash": "138015948936209957227410876136437988497"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u32",
-    "hash": "575246318325320249512530746546845860814"
+    "hash": "1075625232786893911210704714514917782996"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u64",
-    "hash": "58040466875078911655341618928082059622"
+    "hash": "41108727694476257369757419566782510827"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u8",
-    "hash": "26673647802629224667168836089929973138"
+    "hash": "1834696523156267051818164975869941263709"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_unit",
-    "hash": "141753337997269697372751668072179365752"
+    "hash": "382239763175345238114199938498740380176"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_usize",
-    "hash": "42673777719291574245463675027090948832"
+    "hash": "11511995503683118213179084667509984973"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unit",
-    "hash": "689324134787994935411326758909638214250"
+    "hash": "685693598824122000317563499524932000839"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_usize",
-    "hash": "177914902475674915364731627082095414526"
+    "hash": "577171121015011454511277102605466952275"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i128",
-    "hash": "174775390741014390053405165315561568388"
+    "hash": "1722435117845618230213492687996994847938"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i16",
-    "hash": "142048866353554846294577566982689378227"
+    "hash": "335028472216190024715413638883930445334"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i32",
-    "hash": "364541460912482096511935142866566376635"
+    "hash": "6082716670180213963510436597096387100"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i64",
-    "hash": "35220241851420753863538125456005285252"
+    "hash": "896212000170520464816349637334191859368"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i8",
-    "hash": "1810558908056158921011800822272515584988"
+    "hash": "163755686889880640232021432650944323562"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_isize",
-    "hash": "43258784523514452412395693425572446803"
+    "hash": "1517395270487077959115712092473454002747"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u128",
-    "hash": "1833114452296479351113560235388169590691"
+    "hash": "303008628392884888415706272720131993870"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u16",
-    "hash": "27919533875916407864293660286152662452"
+    "hash": "50652784218102479368028266008966530396"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u32",
-    "hash": "707277323632466299412010852321864874537"
+    "hash": "63391428371796542075402026246876572896"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u64",
-    "hash": "1790507493767768924411798306207647705741"
+    "hash": "52992264035800884721141461565176709179"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u8",
-    "hash": "1367128918803930320516622420299129366868"
+    "hash": "117386878272532511233336338922894740991"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_unit",
-    "hash": "462689983539327928214161524900208112210"
+    "hash": "22907383900765150436307750156242526689"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_usize",
-    "hash": "11851342108536372684371000905120299841"
+    "hash": "392753272968129194311093433146012854075"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_slice_is_aligned_check",
-    "hash": "40633048495016183856590486397510222258"
+    "hash": "1499524989893243890014154430666720704943"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_mut",
-    "hash": "117777470482487681418711445947373028094"
+    "hash": "249237478728842833512931658291975139572"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_non_null_ptr",
-    "hash": "41546644467610812826556990811979766638"
+    "hash": "341214187713778708014448450233072314022"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_ptr",
-    "hash": "105716617228133269097545665373400629820"
+    "hash": "627543795123301268410300122295889486491"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_ref",
-    "hash": "127164979549636140754680316738684717863"
+    "hash": "78429416892213296752188951542999756445"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_cast",
-    "hash": "376399865093847840911486449165911927626"
+    "hash": "160066752515252673613075721758359155604"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_new",
-    "hash": "1811613836314477174014808888154227993594"
+    "hash": "536549931544590665715591448789303473354"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_new_unchecked",
-    "hash": "775688553481186341716842585442130327801"
+    "hash": "11792335716319747321464545802227063805"
   },
   {
     "file": "core/src/slice/ascii.rs",
@@ -35228,12 +35228,12 @@
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::into_slice_range",
-    "hash": "78298200851685132247937481372256502560"
+    "hash": "1771666983195198680614983471265562396840"
   },
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::slice_end_index_len_fail",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/slice/index.rs",
@@ -35243,12 +35243,12 @@
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::slice_index_order_fail",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::slice_start_index_len_fail",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/slice/index.rs",
@@ -35258,362 +35258,362 @@
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_advance_back_by",
-    "hash": "139960570267927240949348611761291084600"
+    "hash": "861193825345109948813089720648972906787"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_advance_by",
-    "hash": "1309057817691988006314702262891804976375"
+    "hash": "1670778179932011792813442940843828855245"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_as_ref",
-    "hash": "926682556241345506312163051434323132390"
+    "hash": "9959386809164438754797650497697958472"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_as_slice",
-    "hash": "1457065977724398083810289303087822832423"
+    "hash": "607366646519643514715930887699507572765"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_clone",
-    "hash": "1801947897244010041016543399008262150851"
+    "hash": "1160937473463700776216317998509853696780"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_count",
-    "hash": "1591515875709101590312754828776990510810"
+    "hash": "182686006598902093643207213533348293157"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_default",
-    "hash": "999083644885064169115198293980768460653"
+    "hash": "689024262283676454414806378541386781005"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_is_empty",
-    "hash": "6152498103849136889231032234458312146"
+    "hash": "139415941370266500607062419504683539775"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_len",
-    "hash": "39436383385921255449727394145828152670"
+    "hash": "77724262875764785311901059060696383431"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_new_iter",
-    "hash": "717135312299404984711624214677278132006"
+    "hash": "1106710886555791049713863830344245152268"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_next",
-    "hash": "4681238577650917222198948418260165679"
+    "hash": "1691512815652815021212302328761377296155"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_next_back",
-    "hash": "48781245646140790805774892762785351587"
+    "hash": "9986036763406714986274905766326357648"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_next_back_unchecked",
-    "hash": "15484039302876695458294835233151522666"
+    "hash": "181362399571023939208041318317975875458"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_nth",
-    "hash": "383362540475024558213313487005848360199"
+    "hash": "121448260041314614938788524596520728159"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_nth_back",
-    "hash": "115696503967776524089359898980160257142"
+    "hash": "1408277060550888397813794247984973571811"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_post_inc_start",
-    "hash": "1177562694201273835618163304661684189682"
+    "hash": "1579413168559714474012705852940355797207"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_pre_dec_end",
-    "hash": "61650113099800051494069438331221682505"
+    "hash": "14239161467851783514822119025666694103"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_size_hint",
-    "hash": "50662908790258032158359469751450748909"
+    "hash": "171216423171719021369467889126263287165"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_advance_back_by",
-    "hash": "40133445456369299273071626533770585779"
+    "hash": "1049285573602063975816299047434095817555"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_advance_by",
-    "hash": "651601209045912102715255523964833114571"
+    "hash": "437002137551840210015902403996207033731"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_as_ref",
-    "hash": "21909695368713357817695612970568892482"
+    "hash": "117572879190878403071879571059698923651"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_as_slice",
-    "hash": "528855900097586767710511857051576579181"
+    "hash": "980826399823350586512484238862321607659"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_clone",
-    "hash": "9846246607643053052789514921044984464"
+    "hash": "67093496659591607741578583704856335341"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_count",
-    "hash": "1653045920412370033015300333939554489388"
+    "hash": "105402093155095829192918972706724925533"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_default",
-    "hash": "1075998351906562772214479322133016367350"
+    "hash": "112298455367248753925305453929243918302"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_is_empty",
-    "hash": "102410585837662610115950926803305843021"
+    "hash": "1185895448689024974015149068870592553029"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_len",
-    "hash": "95715431604472015283308187542587460840"
+    "hash": "28939706369634289165941647701748045538"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_new_iter",
-    "hash": "1285913759582449692515380058014953662571"
+    "hash": "1087450656947339622912765726781414566543"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_next",
-    "hash": "84957580405337021201365146694210507223"
+    "hash": "37313375997344997746498023848647067728"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_next_back",
-    "hash": "85482122169895572032068531101973228073"
+    "hash": "236664686667593662110365496336110526255"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_next_back_unchecked",
-    "hash": "167466966316312125512869932547839091433"
+    "hash": "1444489025968958098510295303769005401376"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_nth",
-    "hash": "1545202723736073001917396090090063670479"
+    "hash": "325039137557135876910179121162131639917"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_nth_back",
-    "hash": "15637158173136528171813495242114393286"
+    "hash": "154424749971734828318751321680996551460"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_post_inc_start",
-    "hash": "112747279063842800792257971646037800721"
+    "hash": "1616096750031092521610002185566130323499"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_pre_dec_end",
-    "hash": "1366170040786291903816059907629628071342"
+    "hash": "2672411955581529994740371058722054295"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_size_hint",
-    "hash": "1088443821154933739617417714295520323034"
+    "hash": "9699979090301776414276302173311815806"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_advance_back_by",
-    "hash": "1192930982506545955415193187031921424780"
+    "hash": "702932305369103779817545920429915750735"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_advance_by",
-    "hash": "130067916773912073253886266873492517556"
+    "hash": "169664169634698344735561345216925582327"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_as_ref",
-    "hash": "150589989357585482237959232499075949290"
+    "hash": "144168449965293851717297037097010227984"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_as_slice",
-    "hash": "92599835409257960659625250199070740313"
+    "hash": "101420683250954631914211182879830547253"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_clone",
-    "hash": "1634310256637752416313360944456084972461"
+    "hash": "411129120005459309014805765740285704614"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_count",
-    "hash": "381309416641930447611150968155017654670"
+    "hash": "1673756569186294725167491445006872017"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_default",
-    "hash": "128779033045629232487927283503240826997"
+    "hash": "920793844495442519116442691044500546405"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_is_empty",
-    "hash": "97888119244611737003840594663805266788"
+    "hash": "1031106772079892408611873317942952288342"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_len",
-    "hash": "687367853629764229016655893279991307868"
+    "hash": "100700875500503558915463314157098448882"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_new_iter",
-    "hash": "54041149948734222331988398625368841087"
+    "hash": "26090114237370722466708667347746968499"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_next",
-    "hash": "15591669200241625746387550828422683912"
+    "hash": "3272200516801177579860716317359749912"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_next_back",
-    "hash": "995890544020765136617119862460993837548"
+    "hash": "144970422038065862193607669127509861875"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_next_back_unchecked",
-    "hash": "14927074434639219618962930259053910399"
+    "hash": "175668192865300339488956421570897967378"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_nth",
-    "hash": "1331049345454030817616498914778015109179"
+    "hash": "95261538399817912371018138249387025081"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_nth_back",
-    "hash": "1203911415862282050914618578822457764875"
+    "hash": "482996177165052312810211115389576048710"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_post_inc_start",
-    "hash": "43437479158756851533311982826149103324"
+    "hash": "14442271044432101054230574576855060467"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_pre_dec_end",
-    "hash": "117350661952814726778298880806192145512"
+    "hash": "701201682874368826814637929995934274484"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_size_hint",
-    "hash": "1452105519273497474711829791337138400260"
+    "hash": "1986195812432982307292979577292384340"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_advance_back_by",
-    "hash": "1319450465175723836714042634788934357650"
+    "hash": "59289172209692140598859425130274691571"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_advance_by",
-    "hash": "38748746669302612081496362059625460674"
+    "hash": "250751627071467107910051017301624274108"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_as_ref",
-    "hash": "1646840197862046133916036597784351519646"
+    "hash": "321753956908508752018055215308702696394"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_as_slice",
-    "hash": "54568006866825903489764784701601980103"
+    "hash": "166658351717011667126562228530403172939"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_clone",
-    "hash": "291579395175806939216167472074302694966"
+    "hash": "1143834142215882653916994141189293130237"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_count",
-    "hash": "112326932004283389794052149170527957029"
+    "hash": "976329539027784433516201922970075153385"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_default",
-    "hash": "15810731937134161356285501472461242442"
+    "hash": "137570939972685296873655141484901584115"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_is_empty",
-    "hash": "932691234413829325112747602551700290377"
+    "hash": "52895370479884907428549925094184928388"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_len",
-    "hash": "67515536971943221611815665861176245040"
+    "hash": "69433295534060245163690722234188956908"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_new_iter",
-    "hash": "1107343495967724937810712244816181142863"
+    "hash": "1363526272758237287610468468160399725276"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_next",
-    "hash": "137024524549345782609646547294141104007"
+    "hash": "714695668838906455815869473572060304162"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_next_back",
-    "hash": "377559293388697150516857112865751977461"
+    "hash": "163339030084672594421668058425984523499"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_next_back_unchecked",
-    "hash": "533750375490703866517399809458989611606"
+    "hash": "127686565998432334901061870083221359013"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_nth",
-    "hash": "4840223071120913377508715957732269887"
+    "hash": "957056633302437535015239756775690006328"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_nth_back",
-    "hash": "952746216976093671410410461366422685604"
+    "hash": "992938715268404881713353799456534831407"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_post_inc_start",
-    "hash": "147949041401349756155676307937369275603"
+    "hash": "34937320527431234211610005773948152242"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_pre_dec_end",
-    "hash": "164834321415149450095472617281390396901"
+    "hash": "125505802153987241316572113726374312358"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_size_hint",
-    "hash": "45193465255649134785767519228476047437"
+    "hash": "356765650748154173312519680647704146175"
   },
   {
     "file": "core/src/slice/memchr.rs",
@@ -35628,7 +35628,7 @@
   {
     "file": "core/src/slice/mod.rs",
     "func": "slice::<impl [T]>::copy_from_slice::len_mismatch_fail",
-    "hash": "488069662088004350112809738995584756183"
+    "hash": "403467134703471832816686528817990508081"
   },
   {
     "file": "core/src/slice/sort/shared/smallsort.rs",
@@ -35733,12 +35733,12 @@
   {
     "file": "core/src/str/pattern.rs",
     "func": "str::pattern::verify::check_small_slice_eq",
-    "hash": "135563978378385492726666353229377330358"
+    "hash": "845149562119932975814861053783379673808"
   },
   {
     "file": "core/src/str/pattern.rs",
     "func": "str::pattern::verify::check_small_slice_eq_empty",
-    "hash": "102185519891892527487327436954428029777"
+    "hash": "33048801839369517641966645982641812300"
   },
   {
     "file": "core/src/str/traits.rs",
@@ -35773,7 +35773,7 @@
   {
     "file": "core/src/str/validations.rs",
     "func": "str::validations::verify::check_run_utf8_validation",
-    "hash": "131730157332688882848860392945491271156"
+    "hash": "1123572387366226396713103407163803214385"
   },
   {
     "file": "core/src/sync/atomic.rs",
@@ -35953,12 +35953,12 @@
   {
     "file": "core/src/task/wake.rs",
     "func": "task::wake::LocalWaker::noop",
-    "hash": "123723638901198696813404341783633870945"
+    "hash": "472764338886095420117228579050597462206"
   },
   {
     "file": "core/src/task/wake.rs",
     "func": "task::wake::Waker::noop",
-    "hash": "1743661486992008159612291404162607195897"
+    "hash": "127674890129135189316270498950318572654"
   },
   {
     "file": "core/src/time.rs",
@@ -35968,52 +35968,52 @@
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Add>::add",
-    "hash": "109742324320271269815219537898058338298"
+    "hash": "158701123428408317577826621080364987225"
   },
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Div<u32>>::div",
-    "hash": "403531840734294633314980331633988740429"
+    "hash": "600791011295372228187675651585982260"
   },
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Mul<u32>>::mul",
-    "hash": "1576331431798425232510190777423442331905"
+    "hash": "27293571358936313059362992893665172166"
   },
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Sub>::sub",
-    "hash": "161313175365211766514626638849314671494"
+    "hash": "164576193882935509069664220587060101994"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::<impl ops::arith::Mul<time::Duration> for u32>::mul",
-    "hash": "917258847654041938512616888458549365289"
+    "hash": "17556818814875381251599312119355152158"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::abs_diff",
-    "hash": "1190008920955027549414558268300920333450"
+    "hash": "26869045586565505132860040768134625332"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_add",
-    "hash": "19569297159615508031460179401882422644"
+    "hash": "14110580735580096177824659522826889201"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_div",
-    "hash": "334853331962763434511377330919294441838"
+    "hash": "1674337126137678817717862049789526749597"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_mul",
-    "hash": "1270957039126496278514773072002857684554"
+    "hash": "337837089598643960014907234987613046925"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_sub",
-    "hash": "122792719157580155476280973011202309986"
+    "hash": "70865920824769009197052802876233687335"
   },
   {
     "file": "core/src/time.rs",
@@ -36028,12 +36028,12 @@
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::div_f32",
-    "hash": "86647618178726140729405028356674242646"
+    "hash": "991611201474977183716339654034856696260"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::div_f64",
-    "hash": "45140018449145166078195067686606542123"
+    "hash": "521199485861330628012445971557357911846"
   },
   {
     "file": "core/src/time.rs",
@@ -36073,12 +36073,12 @@
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::from_secs_f32",
-    "hash": "755374780160847799017297064596369900573"
+    "hash": "79953099556852880634104146821471070147"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::from_secs_f64",
-    "hash": "157098851599913139475304395198967799945"
+    "hash": "99203238549934975001889106857293051325"
   },
   {
     "file": "core/src/time.rs",
@@ -36088,167 +36088,167 @@
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::mul_f32",
-    "hash": "75587386486920788356952843106278193889"
+    "hash": "633296327890070211511164033577046143021"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::mul_f64",
-    "hash": "501462466641100985316509253437372271713"
+    "hash": "64855093171223787853089307102977884588"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::new",
-    "hash": "5314983784721758121573985092525882477"
+    "hash": "560522362222698302817024915517888048336"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::saturating_add",
-    "hash": "1029381576398734859717662111519589594169"
+    "hash": "1547215013632414454413365255356869872002"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::saturating_mul",
-    "hash": "353792515781400462011652680312911991039"
+    "hash": "71591559019619054646505433053580302677"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::saturating_sub",
-    "hash": "955154698754365405413054881827955123528"
+    "hash": "962111426188525602715302185202801398846"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::try_from_secs_f32",
-    "hash": "386430803346235433011304754245099095304"
+    "hash": "1582323221010237901714486768599657871333"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::try_from_secs_f64",
-    "hash": "14064064061827562397635626926479232189"
+    "hash": "18512181781032176776757738709236962485"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_micros",
-    "hash": "143953371308447061659784409087493907282"
+    "hash": "149093069380090186064889193936681303234"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_micros_panics",
-    "hash": "9197717600921742818967999055434397761"
+    "hash": "49891574261553285984430708039934748357"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_millis",
-    "hash": "99392989396211020877677722409414049596"
+    "hash": "13786368735983730972471376445803054052"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_millis_panics",
-    "hash": "1593278298721129871617653804794223874262"
+    "hash": "62619583459878820716346327000009655763"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_nanos",
-    "hash": "1806822829692306929717239395562314381902"
+    "hash": "68819276793716182326503000090355799216"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_nanos_panics",
-    "hash": "134604422389350977679384184753437665474"
+    "hash": "542845243352908423117324499414075789715"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_secs",
-    "hash": "373619136652708307018265044138944864523"
+    "hash": "5124225600452617824401242139010956964"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_secs_panics",
-    "hash": "56474447501295750765405004511393428398"
+    "hash": "152243306181619088014145311057851070885"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_add",
-    "hash": "11447966089483765022807339094687920146"
+    "hash": "854180375907274312913263058568331260770"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_add_panics",
-    "hash": "644645159158315310614394451212035857170"
+    "hash": "714539158972310775713321826258624352287"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_div",
-    "hash": "53602273988008304331556382325686351072"
+    "hash": "12863549432509954683707449835503794134"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_div_panics",
-    "hash": "175652462245910622887369578424722772339"
+    "hash": "78722486372969621035259149031912550398"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_mul",
-    "hash": "137256341125787148005413434917162888699"
+    "hash": "342740270554854368616262675168036682043"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_mul_panics",
-    "hash": "37145406260111199889768642749294627695"
+    "hash": "53356829868975264417640421784527349419"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_sub",
-    "hash": "107644569654009206394816251043042500694"
+    "hash": "32660496354749046278117605202571355710"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_sub_panics",
-    "hash": "66129356364066244212301479442248630176"
+    "hash": "66745367161425907209301882029246274821"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_new",
-    "hash": "16125700201101227386931667241377527911"
+    "hash": "89999717233790311152470293408479500196"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_new_panics",
-    "hash": "4195069762151724680317974427567166315"
+    "hash": "92204770616426725348141117855773055190"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_micros",
-    "hash": "70444258993380352033891107648014694533"
+    "hash": "124542813381046865364324865071312233462"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_micros_panics",
-    "hash": "595907716407018342613999463254189158545"
+    "hash": "13699179572696318451943951031996287658"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_millis",
-    "hash": "648131215881160634713073108173378238934"
+    "hash": "25365135789972253982668083183709491160"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_millis_panics",
-    "hash": "1529855138608294633216544210767884400444"
+    "hash": "53271462925618174268302956934064433274"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_nanos",
-    "hash": "164594633053227258477594578482098098154"
+    "hash": "975607428530403251816816470521958393925"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_nanos_panics",
-    "hash": "129736479618869443411201141038012545220"
+    "hash": "943327031114386412717270220480752432841"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::safe_duration",
-    "hash": "12880020053050264589197180469100900669"
+    "hash": "33189514496080489196197566224046525581"
   },
   {
     "file": "core/src/ub_checks.rs",
@@ -37715,7 +37715,7 @@
   {
     "file": "core/src/unicode/printable.rs",
     "func": "unicode::printable::is_printable",
-    "hash": "640233528153813131516715235621471926179"
+    "hash": "50462956522701923657823589723870492229"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
@@ -37730,42 +37730,42 @@
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::alphabetic::lookup",
-    "hash": "114458833989842083205671944971070948398"
+    "hash": "1329015468907602524117083160396805892343"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::case_ignorable::lookup",
-    "hash": "53200597786092391798658450461828367879"
+    "hash": "365548638339558431716578712691189055424"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::cased::lookup",
-    "hash": "432350275258755412415097868397067490816"
+    "hash": "1133486143322644225915808852324512329988"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::cc::lookup",
-    "hash": "1358015945398825292616134865526974975293"
+    "hash": "179845081358912699686376826600196648065"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::conversions::to_lower",
-    "hash": "154059837774755195014293174670994181866"
+    "hash": "622117423559617959813585461945945237420"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::conversions::to_upper",
-    "hash": "173512665571503271513550006003881530964"
+    "hash": "874420712690310273518316387036755391415"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::grapheme_extend::lookup",
-    "hash": "43050873062878551877287422371794203678"
+    "hash": "1780284020915414009117013684329460414574"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::grapheme_extend::lookup_slow",
-    "hash": "115802730984523368611435159107397426916"
+    "hash": "33585099156603560377688831177654593693"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
@@ -37775,7 +37775,7 @@
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::n::lookup",
-    "hash": "389801549401587616013799007575789122504"
+    "hash": "440816291901984389416241033179272663674"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",

--- a/tests/snapshots/verify-rust-std/merge_new.json
+++ b/tests/snapshots/verify-rust-std/merge_new.json
@@ -7216,72 +7216,72 @@
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_align",
-    "hash": "159654417990573153734725866837246671872"
+    "hash": "666793203004228412116660937959085719204"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_align_to",
-    "hash": "1436904537003703106216595419990221959855"
+    "hash": "104799209388555663384110756580113401715"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_array_i32",
-    "hash": "92418459731730002416529056874437017797"
+    "hash": "1511919354302091159614840202987278524238"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_dangling",
-    "hash": "657102533770205003512616866942868069150"
+    "hash": "1022615315194456023917640653651305358563"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_extend",
-    "hash": "1667892685343029114610021873566599939957"
+    "hash": "1596907133474496360413106904143665681486"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_extend_packed",
-    "hash": "239459576545903810113958211925785100631"
+    "hash": "611565180666209211514933972472663094137"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_for_value_i32",
-    "hash": "1789932809240919089616713677796947675253"
+    "hash": "1528837429852814111313228353976698026273"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_for_value_raw_i32",
-    "hash": "455036475449044420913266124106742772608"
+    "hash": "229156763025601494811802730018325680904"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_new_i32",
-    "hash": "15495550015990350784723893266515494565"
+    "hash": "125054458990597870784544900675863498727"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_pad_to_align",
-    "hash": "580604143684896389616247285100694851423"
+    "hash": "127086180829424951072647990948478029944"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_padding_needed_for",
-    "hash": "134247373483857726927464308023491319716"
+    "hash": "3497600786632072949720888623071121346"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_repeat",
-    "hash": "144769718059815834632564258018152058874"
+    "hash": "753734184042368905210236933982825163779"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_repeat_packed",
-    "hash": "61205376468902758013743299005483632193"
+    "hash": "144977692475354240605555374936632334080"
   },
   {
     "file": "core/src/alloc/layout.rs",
     "func": "alloc::layout::verify::check_size",
-    "hash": "1657919342209126008510545976869008900488"
+    "hash": "9290482296179649196991471913156075512"
   },
   {
     "file": "core/src/arch.rs",
@@ -7376,12 +7376,12 @@
   {
     "file": "core/src/char/convert.rs",
     "func": "char::convert::<impl convert::TryFrom<char> for u16>::try_from",
-    "hash": "1763133372215299994811039741193767865951"
+    "hash": "96360680809778568503881772540624896178"
   },
   {
     "file": "core/src/char/convert.rs",
     "func": "char::convert::<impl convert::TryFrom<char> for u8>::try_from",
-    "hash": "3192706117688600356296515598093949405"
+    "hash": "423027026614696617411135897157827428457"
   },
   {
     "file": "core/src/char/convert.rs",
@@ -7416,7 +7416,7 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::escape_debug",
-    "hash": "112782073517766017544601255552110479754"
+    "hash": "35373332899400279104491720870149058817"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7446,17 +7446,17 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_alphabetic",
-    "hash": "163519229420003376308706615671414818101"
+    "hash": "149238269231957986762219589860407004099"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_alphanumeric",
-    "hash": "14227116419785781588368591472595892315"
+    "hash": "1080143101362754990915534899806076462257"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_control",
-    "hash": "13163811105512890876903587377216369416"
+    "hash": "20939913548560002085644679327646245659"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7466,7 +7466,7 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_grapheme_extended",
-    "hash": "481185966460977717417038861653696028655"
+    "hash": "33465692390381201671042265624590950327"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7476,7 +7476,7 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::is_numeric",
-    "hash": "1296705507973385892816589511431256034745"
+    "hash": "119674173681752563867673922848357128313"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7506,12 +7506,12 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::to_lowercase",
-    "hash": "9488563737180875279575393987592525764"
+    "hash": "181222498429811344451706043005003949741"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::<impl char>::to_uppercase",
-    "hash": "129327314940187950013691445649706067440"
+    "hash": "1626054881250292070410373894433826735708"
   },
   {
     "file": "core/src/char/methods.rs",
@@ -7526,17 +7526,17 @@
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::verify::check_as_ascii_ascii_char",
-    "hash": "722814962128736158115895801291033770580"
+    "hash": "145106900651037684646094876905148225836"
   },
   {
     "file": "core/src/char/methods.rs",
     "func": "char::methods::verify::check_as_ascii_non_ascii_char",
-    "hash": "217862162805936216612474336981694230972"
+    "hash": "59046214821120751442008930582501848560"
   },
   {
     "file": "core/src/char/mod.rs",
     "func": "char::CaseMappingIter::new",
-    "hash": "156899052544568594745121053209070839173"
+    "hash": "86803484685046564611262439400120805871"
   },
   {
     "file": "core/src/char/mod.rs",
@@ -9416,1127 +9416,1127 @@
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i128::check_float_to_int_unchecked",
-    "hash": "12570106843364395387677813551291003454"
+    "hash": "88530868724279568667690192194845886909"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i16::check_float_to_int_unchecked",
-    "hash": "144804422370670038769732570344245401752"
+    "hash": "34937355308854661236992592332817910784"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i32::check_float_to_int_unchecked",
-    "hash": "440707822097534019715181108618503401979"
+    "hash": "866541447816502054912562032127620832860"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i64::check_float_to_int_unchecked",
-    "hash": "541219272021275384513056688692650584636"
+    "hash": "138373315061481331911912108179999526304"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::i8::check_float_to_int_unchecked",
-    "hash": "67748106286716442433269026182390219204"
+    "hash": "9178839463185631346212959247776766673"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::isize::check_float_to_int_unchecked",
-    "hash": "328685150021806691515886936154993254949"
+    "hash": "153087535703317381546148665235596763679"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u128::check_float_to_int_unchecked",
-    "hash": "147210504604342710459480859202346545588"
+    "hash": "1350855398323535927312055908456031659862"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u16::check_float_to_int_unchecked",
-    "hash": "729583415293611945510941923549606580457"
+    "hash": "1053457698283725077411487014210877623165"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u32::check_float_to_int_unchecked",
-    "hash": "840411314119499311712887002660154437327"
+    "hash": "527874524859557861913566566362714989078"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u64::check_float_to_int_unchecked",
-    "hash": "987760641575640599817789309314295892356"
+    "hash": "964798959500214880115376060161869130001"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::u8::check_float_to_int_unchecked",
-    "hash": "500799033218852845413642958871284117412"
+    "hash": "35429821651242858315152125474851240011"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f128::usize::check_float_to_int_unchecked",
-    "hash": "1680956773176821406913242386713968635994"
+    "hash": "183188123196729138387605726561533167824"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i128::check_float_to_int_unchecked",
-    "hash": "44411272530435004799291365764762504263"
+    "hash": "113223270409152893518509518672844447374"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i16::check_float_to_int_unchecked",
-    "hash": "576441992052723345814544581021832409591"
+    "hash": "1533528307502051054413214677737584025110"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i32::check_float_to_int_unchecked",
-    "hash": "62874139895559130703750122926382641346"
+    "hash": "908175138871389675610914728856061593867"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i64::check_float_to_int_unchecked",
-    "hash": "1721075069357525410813026084240274228913"
+    "hash": "992539163780421552917856858738409016597"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::i8::check_float_to_int_unchecked",
-    "hash": "797035974649728624016724990522015961830"
+    "hash": "128874261959128961458487827307593671030"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::isize::check_float_to_int_unchecked",
-    "hash": "1497516059630044035716562327286720467408"
+    "hash": "73317654769012584602737184228451032682"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u128::check_float_to_int_unchecked",
-    "hash": "90899523159774280222336224387332024607"
+    "hash": "8982355473561687972977749639660351519"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u16::check_float_to_int_unchecked",
-    "hash": "146754670663784054986985767671757288406"
+    "hash": "80945763592437188410998903105536209660"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u32::check_float_to_int_unchecked",
-    "hash": "124383940522949287234057480686005839172"
+    "hash": "176678704181631845159017129684940753887"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u64::check_float_to_int_unchecked",
-    "hash": "37753891727381295814465178255417158299"
+    "hash": "1660554092039560497817644312880993843729"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::u8::check_float_to_int_unchecked",
-    "hash": "1292448579749761997914680977685996698399"
+    "hash": "173407710967318616544491279187982197438"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f16::usize::check_float_to_int_unchecked",
-    "hash": "69750699019417085254896489862163942893"
+    "hash": "143092465587914219029334990995531049939"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i128::check_float_to_int_unchecked",
-    "hash": "917142034503283031015117020560819873467"
+    "hash": "197966129096194832916869832491042583730"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i16::check_float_to_int_unchecked",
-    "hash": "168516859738585911945204287144124839625"
+    "hash": "508229385435827294913033546054855595534"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i32::check_float_to_int_unchecked",
-    "hash": "1163794436304745714217000459696401291755"
+    "hash": "37651300251186217991254701539855198553"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i64::check_float_to_int_unchecked",
-    "hash": "175162468672550014616011931751277952400"
+    "hash": "848962969435961826110040469863291105593"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::i8::check_float_to_int_unchecked",
-    "hash": "936249769412005307118066887158310923950"
+    "hash": "84107363055613053617323532694246893163"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::isize::check_float_to_int_unchecked",
-    "hash": "31376878588647260110298305624460682830"
+    "hash": "716756287195649674712950607459613883280"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u128::check_float_to_int_unchecked",
-    "hash": "102059755348422786519407030974458553222"
+    "hash": "21614938335965082986577398341803308603"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u16::check_float_to_int_unchecked",
-    "hash": "75893547846924626692214577502033701823"
+    "hash": "63190341987848641551201006341949638817"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u32::check_float_to_int_unchecked",
-    "hash": "60490676320791597247098361025422306157"
+    "hash": "43733581848502671836923054706674290194"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u64::check_float_to_int_unchecked",
-    "hash": "156494070981288901638848760788149660874"
+    "hash": "1575194128635146137710813345945610759434"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::u8::check_float_to_int_unchecked",
-    "hash": "1505867950587343259716254392000192751973"
+    "hash": "33047794355457212807824452327195256694"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f32::usize::check_float_to_int_unchecked",
-    "hash": "1400510279347798407210489194955787537139"
+    "hash": "1066725978560580403212699325481029466310"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i128::check_float_to_int_unchecked",
-    "hash": "110403120446564007134605044660806460104"
+    "hash": "52800164587388004312900774711505584488"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i16::check_float_to_int_unchecked",
-    "hash": "11982044575560574875959342499489150149"
+    "hash": "250817743473464570016813864515390769827"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i32::check_float_to_int_unchecked",
-    "hash": "29979426334107561231237052846984928445"
+    "hash": "31267851871438388428778643376736349897"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i64::check_float_to_int_unchecked",
-    "hash": "1536136605406297903117710835990230106488"
+    "hash": "1842258398104253673976819690325217462"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::i8::check_float_to_int_unchecked",
-    "hash": "906095837508618040713995647276563809720"
+    "hash": "195569492040264218118366152443981267465"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::isize::check_float_to_int_unchecked",
-    "hash": "928471532281455141017557908349032029294"
+    "hash": "1458177127419950318015846951753921067693"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u128::check_float_to_int_unchecked",
-    "hash": "178583535424970431959908135722835132433"
+    "hash": "1653366236408853068512779978574107249902"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u16::check_float_to_int_unchecked",
-    "hash": "1840028684398577734013211579727453511648"
+    "hash": "134723722253154524317571006801252557484"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u32::check_float_to_int_unchecked",
-    "hash": "162500406643591228034674392853400888800"
+    "hash": "1574548892426867394515069780828494204409"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u64::check_float_to_int_unchecked",
-    "hash": "827245535452180575312360388633401354609"
+    "hash": "8205965162915302766429770821299503552"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::u8::check_float_to_int_unchecked",
-    "hash": "1473269455073178883415980694111344658153"
+    "hash": "15911070659092428833546264193462677442"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_f16_to_int_unchecked::f64::usize::check_float_to_int_unchecked",
-    "hash": "1625096206811751443316368645772271656386"
+    "hash": "56126109615173025358359401053540563819"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "40449163879999846926282801496354643305"
+    "hash": "1498803861690751524011363355205315751207"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "716819284212637885112687452753631516511"
+    "hash": "173828987982293429519675204549540160346"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "19126878454937175241208253669313360742"
+    "hash": "1380086860464526104511173865156011167999"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i16::isize::check_nonzero_int_from_nonzero_int",
-    "hash": "1353731719669146941715680030934635806312"
+    "hash": "52548579295726432042726035819425943867"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i32::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "500192001163028004516846233092702328922"
+    "hash": "85711672231899742286584918785623362178"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i32::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "110097462501957107958759786352280502066"
+    "hash": "42921641033427655768127147042084307394"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i64::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "110473372357271889962668693961447397986"
+    "hash": "305846650038003783111788750940805132620"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "10134764055251013883173399862924367920"
+    "hash": "68419233948588966531974981496251558983"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i16::check_nonzero_int_from_nonzero_int",
-    "hash": "616831409387895957815677820271447194813"
+    "hash": "766910421818120766742382095083346523"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "1655708353191798712110195589671829604380"
+    "hash": "140017128742183212937511365209203651070"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "23478049692240901202291302191734365976"
+    "hash": "84543252492025985513811551389814016868"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_i8::isize::check_nonzero_int_from_nonzero_int",
-    "hash": "63924788796898467613965790388160983918"
+    "hash": "66976535000348210088758593059348348008"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "1595091601885172070816967918401399906880"
+    "hash": "109327272756434010007353484807092270100"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "32416296746130187169611041354141782575"
+    "hash": "797296202572388771617130620061681782248"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "94413317538747980154508366748674189459"
+    "hash": "12350643888228726128873529742700062009"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "603966938570701298215605140824202209447"
+    "hash": "464933043559681385612238354605363015550"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::u32::check_nonzero_int_from_nonzero_int",
-    "hash": "174690491189666546591751939327544930254"
+    "hash": "87357088472070404125898075894096557"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::u64::check_nonzero_int_from_nonzero_int",
-    "hash": "667682458365202457710052860957199519056"
+    "hash": "104561338590463103532495094580591725737"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u16::usize::check_nonzero_int_from_nonzero_int",
-    "hash": "73987066715863563058188261366780570815"
+    "hash": "11127967812989483325757445509847280422"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "91351681832271918284123341943761570"
+    "hash": "183947856430693338793998816073683778817"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "129294772442453561586565518583240194482"
+    "hash": "1222018056353191709415329565388784456625"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "113445193795833229647888730880242674986"
+    "hash": "1047642869144102671650044943313723161"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u32::u64::check_nonzero_int_from_nonzero_int",
-    "hash": "771751672716791970117024944942636072060"
+    "hash": "338342713928260505113584097900482463157"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u64::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "80976031425752800777056812473822483223"
+    "hash": "1387777773008593966218235583390126946493"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u64::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "1034906910026855861516444888001298241686"
+    "hash": "1458866589914354783318434352266247893956"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i128::check_nonzero_int_from_nonzero_int",
-    "hash": "640271430533095534214903204041580211865"
+    "hash": "1828411956562748040814406531541804314979"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i16::check_nonzero_int_from_nonzero_int",
-    "hash": "119769194545571452727891949397085400846"
+    "hash": "90307045218631486988677736640995831233"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i32::check_nonzero_int_from_nonzero_int",
-    "hash": "47388569392930426107246067053703949591"
+    "hash": "739673736476333531515962066899918224418"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::i64::check_nonzero_int_from_nonzero_int",
-    "hash": "9437647321114846263670039572843549497"
+    "hash": "129202103371628139317860509632388318636"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::isize::check_nonzero_int_from_nonzero_int",
-    "hash": "115431555916596025554386836699723339923"
+    "hash": "1340609313670310690011544826806740825869"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u128::check_nonzero_int_from_nonzero_int",
-    "hash": "1373876865099118488118255449102878801823"
+    "hash": "160103706116688542964464990360049165429"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u16::check_nonzero_int_from_nonzero_int",
-    "hash": "11360868470400314962315459985343709955"
+    "hash": "687919215129014736512205960468316270916"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u32::check_nonzero_int_from_nonzero_int",
-    "hash": "95853604660969459266107771598285792206"
+    "hash": "152860779879992494993851300727381541860"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::u64::check_nonzero_int_from_nonzero_int",
-    "hash": "1636259254691348849115329975207401760111"
+    "hash": "15475464694164382958914693723759573742"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_from_u8::usize::check_nonzero_int_from_nonzero_int",
-    "hash": "1054765931475985699110331127746800638846"
+    "hash": "1787763205164412041111318504102285407584"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "175612453424451710602824772229217507671"
+    "hash": "167863530167049084428606856447653075948"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "410673367305114838510986827398837811103"
+    "hash": "509882759855550173215710081660020355073"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "78688405688059959887027530029615167764"
+    "hash": "793865077068849746312390863634841117029"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "624943109680614884912701537186314939234"
+    "hash": "1419207400792403250714850216292369600996"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1335833871685990953615994589161224765876"
+    "hash": "63908409883373467722916460755814924002"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "168824748529368427325213522370277254383"
+    "hash": "182277701132156333476175992815041389809"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1504721215319558403918141731457104279957"
+    "hash": "160994659640058830083153994828496516325"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1243837175110526465510754823527286539249"
+    "hash": "92129124968188909226210770368492105324"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::isize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "532351031685588197118423485917739564412"
+    "hash": "1600173262558599823292031454005529975"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::isize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "692012640145671583118221037929269115679"
+    "hash": "440981366545071294516858976276723952357"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1330790242295050172610785111346566371752"
+    "hash": "891767361960142981913506418054583229254"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "113095486928544702482669641047692337015"
+    "hash": "174985044528843530956752560692753678423"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "90285741425382045284124543392905945645"
+    "hash": "1684762841141883770611285384145713908685"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "29331391646556453363447448186631015311"
+    "hash": "1723981160160979817212557388921336046181"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "696350844329669927410131368711206015146"
+    "hash": "1621895243266173547114453029529160613516"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "32411923195148946355898179700428174917"
+    "hash": "140112412251869050808151200990310817890"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "67689806158992336954278415188153028170"
+    "hash": "70433403315409176377444713908912277080"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "172125109140193832979915074409036932626"
+    "hash": "1812460676869585079714429030180171992591"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "60690941823820151365585179604242696901"
+    "hash": "735875607849638714612281258823240966442"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "138943338157253786286630391254636277480"
+    "hash": "18734766327267145218327158172218514377"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "129316890227340356126554834068875017681"
+    "hash": "275421363655621758415537377844160621109"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i128::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "128537726827781461610081464983249559575"
+    "hash": "1471246302000358870813338492905602881169"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "152081828512111729554809672325943762414"
+    "hash": "123513729746306081493716218337345484138"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1647586779467389089914935205714516230874"
+    "hash": "64349876044182482614188459523740142181"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "255361732892522004010494301102150926776"
+    "hash": "637362293039246926515755351724293491966"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "83316122854290216382321805583019311529"
+    "hash": "112153843490872159610928258272232317327"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "67906769714025296910082717883190151172"
+    "hash": "179980765156261513868824089386514475204"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "28266526782282021549588244232906286664"
+    "hash": "507807915317683999318009687310684019081"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1615479432226699409117266088148410751975"
+    "hash": "182566777239946047907646589117337435220"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "218974218576165018710966631887183306312"
+    "hash": "45877944850543814984212990707334909944"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "530133909947150580712640313633580881002"
+    "hash": "1515775864512778570012913265589594680543"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "837554868693008760216490314364163292775"
+    "hash": "1538841257242451168717692391201018022032"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "95385912501232617481743742552339750354"
+    "hash": "802743609706238402916950867808012390884"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "121528367801633667981598080808788884334"
+    "hash": "164072505620590306404723802771193494297"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "125024479390174306352950551446454898407"
+    "hash": "1305002274907545954716047230442584041418"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i16::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "52363303404434936391183485814777502852"
+    "hash": "103043026970309235326655005892359333935"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1094512140936682911016577092330415806052"
+    "hash": "67831676176266418141582512031795370635"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "122860433635065201486450560013747013661"
+    "hash": "1593290381167487255916656781694970093411"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "318655672956025963415436522575275490332"
+    "hash": "116065423429644803073847944334852298023"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "448273078513138518415721439015789597180"
+    "hash": "398129562318014661214886998305949300770"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "349507625621530847498927964686965134"
+    "hash": "141328925261243815714157941793947395443"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "16120771873096742216716161063269556914"
+    "hash": "1593219019058104066711179138587900793069"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "80822368861535163934550412461278336494"
+    "hash": "51073630568803480372895095349041196760"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "990626697294504572715231465769000550416"
+    "hash": "1117249177816817677017348425171579603010"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "52033020968688261910752655010586344467"
+    "hash": "38724348749429587444767753340976943784"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "62207060022152817159179581698866038300"
+    "hash": "100427665676518575035801530240506580607"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "342285889648999601711803404354581100783"
+    "hash": "47209032944545583049544278869143201656"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1191548147394097344410103331430554509285"
+    "hash": "112923238294501206172559691966967544870"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "3419699125221038026238479535184699620"
+    "hash": "1467577380973156714211482319851664639450"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "92580449189122757796129795714074948645"
+    "hash": "547611587991698122410844102280190886625"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "180163746343378528617977705409150148782"
+    "hash": "1176683993095146888910936933753272801754"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "7936096387762738835072036818012103864"
+    "hash": "1159997537210892232870879964162739465"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i32::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "32083605182900833154086306235594743045"
+    "hash": "18590549862084215503979009259119181702"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "6038397622464639809024631855434245884"
+    "hash": "317791442593858283816481939109174055463"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "92412780102012950039639459672731231296"
+    "hash": "112565765677055229813622358500829320475"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1564870405631101064714286785389108368224"
+    "hash": "125097059904746997802950723331637166051"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "494182649611527991910012578211638652508"
+    "hash": "1331765835878615856712104619258569764723"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "42731605582780041633143751888313520418"
+    "hash": "161740940164852655977142307076893457004"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "698431288400716430310669264037482182031"
+    "hash": "144954514209845127617340148079410624031"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "13483522159944060327257036069345210082"
+    "hash": "117032103277411457721364314175582112583"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "54109080271279491432305598052717504862"
+    "hash": "24884292491309310854103019221140785009"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "746887572424036875215899430313345208426"
+    "hash": "174452422864103082032592420150425365945"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "42975575801685365813190982724266252962"
+    "hash": "111788936478378768657656618924534647876"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "95706576796697127179941402473466433369"
+    "hash": "1505518741679864603516023121199098350263"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "106732374918709542363681848683658926701"
+    "hash": "13665280732001263742329235779982156772"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "35751610570140637738698084269174597021"
+    "hash": "1539081123259105779414934102364656552891"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "108587229368049654556731467717982136351"
+    "hash": "144232860793133280624717096937552368806"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "625773361179750276013758512030032146778"
+    "hash": "240101475004776185117696326510810930247"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "181233011778022334895957036267006572255"
+    "hash": "152618456754425952235849831168037525834"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "336817435041308047116705174874101195835"
+    "hash": "72290972573712864403733910354338145708"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "42705155295422575668044899582331421416"
+    "hash": "149955998202133288408829941610918340856"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i64::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "629852498002078942715648530120265751824"
+    "hash": "198333777453521902010917322298554977892"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "638636303940244236213651865722592477850"
+    "hash": "787627909011309150312034659316436881546"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1017091456066027537717468212149797299989"
+    "hash": "23113066556938794664576590470610311052"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1420091586319227820213150511727911135838"
+    "hash": "1595463265437722471714507920948574364770"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "104960897458025337488174398195169923252"
+    "hash": "12421327691065968225604955642908982526"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1673560360802450071310288471654989094825"
+    "hash": "5146870273986599254205384988723123985"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "54106159230242353689779996248628011130"
+    "hash": "35568604725390947259048175048014437188"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "241603944760273585114653994146077477803"
+    "hash": "1244770527212436397711170495754634866362"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "90244826586135079336954737753048413911"
+    "hash": "73289030705870403211230581177394643680"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "9845094037901015505219707293563758865"
+    "hash": "121983795279007181079781412200376980993"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "13588381002981628890318323257219843908"
+    "hash": "1765197404869149539515852918202451738519"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "659773920687559834417129245767952292673"
+    "hash": "110508055154344845127995830112886982494"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_i8::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1240538538745922999412351952017376556891"
+    "hash": "143480726743850002436113930906900722934"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i128::check_nonzero_int_try_from_nonzero_int",
-    "hash": "95132714731835379149480573137712413029"
+    "hash": "173182256565918692029002150135077997553"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i128::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1186246110828032995916086288550682171529"
+    "hash": "99047179907002267398074717714973864067"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "34047567465092881287239286495684897603"
+    "hash": "572536889152389319811820130069610581045"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1294053565553777134516035098347721377699"
+    "hash": "720409031999184417215350735082560323057"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "22906552742002348646185031643506540058"
+    "hash": "6326575109500355407541302159115677430"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "64501851282918469319986757783886815744"
+    "hash": "82558823977849122349305451719034781421"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "150893080908220625106171375150020556624"
+    "hash": "615578499411631465618039218887366176300"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "950119083680680673716926192164226968480"
+    "hash": "69616272368018518061418763059334018105"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "102916545025473719156841817079399843928"
+    "hash": "173020741692950139445149527454787015445"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "58281268640159292523291633162771050388"
+    "hash": "51601496979852913797129294969357247183"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::isize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "4697257143784098540261420841239988916"
+    "hash": "1579560798030362539615334371299398615363"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::isize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1698413023095139585212879564176581803737"
+    "hash": "922103451526309966015216069335275117589"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "218063354083376336113113420315373200105"
+    "hash": "93018871973111381303175292929025358963"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "95672244732469927382995688540173609649"
+    "hash": "10823259171806135275342632442268372979"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "132713699494588416639681895606917319750"
+    "hash": "1743055593611384035617380950780330415556"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "174405405113041265731440742758524445652"
+    "hash": "23733014348893435081757843349963233420"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "176920187331910071936799771542195361570"
+    "hash": "319473677680040765012527022231927212355"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "163898042281882255748970059446743578120"
+    "hash": "1284230925776223916014764875257793978791"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "689303941873361294015589709646539628384"
+    "hash": "1933170207269649714115002409916385691"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "930791792036395123515318198896472925421"
+    "hash": "105537870575954219352764588909800226715"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::usize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "13835632781916690304842834560821968689"
+    "hash": "548700984875842486714168609086173721734"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u128::usize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "51755092613715403138254142784511744027"
+    "hash": "21172103212906285522814614428264632139"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "30546426853653084299794501020432284765"
+    "hash": "1460156144866562969910343198229639204728"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1140464778483098224218075142812872943066"
+    "hash": "76436289299345957434498193490187269881"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1732149147193691065011334087403156126904"
+    "hash": "1380246108507545914113366292419178817467"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "11863759348967736959407823821159744570"
+    "hash": "88659376676431159896405862720313433320"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "116582212197189028914967478295614035294"
+    "hash": "145587173272797538591524778829382973587"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "30231336607320045187353534190834971969"
+    "hash": "65600837018888525486753977263006167118"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u16::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "110168467648833136823277603031602783497"
+    "hash": "23203877026251207965680306514655696700"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "131902666120833515210080356796749305049"
+    "hash": "161602832646647240527834857872149199708"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1716500011045675291317505631882124996938"
+    "hash": "111369069761955714927122602829454379358"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "11436904518684370250252941949593112169"
+    "hash": "128401869644782486718406782014075402075"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "95230130933538148112830276697618649597"
+    "hash": "1250000140426586736212750794088976729721"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "168040932025120115993084219277736221631"
+    "hash": "683908971115164128612989147754205858498"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "90288115843171719667643035419023154350"
+    "hash": "25769949353085235624168541323527156099"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::isize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "140416837262356465643986883571453421477"
+    "hash": "143949827240603448295178736507232408847"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1498750439860108348215637263201738708"
+    "hash": "67706986840353303311623710154527413396"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1697011398988088401114332869682062070224"
+    "hash": "148072755823918461099542311010808677542"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "933856725576814533910289529885176916363"
+    "hash": "1207836399974846443217523914748206315557"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1124806734436718507518065694977125496874"
+    "hash": "182217217852229359365296772885102992118"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u32::usize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "156878813857011095507318240379586005065"
+    "hash": "68634997358580803062207123542237550457"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "40041519107379044118153916356458995955"
+    "hash": "933443332794624844610784547363448971918"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1032628273019650727114687341613691457675"
+    "hash": "1002755433813041248415728681676652349569"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "87369623460449361476247900362020589561"
+    "hash": "169677476924428649899981020160570979492"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "55871342420522856657010406014345539010"
+    "hash": "18098894874579727109903971268074662503"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i64::check_nonzero_int_try_from_nonzero_int",
-    "hash": "82657103814044883045943293015485363382"
+    "hash": "1462850021912084560213874346738302945702"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i64::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "657959562242623404010096293764350607886"
+    "hash": "160044652239403766678415238599515757352"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "52053147848731290961536718286032448641"
+    "hash": "69880916569051831844690508565359598384"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::i8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "1063764815889933286416050031409622367539"
+    "hash": "1662391869904712420612051550757079242384"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::isize::check_nonzero_int_try_from_nonzero_int",
-    "hash": "99902300206195746743500593215678788779"
+    "hash": "805587235004508171117109247346763463954"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::isize::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "165626776133261083245843275606522213070"
+    "hash": "12767710176264674816317510690488346177"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u16::check_nonzero_int_try_from_nonzero_int",
-    "hash": "787731017053874312713918686193614142537"
+    "hash": "107062756289766633579847607683430262626"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u16::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "52102298199651940404392495967630093316"
+    "hash": "1679656131215881041217804677334655001869"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u32::check_nonzero_int_try_from_nonzero_int",
-    "hash": "175504254144785772410051401228541687267"
+    "hash": "37155069263654866409804953250765377818"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u32::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "617783076415223069312101198542826256215"
+    "hash": "83591994068114521417741697530268334094"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u8::check_nonzero_int_try_from_nonzero_int",
-    "hash": "1504336928964384734317244950311738354506"
+    "hash": "11949480510292002933615012298302033378"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::u8::check_nonzero_int_try_from_nonzero_int_should_panic",
-    "hash": "10686834027586206883806441638377732851"
+    "hash": "77050259537074377318948839846575142046"
   },
   {
     "file": "core/src/convert/num.rs",
     "func": "convert::num::verify::check_nonzero_int_try_from_u64::usize::check_nonzero_int_try_from_nonzero_int_infallible",
-    "hash": "1008023026971308131017238918130726539960"
+    "hash": "1170573726740739897415896020688793032210"
   },
   {
     "file": "core/src/default.rs",
@@ -10651,62 +10651,62 @@
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_as_ptr",
-    "hash": "1005737773232775424011537861850140803635"
+    "hash": "1668536483415561831208054033756593945"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_bytes",
-    "hash": "183709507221698258354847358619705930320"
+    "hash": "29852727657653349481497090967342985635"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_count_bytes",
-    "hash": "1782561976884520703715896351820702106162"
+    "hash": "1455705036513831852711197642096900310603"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_bytes_until_nul",
-    "hash": "3859030188732282614907904060482482485"
+    "hash": "132558817532802772814506894125046621679"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_bytes_with_nul",
-    "hash": "85314328887836552425887759882817772416"
+    "hash": "1762134566566203163414638028955495933308"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_bytes_with_nul_unchecked",
-    "hash": "1627063208763579322416212839407153991313"
+    "hash": "152363027587936228828882123735945463105"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_from_ptr_contract",
-    "hash": "10963796904382741413080573034712702440"
+    "hash": "1235756292645422477210242321124036019659"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_is_empty",
-    "hash": "86228479985880985263425385775605152162"
+    "hash": "159729346751015565506683133188509600769"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_strlen_contract",
-    "hash": "1537978948734802359313075892497443644361"
+    "hash": "264771923508448919716761425121020509175"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_to_bytes",
-    "hash": "164811967598848879844306277122946919823"
+    "hash": "922871391019833145410819029299661261530"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_to_bytes_with_nul",
-    "hash": "873301063112014476712704450973234604095"
+    "hash": "85894990503989379014978974317823709350"
   },
   {
     "file": "core/src/ffi/c_str.rs",
     "func": "ffi::c_str::verify::check_to_str",
-    "hash": "1752740417588739807610194177552998548938"
+    "hash": "173453639731594168145057133628959451678"
   },
   {
     "file": "core/src/fmt/builders.rs",
@@ -10741,22 +10741,22 @@
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::Binary as fmt::num::GenericRadix>::digit",
-    "hash": "167805964473331543828322231840352753969"
+    "hash": "54656828559507721555474249308559461375"
   },
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::LowerHex as fmt::num::GenericRadix>::digit",
-    "hash": "242080123789224994214453644503811159479"
+    "hash": "1819320044930233148011820379372356252633"
   },
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::Octal as fmt::num::GenericRadix>::digit",
-    "hash": "42909843583956871977524929806362225071"
+    "hash": "1526603118578937328418332548998107150534"
   },
   {
     "file": "core/src/fmt/num.rs",
     "func": "<fmt::num::UpperHex as fmt::num::GenericRadix>::digit",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/fmt/num.rs",
@@ -11136,32 +11136,32 @@
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::Assume",
-    "hash": "159876217636128777997238053184447116430"
+    "hash": "80462426220111558147385728798769792647"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::Return",
-    "hash": "127617347754016229741960697334448965792"
+    "hash": "963671311509051311714239059969085537935"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::Unreachable",
-    "hash": "939022033609935605912053307854678669934"
+    "hash": "103258612607140405504461305791108581823"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::UnwindContinue",
-    "hash": "1834807253853936654216167106079166354372"
+    "hash": "924409717289418380912018685441358051117"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::UnwindResume",
-    "hash": "84593103041004796133743235947209857500"
+    "hash": "111865786195385373936207092654720643527"
   },
   {
     "file": "core/src/intrinsics/mir.rs",
     "func": "intrinsics::mir::UnwindUnreachable",
-    "hash": "113019058793788161892863156641951717554"
+    "hash": "439859689520047162718303977102409029100"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11171,7 +11171,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "char::methods::encode_utf16_raw::do_panic::runtime",
-    "hash": "1072707188431150672216694450913705836092"
+    "hash": "85905003442401298274746688489468417169"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11181,7 +11181,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "char::methods::encode_utf8_raw::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11191,7 +11191,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f128::<impl f128>::clamp::do_panic::runtime",
-    "hash": "70414816962556708501312417167098573119"
+    "hash": "37477924359411098836512345888661426550"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11201,7 +11201,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f16::<impl f16>::clamp::do_panic::runtime",
-    "hash": "85517861577788698702401178925022005364"
+    "hash": "149641901401928124253091120495714928683"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11211,7 +11211,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f32::<impl f32>::clamp::do_panic::runtime",
-    "hash": "81135406048345508319447053781798426202"
+    "hash": "184365894090260783921579835441030046772"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11221,7 +11221,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "f64::<impl f64>::clamp::do_panic::runtime",
-    "hash": "11151493258034151214451187101936381621"
+    "hash": "1116795696853849687817088617110399943806"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -11301,1572 +11301,1572 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_arr_to_struct",
-    "hash": "13248293318748791366182484231915863621"
+    "hash": "44569125889545126145260230876940158158"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1163900701481358647912539676006912637728"
+    "hash": "1650935973777390599616124140475025887822"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_struct_to_arr",
-    "hash": "5237503072436321651528602027315825766"
+    "hash": "640528775520460352612220242766827359386"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_struct_to_tuple",
-    "hash": "471810001363165698111177484508262329745"
+    "hash": "116160154449315947723610610800111391688"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_tuple_to_arr",
-    "hash": "132312363606072742824555516972435143445"
+    "hash": "7474123538291552868328664896342378516"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_2ways_tuple_to_struct",
-    "hash": "53978139399382359904632957520618193882"
+    "hash": "98261023119298773441423312607166435753"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "48868899909216543865450910325374942094"
+    "hash": "173672762519796524074018147194011328412"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "26951453643687293619200869224204075130"
+    "hash": "73556784291181012719169352132900128"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "216242883622705475811760789398293580917"
+    "hash": "107706195453488360168160949661816817403"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "3187146692073425460312699975368439877"
+    "hash": "69022529664357093311395269393270655300"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "135413085772143712661404523197841773076"
+    "hash": "94136760972190875245368731647477361843"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::arr_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1287295852626105971714239968018500325842"
+    "hash": "177617129200817568585676133619091757219"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_arr_to_struct",
-    "hash": "136757766027878059042794421550018720444"
+    "hash": "1310169166851099738717373990258130580430"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_arr_to_tuple",
-    "hash": "916651903214366398311423281079253019843"
+    "hash": "543713875495574293416837076912053343531"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_struct_to_arr",
-    "hash": "166423821886689425197155798972842769765"
+    "hash": "1493190290683572653110461932586800235924"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_struct_to_tuple",
-    "hash": "702988052336628137116778670550679438181"
+    "hash": "182672765012148936769077991007385677099"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_tuple_to_arr",
-    "hash": "119737714934479238406451844303629136988"
+    "hash": "164329964467819024399949765554904951870"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_2ways_tuple_to_struct",
-    "hash": "1447867035813266969616840533087938564366"
+    "hash": "96706940520950090445264677517848558696"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "623139454430470547215074057912935897231"
+    "hash": "123092613973336563578330524049786522839"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "195920957741234148415050589494040631"
+    "hash": "1130361286130292352011282075760894755639"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "1802697736753414398411114999321353748745"
+    "hash": "293107958269608413764086846119512174"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "1163925318987389266418029119331716795960"
+    "hash": "1187050938999602644211067256745721099649"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "248512670678380030214777300626630776803"
+    "hash": "578175429318660494411095041234355604349"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::bool_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1499684163779842665718444728855936646491"
+    "hash": "121353859384644629095605154397348960697"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_arr_to_struct",
-    "hash": "1806827583500956819417759378681326534381"
+    "hash": "152554245705469865486480138968048730216"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_arr_to_tuple",
-    "hash": "41855591576755519416207314381145252560"
+    "hash": "372413925358458855115734439217791214147"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_struct_to_arr",
-    "hash": "176112358994393932335859311689165723367"
+    "hash": "26269637561235790717003600825227546135"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1822819216806798794915268055819264386449"
+    "hash": "164702713458602662209346646770755162986"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_tuple_to_arr",
-    "hash": "177271968633174896657590237138957215635"
+    "hash": "96245530057736922163846538034025383561"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_2ways_tuple_to_struct",
-    "hash": "15152605424012338474262865335536114770"
+    "hash": "100064709399584732987066583713387627528"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "74323925770363510351761025852102269238"
+    "hash": "169993765283258853013264083075641908776"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "138874241880949605019963439190306325753"
+    "hash": "179155751014380566229873440378544228268"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "20306047316866064852610138480721793454"
+    "hash": "7095194972396872612219209694930620475"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "49269054593991501852626456234218665195"
+    "hash": "539300933935109803613245934471992101455"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "1644051099343434409412695338775715541504"
+    "hash": "1560654115512379233110613619926477240886"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::char_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "387905968064484398814302004823375942522"
+    "hash": "443544149012828563215283745615880822056"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_ptr_address",
-    "hash": "269336529325160803312777561837739194197"
+    "hash": "32355353719906571489890709385432570584"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_ref_address",
-    "hash": "65570911599995402167339139066957291059"
+    "hash": "1659168321055305236211799603821165704226"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_slice_metadata",
-    "hash": "163306145599921756017071566682876115002"
+    "hash": "1458007826251106173918095246070352560599"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_unchecked_ptr_address",
-    "hash": "116543630117621828928525069854561310485"
+    "hash": "1744861217698745662412427596037485090802"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_unchecked_ref_address",
-    "hash": "694251869748147451310560423886172453351"
+    "hash": "1446401524349668065516803468169176709022"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_transmute_unchecked_slice_metadata",
-    "hash": "150363782097130699323817202465069520344"
+    "hash": "6280401421944041006338495349144657908"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_typed_swap_char",
-    "hash": "49410778264991796801321280308419329527"
+    "hash": "1563338564756174921818406329475838177851"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_typed_swap_non_zero",
-    "hash": "391319576546783846918065924556251616593"
+    "hash": "240343050484729600915344921054840450182"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::check_typed_swap_u8",
-    "hash": "163819056602822067473286112756992207329"
+    "hash": "21342853647494806448879587279256384957"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_arr_to_struct",
-    "hash": "134915628612246779145260544984322773517"
+    "hash": "24597318974969652808082326082391723624"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_arr_to_tuple",
-    "hash": "101802680512194726681132431534812590602"
+    "hash": "802429368142666418411220013100042039749"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_struct_to_arr",
-    "hash": "2462983420171274191328151901391184695"
+    "hash": "15772297371200870768665848444729123354"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_struct_to_tuple",
-    "hash": "178609637136192738772779663315597323859"
+    "hash": "1754846157670625337710298736887904593111"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_tuple_to_arr",
-    "hash": "184250108646340877957549182907815444520"
+    "hash": "812443135711084326616085257639663210525"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_2ways_tuple_to_struct",
-    "hash": "18129924147396817703776847452779006884"
+    "hash": "1639726635349362027815370983891751354116"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "146539267481254904269879781678358080847"
+    "hash": "137813651700518802017922833602532941403"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1629303072883594756816686976959182752954"
+    "hash": "1307823549450968602813637777857831469831"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "697331123576528958910348154027294303233"
+    "hash": "102088731710407801152083097508240299318"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "101183523205054469614024633585740442537"
+    "hash": "654563135351998835418278523183978038377"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "95114751544184766675391012464287800679"
+    "hash": "307541677939140450613349551929293225719"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i128_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1042374157791819625713355173121291721292"
+    "hash": "876782485459304043717538011045999136171"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_arr_to_struct",
-    "hash": "27096903324296510223663840455414009485"
+    "hash": "107685457936415995632987510076913880572"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_arr_to_tuple",
-    "hash": "164409615727807306152212715949157996496"
+    "hash": "1453437869469541111314627405885350524956"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_struct_to_arr",
-    "hash": "122376420630650374141838573720630162456"
+    "hash": "1682939032875241422115878642923158481884"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_struct_to_tuple",
-    "hash": "106575957760354937473174354932497295406"
+    "hash": "160385835519796804014355241199242699673"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_tuple_to_arr",
-    "hash": "89279028839483997958878682900080734211"
+    "hash": "1483370367442224805910750342311868942610"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_2ways_tuple_to_struct",
-    "hash": "137397829091681735225801695820645212595"
+    "hash": "114532685014450561698514780911515646432"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "862896983280864749411624352114511766997"
+    "hash": "178316721353762915495054000132446179920"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1065215283341238361616085326305145102232"
+    "hash": "51367999022937256551849255922734810169"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "1061402018678312503615423538391258142472"
+    "hash": "56413737415596956715498555424080947736"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "651755887455260090317515408413318797235"
+    "hash": "348514653716396781979672137482860418"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "27112284175082759899683952481466461471"
+    "hash": "1036469178138040189317367563687232686449"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i16_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "107187454697524039564722429981941982993"
+    "hash": "1130717618106968336416437531681141994941"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_arr_to_struct",
-    "hash": "146147149943226986686571950847580318133"
+    "hash": "252390025955977038615291447074116343212"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1123328495071785584512946568441758412410"
+    "hash": "105147751896258600768889168631657337852"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_struct_to_arr",
-    "hash": "628269419958306087716978405938018081531"
+    "hash": "1094470028327600307517356763675777028812"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_struct_to_tuple",
-    "hash": "78424691907728912394134639825412372772"
+    "hash": "56962175248234341345475937941068929028"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_tuple_to_arr",
-    "hash": "1561547505347056181618000832638872633716"
+    "hash": "72878543223592621452231547144462184724"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_2ways_tuple_to_struct",
-    "hash": "943017040620421161711121900201060415908"
+    "hash": "1000481354854575140913832348827792806748"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "158375863784326216084491539950370670115"
+    "hash": "140562676205013236112843327448102361086"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "3302376687321905931942959361283694511"
+    "hash": "622718222567680161518255810477017715924"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "3037347964065867686745439596530778182"
+    "hash": "51196465252896645011129751545039580101"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "1397948992427156395914570091011072633983"
+    "hash": "1531254356685113518816978935635817956245"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "100205917730362927399177835575693140669"
+    "hash": "23642105772838316616066303888549047622"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i32_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "171490570582371482845903495683746072788"
+    "hash": "573087581663753659912891651176610496950"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_arr_to_struct",
-    "hash": "1109040433393375080017201699983557175171"
+    "hash": "545897896028009831317360086024221914056"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1755045247700869695915574179057838021621"
+    "hash": "61288906016541883810301104653069393053"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_struct_to_arr",
-    "hash": "435563540182087077712187232107973136376"
+    "hash": "51145076374723729042138468422051451021"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_struct_to_tuple",
-    "hash": "936424835068145113914623519653460922786"
+    "hash": "139154946046469912686173966804140724993"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_tuple_to_arr",
-    "hash": "37489565301126390612636586229640713285"
+    "hash": "44444153150394575233687774198272924300"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_2ways_tuple_to_struct",
-    "hash": "289826728458330288215006482355457616640"
+    "hash": "1600835920534112036418405504728364676834"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "272443227015425070318331482113976333912"
+    "hash": "83980497596166617757623541380175985509"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "183724077250086469307356138145387691570"
+    "hash": "14060753912964489728687538377054555277"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "14978242298890806344944303179590623525"
+    "hash": "173824230194132338824233900141801126470"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "16254391547736023908609750938831530106"
+    "hash": "94630805478702040652179085888664813940"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "815290329198514717118381084459787700145"
+    "hash": "72072737031151982584675106208794615527"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i64_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "85134813673735595821971428891213429436"
+    "hash": "93719680103898474239507667662148176910"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_arr_to_struct",
-    "hash": "696764862950535249711929613782824718737"
+    "hash": "293450096612153991214323590555141173760"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_arr_to_tuple",
-    "hash": "118625330685287331512682373677396708"
+    "hash": "1004763697399045566012218725135065445"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_struct_to_arr",
-    "hash": "34928772486876841711337441756384325022"
+    "hash": "1351273312697990344811823721382805213635"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_struct_to_tuple",
-    "hash": "130867711320842810084697359209306586579"
+    "hash": "144258282561795579310179287382373443475"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_tuple_to_arr",
-    "hash": "226505007721923030613659221558224349944"
+    "hash": "217712549999757443712477905925003221131"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_2ways_tuple_to_struct",
-    "hash": "1451031192224828323517578980619516119581"
+    "hash": "15862716028742405340189402058900463358"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "108135994940136824382403241068119306328"
+    "hash": "2225714045985013931851813542412815494"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "35321115486253398761969133181744285480"
+    "hash": "59022334653930750572966747940806215781"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "106817902771106603113339307886578385771"
+    "hash": "631702073515873004712002574090004153502"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "92655024625060800317921207710815856160"
+    "hash": "50681511270511623327389550111414286128"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "12896234835419953792925192937907918595"
+    "hash": "927388575517509607011145216123532555497"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::i8_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1831845329041756613216622263014404503060"
+    "hash": "645466028325734713315485251540467450736"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_f32_to_char",
-    "hash": "11972788914022613504512224727905325857"
+    "hash": "140906583300619398211072358042293688741"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_i32_to_char",
-    "hash": "183009218307993035065127616231255126692"
+    "hash": "7499275229267252276734222048237872144"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_i8_to_bool",
-    "hash": "141947526478684504484455533304973582126"
+    "hash": "1807091473613196132017856300370255705198"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_tuple_to_array",
-    "hash": "15124859496964532759416376986684206156"
+    "hash": "88352573943510473602492843554278516661"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_tuple_to_struct",
-    "hash": "13966365381106221134925360082037829754"
+    "hash": "108006519523114540432535069553384320181"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_tuple_to_tuple",
-    "hash": "224229299950751717510813020650838815972"
+    "hash": "32977623595717019234286231648301301352"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_u32_to_char",
-    "hash": "936802995631102935110537338002154751600"
+    "hash": "1317596444549901075717644712273018415003"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_fail_u8_to_bool",
-    "hash": "12801827774048120605987355714471140510"
+    "hash": "40452518471158737082265544006347566849"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_bool_to_i8",
-    "hash": "13437254361587576717902569064044021311"
+    "hash": "7484522945516565163448950845888842350"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_bool_to_u8",
-    "hash": "1036674688877487411716216160279808078456"
+    "hash": "1074704597734323633612077667070881119315"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_char_to_f32",
-    "hash": "84097251556424254879721629117934614696"
+    "hash": "144250244438825397292485872423907389964"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_char_to_i32",
-    "hash": "162146041144241456778592515047157433597"
+    "hash": "1320686980318122530413148691136919955849"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_char_to_u32",
-    "hash": "743401287409270426212218994036364427403"
+    "hash": "6557438463566531201068357703498751462"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f32_to_char",
-    "hash": "137379404782891703424664819078380606014"
+    "hash": "1142719032474819535814632168326682589218"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f32_to_i32",
-    "hash": "155517997269858459842269454257659417064"
+    "hash": "8805239034890122451129887791530205730"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f32_to_u32",
-    "hash": "1407609228626843360613468652319593191461"
+    "hash": "1225966564095818746810997113431697230360"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f64_to_i64",
-    "hash": "19628605499078099014976429462208442829"
+    "hash": "1490337833217060637412279929583293401534"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_f64_to_u64",
-    "hash": "1239747852168857350916932505633142351839"
+    "hash": "170302507757241775667413189097694191703"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i128_to_u128",
-    "hash": "131038971337009132969611725027088829324"
+    "hash": "46337359892087720519646717442801618066"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i16_to_u16",
-    "hash": "733752884668148588214411717430725741454"
+    "hash": "116396083519407885159186086306617035425"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i32_to_char",
-    "hash": "632071501719190272714929772185579143273"
+    "hash": "863774453150304800616091108611780688990"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i32_to_f32",
-    "hash": "156388642096667691965022545271619272775"
+    "hash": "64103017797867815481791015100818686992"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i32_to_u32",
-    "hash": "174535098750936998554149725501644221626"
+    "hash": "104924789687708168212445074848167322287"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i64_to_f64",
-    "hash": "1163814820903667546616391091713134102321"
+    "hash": "58463380786465759895875105744371973726"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i64_to_u64",
-    "hash": "22063627417220653095649646057176241894"
+    "hash": "188088180358690281410188566618394104818"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i8_to_bool",
-    "hash": "752646409628139871816394520959139062419"
+    "hash": "22758659408221083697382217835827492302"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_i8_to_u8",
-    "hash": "26262006651678747413822532645683866608"
+    "hash": "1397110951263362347213890054237203394212"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_tuple_to_array",
-    "hash": "1837296845162134528714547554385224223311"
+    "hash": "33332760734673652513136549723180083152"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_tuple_to_struct",
-    "hash": "1379031490205205777617280709762611229017"
+    "hash": "91614964969992724283636714556201554759"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_tuple_to_tuple",
-    "hash": "77127992187396274673937561414725766673"
+    "hash": "92023540791246929331714239221885595475"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u128_to_i128",
-    "hash": "133046288916532182199463652787293557156"
+    "hash": "158334884197859806155730418593563218049"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u16_to_i16",
-    "hash": "12549280282256114058983389302235257925"
+    "hash": "1306937743143852112115951685599667922873"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u32_to_char",
-    "hash": "1708493581666015024816000321885326974071"
+    "hash": "880595753718994005414126199299340421758"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u32_to_f32",
-    "hash": "1186212559281687423811465277925530406685"
+    "hash": "1093733521210251256010261542073825322101"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u32_to_i32",
-    "hash": "181080173347664804551515153474533440272"
+    "hash": "160841374390556351263552274219288835235"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u64_to_f64",
-    "hash": "654898867171225496911599187280294732292"
+    "hash": "128444369804722605672754870069248770630"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u64_to_i64",
-    "hash": "41282494317944276661662271816591911438"
+    "hash": "173395629140527825416259835209487636413"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u8_to_bool",
-    "hash": "124532716537700031122974909278454298497"
+    "hash": "104573746883803005388933926502488327543"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::should_succeed_u8_to_i8",
-    "hash": "68445340958934852646884103006767116166"
+    "hash": "127643761208084300647227392977042656760"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_arr_to_struct",
-    "hash": "1393693473521873027715904969109623752618"
+    "hash": "175970139447523998871613319466624090605"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_arr_to_tuple",
-    "hash": "173373291662731916638957512269807670615"
+    "hash": "276473352547758650410027744433260707618"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_struct_to_arr",
-    "hash": "131996599422232464082968438409989272591"
+    "hash": "1063611635883242779317906683383654699215"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_struct_to_tuple",
-    "hash": "84522475323039240729985965919576623703"
+    "hash": "716081931756475649716793441601547884217"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_tuple_to_arr",
-    "hash": "107899330845554099412298256042077311244"
+    "hash": "1671641040328344221813404405294552747106"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_2ways_tuple_to_struct",
-    "hash": "94980533049475820676920047911127939360"
+    "hash": "20400154684991926435066556405607037973"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "830391920562445304910790223774248707029"
+    "hash": "1533357498317532336216387082799552859976"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "255832612564051690414692970041488088946"
+    "hash": "825777769946045336016991537424678045988"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "19796167532102350792553606433896022581"
+    "hash": "118439629685697997158714497623363202017"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "52413376137219537542864903431709757440"
+    "hash": "1140192870421641020515244311374560554954"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "78550809199846339022909821522374620405"
+    "hash": "1206186357971162067017833206082521643643"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::struct_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "184215758231183868554002737070636966916"
+    "hash": "1130471892056720534516153246396201366267"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::supported_status",
-    "hash": "652306216325428494210843435710275302324"
+    "hash": "176210567283599110817330099341857896355"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_bool_to_i8",
-    "hash": "35579245934029664749591353693233831332"
+    "hash": "7803038167033946249560725899081911827"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_bool_to_u8",
-    "hash": "1248838216365879320714271895265288669230"
+    "hash": "1077367388785330251314670211076166091520"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_char_to_f32",
-    "hash": "1529442532273747110917233284124682850277"
+    "hash": "32476567006856217489840922375065119643"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_char_to_i32",
-    "hash": "100526788950486281387700227778755996681"
+    "hash": "1717345873446708615316987942301562277068"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_char_to_u32",
-    "hash": "144649608112205923613840823226860285105"
+    "hash": "1368047778365871499413990888124378386986"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f32_to_char",
-    "hash": "51713415348912154838409215659091353798"
+    "hash": "1682361354308782274415621596232174588036"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f32_to_i32",
-    "hash": "42151961709958381599341596006257244287"
+    "hash": "24760763325492678637917370722666938235"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f32_to_u32",
-    "hash": "7163736578214933146967967426672988242"
+    "hash": "359558095388559954111367501247788802345"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f64_to_i64",
-    "hash": "209821095850350980211188401707123570645"
+    "hash": "1057160309753158480310852585279441022155"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_f64_to_u64",
-    "hash": "100029452074246585582273339748090714879"
+    "hash": "1824599420003180944013921603592615920348"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i128_to_u128",
-    "hash": "167695553379826925739194124072425968037"
+    "hash": "743587293879211950817440951736797181994"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i16_to_u16",
-    "hash": "711227497683037237212645456905249743929"
+    "hash": "1394929383335954295713822286534785105338"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i32_to_char",
-    "hash": "161733696570706205299832803578261513171"
+    "hash": "148107746449483954304071370866301753962"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i32_to_f32",
-    "hash": "1247452141023291059214939651250338432867"
+    "hash": "51956922435423853946534627349183779006"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i32_to_u32",
-    "hash": "7627613076683126890193378222591738686"
+    "hash": "24995348647024155782610958596290214952"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i64_to_f64",
-    "hash": "1137486477872710043914952805433836179002"
+    "hash": "1635806931752244743318135708180658830019"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i64_to_u64",
-    "hash": "182996090044071408894408084618336998632"
+    "hash": "430506396941725233114497682132734380353"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i8_to_bool",
-    "hash": "1825186359109900727915925802818160872694"
+    "hash": "59025498954790523558454609232456230399"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_i8_to_u8",
-    "hash": "438756001199482362818185721271958403098"
+    "hash": "55795134079747533417018187121805047639"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u128_to_i128",
-    "hash": "1282023412583613091715826508186518590629"
+    "hash": "63599031650807848163005584753409618908"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u16_to_i16",
-    "hash": "143557574993388697306726008297666920890"
+    "hash": "149940807080223545924972181685537926751"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u32_to_char",
-    "hash": "7091256019282908760656494509762450772"
+    "hash": "24000000317960677613619516020269152055"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u32_to_f32",
-    "hash": "1039053865592583173191731549305752303"
+    "hash": "109888500961959673143525830223128708695"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u32_to_i32",
-    "hash": "731099969925691723494159062227946685"
+    "hash": "61235706191679274103025117207140036533"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u64_to_f64",
-    "hash": "704178529910814507111963094200351836713"
+    "hash": "1038643481818073871915390537803004328866"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u64_to_i64",
-    "hash": "9392059493865588657770687764471652823"
+    "hash": "157232091396871914678901077240604146162"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u8_to_bool",
-    "hash": "43359695930846486411313203511638616757"
+    "hash": "716515509267472772216743731123586231609"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_2ways_u8_to_i8",
-    "hash": "114128519066251327898071527985721734523"
+    "hash": "106347591898181620428935527996997411220"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_bool_to_i8",
-    "hash": "69685967925669211344235506275776506522"
+    "hash": "460607062302778615015018552655071677222"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_bool_to_u8",
-    "hash": "49997263120663512281979067924647927464"
+    "hash": "562906173826815780612049412991261900889"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_char_to_f32",
-    "hash": "1049461926105003983714594731044104289518"
+    "hash": "63974031557943865512036568900635245916"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_char_to_i32",
-    "hash": "160548376782164542818425533440139462989"
+    "hash": "1060469107840222074311326458966128413001"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_char_to_u32",
-    "hash": "108798975128578856057407094768701364428"
+    "hash": "73291436420913961731524070396786849623"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f32_to_char",
-    "hash": "279053842410403866415392666488436785055"
+    "hash": "38814079630353494654866997540882688436"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f32_to_i32",
-    "hash": "101509702414623113364621380681114850443"
+    "hash": "28982657480402774671414348869893151960"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f32_to_u32",
-    "hash": "105148290008859542347044026620189603346"
+    "hash": "914926030277221935517430117380649299034"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f64_to_i64",
-    "hash": "541993045212804489010172102105486813012"
+    "hash": "188526931730342563314467174294190649294"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_f64_to_u64",
-    "hash": "26448439970135323392078810749226995485"
+    "hash": "972350434781797568514083630042109725531"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i128_to_u128",
-    "hash": "1813431925834908615413122965850350233748"
+    "hash": "80758717044549722858470481517914304038"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i16_to_u16",
-    "hash": "16522480201089085855007158322708721925"
+    "hash": "3191534991989960488995488038868757131"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i32_to_char",
-    "hash": "172219949975573053246507663779522075861"
+    "hash": "31017810217440822557857276514730230445"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i32_to_f32",
-    "hash": "93437120299983707986322379532478246673"
+    "hash": "181435577113556083005390165153170012912"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i32_to_u32",
-    "hash": "115240346548036293041550251685295839786"
+    "hash": "13928594720605952668208501997092415713"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i64_to_f64",
-    "hash": "47227452276491509192361932012517035124"
+    "hash": "164452083897616354247703110077256380213"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i64_to_u64",
-    "hash": "262596102109654346706399458749135554"
+    "hash": "171432845103958780229236800384344893285"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i8_to_bool",
-    "hash": "533742211447964728711572541023369852041"
+    "hash": "90967580176222302951307545077749566635"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_i8_to_u8",
-    "hash": "710005524313267084712972906886410666575"
+    "hash": "306005297419514145012296582573767372391"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u128_to_i128",
-    "hash": "14730433835424978990867920374924590632"
+    "hash": "98012503510385937147194796412240500392"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u16_to_i16",
-    "hash": "247352863263322650016873101910041811997"
+    "hash": "35381324470640860253475376990831874815"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u32_to_char",
-    "hash": "31805302947362972159813743456694075907"
+    "hash": "61525275732514773241268181490815915222"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u32_to_f32",
-    "hash": "1467560049720444138016057764334994834280"
+    "hash": "395776834924101650611275237152382322635"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u32_to_i32",
-    "hash": "64656489632266919012086406175916155458"
+    "hash": "16436321000473981242264740181521142566"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u64_to_f64",
-    "hash": "1166136745496660811916334544242857659138"
+    "hash": "141503738022527906210678656054330869275"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u64_to_i64",
-    "hash": "142257722401827607367163443715166478314"
+    "hash": "64363582169024897402779438503863065301"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u8_to_bool",
-    "hash": "356242690992899236251407276902058472"
+    "hash": "28052398809382905773652673033240099999"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_2ways_u8_to_i8",
-    "hash": "110497638763598660612729067213023826583"
+    "hash": "154998292509770305397488068849462127279"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_bool_to_i8",
-    "hash": "40571579524698430387086537325640298370"
+    "hash": "39203700899440265917400988704985247030"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_bool_to_u8",
-    "hash": "1775591543980087589215315424094924804218"
+    "hash": "1328322431176515248111217608179330832622"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_char_to_f32",
-    "hash": "177139623738008497695853902807120689049"
+    "hash": "1333890996293065603316681353101584142375"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_char_to_i32",
-    "hash": "174276956716299923301076473950890704302"
+    "hash": "17780157183772669921504144962980565071"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_char_to_u32",
-    "hash": "1799567746277363425216106955802785348034"
+    "hash": "1786382183564610409914617647513986469323"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f32_to_char",
-    "hash": "50743283851099475104739055859366888389"
+    "hash": "397677672020361461813389590420128063435"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f32_to_i32",
-    "hash": "84518791777509346395179572784757730962"
+    "hash": "471489478375305200314399649058520043389"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f32_to_u32",
-    "hash": "1501079994757302346510385981513059757366"
+    "hash": "87499970972966097741050693380752103765"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f64_to_i64",
-    "hash": "589581261955707399318420404624126798652"
+    "hash": "1757286875861455595961788563704209399"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_f64_to_u64",
-    "hash": "42766365128279153521618304796815784391"
+    "hash": "608087901346814287715515078879775951314"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i128_to_u128",
-    "hash": "174274986468377306414730781832164688761"
+    "hash": "186794990443526797316535734874460985972"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i16_to_u16",
-    "hash": "524073745828649617211518028619573411938"
+    "hash": "112712733727129411387298199480036600765"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i32_to_char",
-    "hash": "1643862032976969642013662408187349411099"
+    "hash": "1088585154132639452010170750555012003474"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i32_to_f32",
-    "hash": "70530107434988156832300109308895397726"
+    "hash": "470116501538655423812735279125062926247"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i32_to_u32",
-    "hash": "135058437817578607868311711810828150092"
+    "hash": "77042960179458751515430033852317922613"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i64_to_f64",
-    "hash": "60649827606860866191132754128291331024"
+    "hash": "383013820168509871613268882013974685449"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i64_to_u64",
-    "hash": "131646533596745016708207583188300414861"
+    "hash": "172317501345473276432125342110539786268"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i8_to_bool",
-    "hash": "1838346132269797411010422713578965205699"
+    "hash": "67556597945921850162536870036321551828"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_i8_to_u8",
-    "hash": "106667555771206196981258209043689752281"
+    "hash": "480461923696496213010615688926525618078"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u128_to_i128",
-    "hash": "158397684791320462935671247663460484335"
+    "hash": "1694901948628501264414856731769966419305"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u16_to_i16",
-    "hash": "104045080215578638026379125725669233200"
+    "hash": "5762704782027590712971158976976347294"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u32_to_char",
-    "hash": "181267809824376906879981013654159777232"
+    "hash": "767373897084728104513874884705539342878"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u32_to_f32",
-    "hash": "80344282304707684566457116616434038815"
+    "hash": "1766928874225674123013253975587316276661"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u32_to_i32",
-    "hash": "1841514990413977653111084869772279111640"
+    "hash": "411666566584893805013643366047274028279"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u64_to_f64",
-    "hash": "135472670910851948152976097386670490751"
+    "hash": "114770409388146779833994854775126609920"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u64_to_i64",
-    "hash": "122337735156644273472426175594335932962"
+    "hash": "421887076808131971013307193852329609377"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u8_to_bool",
-    "hash": "150358031962858492953668125965430113332"
+    "hash": "969749409976288813711823671769941967183"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_unchecked_u8_to_i8",
-    "hash": "15416710319949202021834867917907567882"
+    "hash": "1401366778904823521212037998935931500286"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::transmute_zero_size",
-    "hash": "1688595152874343380718088245850655928251"
+    "hash": "499620493798060932310788748314603745263"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_arr_to_struct",
-    "hash": "1242949800376913500011724981220200922013"
+    "hash": "941253467692189555415119967480748210402"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_arr_to_tuple",
-    "hash": "6451869781767694869804877125603087923"
+    "hash": "73192188090626938897841815496032941087"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_struct_to_arr",
-    "hash": "182529845188673921756093299657876947142"
+    "hash": "1466183784157681664210365205932630928284"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1620259353822693536711727230643866603693"
+    "hash": "1399343070618708880617155774749814825371"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_tuple_to_arr",
-    "hash": "1480018346818938489413859529412373367113"
+    "hash": "598659216587485298415512167419975392100"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_2ways_tuple_to_struct",
-    "hash": "559168905688288478014312564999259109015"
+    "hash": "457268697072278421614932835125838153521"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "6311225056220231200361745354661468797"
+    "hash": "146515658176943791961203440113321469278"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1158873978894551434213527000470898031579"
+    "hash": "115173235070657408634940433242723785551"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "80757242519582470191616488329052454026"
+    "hash": "678191375821788441210805984348159624374"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "34768440520632385354805272716725155903"
+    "hash": "47423823707329831139825605923793738159"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "105877637475590325094181243572074883127"
+    "hash": "121058813025174967551125287178131583316"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::tuple_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "64529574663391420139447806965852690783"
+    "hash": "81128718632068810981403107706594330594"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_arr_to_struct",
-    "hash": "87560304681309063284628654302484437552"
+    "hash": "6147682608914230193183969265257446810"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_arr_to_tuple",
-    "hash": "896991178947151963714293181847144325364"
+    "hash": "172093645190810031307965417103015663859"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_struct_to_arr",
-    "hash": "57572667908953354163252681501313342718"
+    "hash": "12733944326069406851408957682278333489"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1219314550987626750417320441573752636860"
+    "hash": "154579043935092572009891513008217319628"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_tuple_to_arr",
-    "hash": "248019648420538384511893110021188584414"
+    "hash": "60543047892402497685831736045156357717"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_2ways_tuple_to_struct",
-    "hash": "408836984793484945614170725774218345500"
+    "hash": "118150950244375543466072330756634262867"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "1620822783167990148211637666479410727601"
+    "hash": "1554348320500651746813237272563451148469"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "713128504018382238015769212604365956249"
+    "hash": "79308899115356149243247578727240040227"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "173250042814265476281046339078296031632"
+    "hash": "1505042777210719993710107443870890154085"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "15142138272567327329518077857942770155"
+    "hash": "133861970629973675054549247214350830833"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "107431300450262689069177052316108312671"
+    "hash": "924813039965508305110318395442395653139"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u128_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "1185972420294812275113132290095068741985"
+    "hash": "104480564037026185114573493720882129075"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_arr_to_struct",
-    "hash": "1400426107303116286916146221633257955244"
+    "hash": "114163356432579276016383281717982833767"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_arr_to_tuple",
-    "hash": "95729408462414267554363324225561031436"
+    "hash": "48861987586188574593927542320161276063"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_struct_to_arr",
-    "hash": "944086809461181108616332609118361121164"
+    "hash": "182464465074586406716241442285501423677"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1596595056946706132213224090016971129098"
+    "hash": "68839938751831832658958013738687955863"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_tuple_to_arr",
-    "hash": "69360557044774908866612556606067313762"
+    "hash": "214620408434228363812301839171769111954"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_2ways_tuple_to_struct",
-    "hash": "107728647604726859029349929987554804997"
+    "hash": "27346462861338733895394429731495709725"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "1339244457647116339014232702395648146488"
+    "hash": "1793092421061952957912604426762338059007"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1693441605001390291459947713724680660"
+    "hash": "63507605800288153407077009887841396697"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "158852642210891080967591261141470186997"
+    "hash": "565997117188039027411543864095678215966"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "142644099852661110626271220888045116770"
+    "hash": "151513945171440174947316417371758361678"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "160949526281391937551323383773067349613"
+    "hash": "439924013339821610915846078009272766258"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u16_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "9964025946777040518656440953604030752"
+    "hash": "149292572481523640877974316176992104155"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_arr_to_struct",
-    "hash": "697252897426514195711804326219498174155"
+    "hash": "668941744489585285814433634927243741280"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_arr_to_tuple",
-    "hash": "1441884191000259280710415640499289469189"
+    "hash": "23888516328993999055330400968185768605"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_struct_to_arr",
-    "hash": "1340457831517701267816674789855469343027"
+    "hash": "69309176953551968187401127218241465939"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1095560391771752729615002400098732919245"
+    "hash": "762737358127493661111879842055939497438"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_tuple_to_arr",
-    "hash": "75253019969858946118839644459115831703"
+    "hash": "500818771297247874016984734901846704561"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_2ways_tuple_to_struct",
-    "hash": "181107419785328940426134490123612242155"
+    "hash": "1164336934777370260312467339236724069107"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "55394153973757147814696552265358051830"
+    "hash": "72363292510866287415109858993223727770"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "766971170826575242812499046223726891578"
+    "hash": "1687114987564127243512879412316718808835"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "151341235129625187866207036438455327527"
+    "hash": "121882558234065522327312433604287342808"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "136733214397715396268921968303411363732"
+    "hash": "168720922162367677128852133707669492712"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "822845920155144511211108026657145946680"
+    "hash": "29329396205169077416996702572830912141"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u32_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "89207015235671720815837245581370944855"
+    "hash": "88729583703553559596782457843320444473"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_arr_to_struct",
-    "hash": "691061749589234294017032963883506587679"
+    "hash": "20231151165990813207021819428837037271"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_arr_to_tuple",
-    "hash": "141308975431550224281443470628416571753"
+    "hash": "152569399462298904737740663479274494072"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_struct_to_arr",
-    "hash": "1494227107700885727315077150335863750627"
+    "hash": "1006295602695234140115874893523866687525"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_struct_to_tuple",
-    "hash": "156556465767750394819787953690071065633"
+    "hash": "311924515547707351913486042638477638371"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_tuple_to_arr",
-    "hash": "516235745431427379517798844118732137749"
+    "hash": "14191430902925138061792977846512846885"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_2ways_tuple_to_struct",
-    "hash": "100580129071289671814921725797679701991"
+    "hash": "81195997563156969639194343561468521099"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "95415916296551072928561459585115114529"
+    "hash": "9356645719260393021647692465914326731"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "29259843842929338565852124902496737846"
+    "hash": "934756421805699541716227349430796526225"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "78712815343326167313823974800067149658"
+    "hash": "346519692692135629117282383947811102817"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "44002218499606348787115458247460668661"
+    "hash": "30736919165201671234874992590979915335"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "27259564758987610157639144868756409156"
+    "hash": "1373685961298648135613012510264985461296"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u64_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "720372444301103004317073957650329399761"
+    "hash": "181732097020031339207230778803848350554"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_arr_to_struct",
-    "hash": "111855566886697997176708295030499335313"
+    "hash": "1224459017493261935113909496448479134571"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_arr_to_tuple",
-    "hash": "169951859459787285713480151847238105883"
+    "hash": "155758320693798435431251088685433257993"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_struct_to_arr",
-    "hash": "1605285197485675838612351897663879703177"
+    "hash": "1179091152129235859018050543439998760705"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_struct_to_tuple",
-    "hash": "1508479806861026300912034470411722778063"
+    "hash": "72279860681301787359940202072319019707"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_tuple_to_arr",
-    "hash": "8842853494882443339997473325092810066"
+    "hash": "457212396308489680515673619659956079151"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_2ways_tuple_to_struct",
-    "hash": "1233468274084216617016472471726357231216"
+    "hash": "76801601819871806562621702531038455938"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_arr_to_struct",
-    "hash": "1644979239444676853215033476853774174129"
+    "hash": "356619604960476256612530900536844548017"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_arr_to_tuple",
-    "hash": "1670080810392953386816426317610138621757"
+    "hash": "134188854215328695513334055466375180783"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_struct_to_arr",
-    "hash": "83177126884486105078595478124648925791"
+    "hash": "132353983149677870847809273491871615386"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_struct_to_tuple",
-    "hash": "623647152302300431311674913020226196753"
+    "hash": "668329820840504282816227986213749058821"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_tuple_to_arr",
-    "hash": "105672149854026198252573575766054222845"
+    "hash": "11877487420956021211506557124079752603"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "intrinsics::verify::u8_mod::transmute_unchecked_2ways_tuple_to_struct",
-    "hash": "58395005556061348573615230311429036947"
+    "hash": "1631190164247486557617246320202048379308"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12876,7 +12876,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "num::from_ascii_radix_panic::do_panic::runtime",
-    "hash": "572222327024561109410458886622292987798"
+    "hash": "8085340008954982436007559992596241522"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12886,7 +12886,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime",
-    "hash": "164918453571405400974074030407238101404"
+    "hash": "42705179931592161279303093456354038844"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12896,7 +12896,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::index::slice_end_index_len_fail::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12906,7 +12906,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::index::slice_index_order_fail::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -12916,7 +12916,7 @@
   {
     "file": "core/src/intrinsics/mod.rs",
     "func": "slice::index::slice_start_index_len_fail::do_panic::runtime",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/intrinsics/mod.rs",
@@ -13381,12 +13381,12 @@
   {
     "file": "core/src/mem/mod.rs",
     "func": "mem::verify::check_swap_adt_no_drop",
-    "hash": "153356910755839419144111258713658110160"
+    "hash": "1468458490891763406918132998733463594442"
   },
   {
     "file": "core/src/mem/mod.rs",
     "func": "mem::verify::check_swap_primitive",
-    "hash": "249109524093011347315364397622148827717"
+    "hash": "713263532860424991916659848523870537330"
   },
   {
     "file": "core/src/net/ip_addr.rs",
@@ -13711,7 +13711,7 @@
   {
     "file": "core/src/num/f128.rs",
     "func": "f128::<impl f128>::clamp",
-    "hash": "6479907919745990292693314104600846808"
+    "hash": "27305651964845757727810448081293979420"
   },
   {
     "file": "core/src/num/f128.rs",
@@ -13946,7 +13946,7 @@
   {
     "file": "core/src/num/f16.rs",
     "func": "f16::<impl f16>::clamp",
-    "hash": "8889720973201245612464821855150462729"
+    "hash": "1431444161292499658414512782103964732057"
   },
   {
     "file": "core/src/num/f16.rs",
@@ -14171,7 +14171,7 @@
   {
     "file": "core/src/num/f32.rs",
     "func": "f32::<impl f32>::clamp",
-    "hash": "82766645379776897966239759618439045427"
+    "hash": "77221412034397648712824431664785264328"
   },
   {
     "file": "core/src/num/f32.rs",
@@ -14411,7 +14411,7 @@
   {
     "file": "core/src/num/f64.rs",
     "func": "f64::<impl f64>::clamp",
-    "hash": "89832384597360019478181443658524137375"
+    "hash": "794722660488271877317009445203348662254"
   },
   {
     "file": "core/src/num/f64.rs",
@@ -18711,907 +18711,907 @@
   {
     "file": "core/src/num/mod.rs",
     "func": "num::from_ascii_radix_panic",
-    "hash": "391082212406587225615191173387750669490"
+    "hash": "13189432535515488536873851371539412776"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u16_full_range",
-    "hash": "824628260284943159661864229279646158"
+    "hash": "1249970043808570860317208847725935472889"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u32_large",
-    "hash": "1537717584335698134815958902221569048999"
+    "hash": "15677168672440338312576232817343167077"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u32_mid_edge",
-    "hash": "1231006054060451778612406292321293406329"
+    "hash": "1825211785563604627410744615275765637933"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u32_small",
-    "hash": "1684631527349743180113767378997354970239"
+    "hash": "148692753183044410817258175559846756085"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u64_large",
-    "hash": "1444724056709609981215893737491316997909"
+    "hash": "105923509920519685076890321905079120657"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u64_mid_edge",
-    "hash": "51511843706619116041937035720055873316"
+    "hash": "44081710051214180281950997476103837116"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u64_small",
-    "hash": "1167706481219390876316904382412795577214"
+    "hash": "176244195594976667092012720858218163506"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::carrying_mul_u8_full_range",
-    "hash": "77204947959524010759750302151599803035"
+    "hash": "582422087515056604216954804889906048167"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i128",
-    "hash": "978833740622283457516115635011276547198"
+    "hash": "1427121081446288910812457302507550201832"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i16",
-    "hash": "165025970505183203888632612070084635719"
+    "hash": "1120195155360170544615788382573529081459"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i32",
-    "hash": "67208186192814049426603048684633079861"
+    "hash": "539219750828522020314664655659667419151"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i64",
-    "hash": "181814194332437231856813280762660367357"
+    "hash": "569149059890359527110196704991047816956"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_i8",
-    "hash": "13289186881960258629535192605372747562"
+    "hash": "16386006143532718080760915406259169411"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_isize",
-    "hash": "509522786876887671111345602043300979545"
+    "hash": "143465316349671465367294923723976236214"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u128",
-    "hash": "1578891110741218895414547426550640773724"
+    "hash": "113136942798462332852764443691716519858"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u16",
-    "hash": "972827549486141945516540996624744681089"
+    "hash": "4431123422129033779879029470076876463"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u32",
-    "hash": "136733980166841358631676887036254619891"
+    "hash": "94855926932657844495320540933247464721"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u64",
-    "hash": "121721698910113458941693400347132581484"
+    "hash": "1154660679985782807117243961429810655167"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_u8",
-    "hash": "104357400557413262993392073430034069657"
+    "hash": "96104954434258988205131699201574357984"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f128_to_int_unchecked_usize",
-    "hash": "100278967968299061324789627308948841620"
+    "hash": "899143831861790824118002783431830718725"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i128",
-    "hash": "1809943478706381391913543221244102017462"
+    "hash": "25618759601579960233224702829128999391"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i16",
-    "hash": "81455061771093914614885399807833001494"
+    "hash": "711171067815315271914661939719395123317"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i32",
-    "hash": "60350607535333797731996611704849531277"
+    "hash": "166164085090087049118010379127065817301"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i64",
-    "hash": "45297729115281622141877331296117398778"
+    "hash": "459687332953291487713345144651158057640"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_i8",
-    "hash": "118640510470281325301189978847001192229"
+    "hash": "78173140075082294624690686931277209118"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_isize",
-    "hash": "138253949981659901564922972569970803774"
+    "hash": "70153806396777524241885698588895951319"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u128",
-    "hash": "1142101599089743921115665209010670147270"
+    "hash": "42489223951048354751250718346230449429"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u16",
-    "hash": "182003076907233379391611144576903167654"
+    "hash": "1351418380822822663517457112662970896693"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u32",
-    "hash": "176318586690812083264927965698025394428"
+    "hash": "1801675442878868772618073516676050505139"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u64",
-    "hash": "1153495259199985728017829707080925477766"
+    "hash": "340560467303470010611307726335567733866"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_u8",
-    "hash": "568579686153963626018126439718224994292"
+    "hash": "141035523441698554605814415208621026237"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f16_to_int_unchecked_usize",
-    "hash": "61061756280514368874263876872288983386"
+    "hash": "160481115415766642147632970425696968082"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i128",
-    "hash": "45357257229266360107344815124811337105"
+    "hash": "87891480747840847332792612348948666863"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i16",
-    "hash": "26720902508876026521487255241634334685"
+    "hash": "6033542213948200091233455438458472731"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i32",
-    "hash": "575117114856083829917089652314281511611"
+    "hash": "1760809139270516711411270937313992251344"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i64",
-    "hash": "144717455733977927178506009406330805854"
+    "hash": "11314030918308705189512141645972224591"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_i8",
-    "hash": "142525668462189657745628625747056223075"
+    "hash": "154911708468826220783471096608196161524"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_isize",
-    "hash": "26769873060670325132006587962307792436"
+    "hash": "176858216053879295617766601709794521045"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u128",
-    "hash": "30429546156342235217057216666524613351"
+    "hash": "177725548623570635396993522303694692348"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u16",
-    "hash": "171150320748512275307985984488975127086"
+    "hash": "438376315556943000912840761799358000830"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u32",
-    "hash": "778733836873987871015119875853292943701"
+    "hash": "85408314372831429447709174279437964149"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u64",
-    "hash": "7870493490896907177919728719339650051"
+    "hash": "133908411226501873031931364229980993362"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_u8",
-    "hash": "780060622397445683711180101230876206359"
+    "hash": "71690170847017857551752941904374667654"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f32_to_int_unchecked_usize",
-    "hash": "500314036342640390516053247229102276750"
+    "hash": "470324279820042948910581703009464219741"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i128",
-    "hash": "139746171745786259815306889069760264764"
+    "hash": "129154598739992662024567025457777225952"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i16",
-    "hash": "968771360047422231617270713981680815628"
+    "hash": "9992083971599404354617334490968748174"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i32",
-    "hash": "1380492010288310026218263251514318783832"
+    "hash": "1505219830832851680311000114520788344667"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i64",
-    "hash": "71495237411121913075517062970673771238"
+    "hash": "164716888645406967967907471614242293495"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_i8",
-    "hash": "393264293021864474713301782429787389078"
+    "hash": "14023418333411500139032212042811510225"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_isize",
-    "hash": "1189197566463440098410561009393550501259"
+    "hash": "23005549026323547513211374555943155970"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u128",
-    "hash": "863730285618653365759420896261699572"
+    "hash": "166207288291360243335327665960841018696"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u16",
-    "hash": "4151403074920531953537633784330789477"
+    "hash": "42893981240816423734052863674230672900"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u32",
-    "hash": "44599729353139647352420618256456099215"
+    "hash": "752765932701607724112222637230628299842"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u64",
-    "hash": "148359323500883670353934317873394417370"
+    "hash": "350143591732336880511584783057824979397"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_u8",
-    "hash": "1783426526883664248811186363314377628045"
+    "hash": "2478015978056717617311820088422551623"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_f64_to_int_unchecked_usize",
-    "hash": "21091782126443760321300332088195618819"
+    "hash": "1354891357029701344414470810227137469102"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i128",
-    "hash": "140421870867521079443646924908157155951"
+    "hash": "1013749186596726768713012152501494832141"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i16",
-    "hash": "15804324394481603994855176087374193447"
+    "hash": "68343789891555817243142200253569360134"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i32",
-    "hash": "8238632730041472982332733985428641015"
+    "hash": "1701047075570715911217364379954437613552"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i64",
-    "hash": "1175985131879755791814159135291734478011"
+    "hash": "886045156360048873112760555304345418472"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_i8",
-    "hash": "96220362529995047469534002713346645201"
+    "hash": "214409874265393497511623345821340821176"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_isize",
-    "hash": "91153463015061057823475896129739242779"
+    "hash": "9923857861951517974897975818493487160"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u128",
-    "hash": "47116055130375835651628713500473870966"
+    "hash": "119961033539435008010082081546902233502"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u16",
-    "hash": "827758921188068592714063842495843552189"
+    "hash": "6107685982318083178425082532491552593"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u32",
-    "hash": "11374754300323795711726285988993546029"
+    "hash": "110438353523333858910657418880158370630"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u64",
-    "hash": "1446295761027461846315987624412670347536"
+    "hash": "1200448108486391431312301260975809195309"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_u8",
-    "hash": "7264010339901700965741002536646612431"
+    "hash": "800817383691493688414615751163426988002"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_add_usize",
-    "hash": "139542109014261973004490748287665537319"
+    "hash": "108530574253469523643838248653581919537"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_i16",
-    "hash": "909440523705038587018143410324582422085"
+    "hash": "1387905891481403345511259874807665344245"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_i8",
-    "hash": "57108695913641384271185418307563114466"
+    "hash": "1492170100879605530510578173094822546497"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_u16",
-    "hash": "122746193386374189899973501097539819385"
+    "hash": "942700659256999177513956430969055562140"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_mul_u8",
-    "hash": "3752173014653082815407013514643546398"
+    "hash": "51126573755411395689630491929625371561"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i128",
-    "hash": "26232306569782581089911815586829987307"
+    "hash": "1238515567443510577511031396571533205025"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i16",
-    "hash": "29456679265823307441659930142281511481"
+    "hash": "42271907767383313302828168913515368388"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i32",
-    "hash": "53717516097476101283170957265935548227"
+    "hash": "1063627082037733943216357538470152850694"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i64",
-    "hash": "306160513162314186616064739900562474697"
+    "hash": "1689178359101401992211127643102361763569"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_i8",
-    "hash": "1521686720167345094913751368793024500183"
+    "hash": "1436022730384850965610347102492139437879"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_neg_isize",
-    "hash": "907678476538512923612754483983141650096"
+    "hash": "1573287251293698691411299920878380615939"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i128",
-    "hash": "95318338442787312186065867512430690716"
+    "hash": "130816155578122745365384605679474628696"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i16",
-    "hash": "1467578668439080352813460441133071150073"
+    "hash": "135338504328137606616332517051991950563"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i32",
-    "hash": "152073267818902179804130642921123883908"
+    "hash": "161651709658220517861059375003837612990"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i64",
-    "hash": "1117958921169778258517361013222365512493"
+    "hash": "1631559893009888129111899306849316400665"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_i8",
-    "hash": "1196975807458080743711208556230896327992"
+    "hash": "281719662670971816318362051691814169326"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_isize",
-    "hash": "1101975348372065642816512288743683404474"
+    "hash": "18113317400600305127352701070190740488"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u128",
-    "hash": "169653152085358931256691298857610020332"
+    "hash": "151567894333574530388563038928218233515"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u16",
-    "hash": "82550117494484070222399250299787363447"
+    "hash": "67353996127582813564527446535932950089"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u32",
-    "hash": "20142923965630186639142474056572355419"
+    "hash": "281424207740908059412242870558515094382"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u64",
-    "hash": "177157500111898294108537584680329356474"
+    "hash": "817077741114136821616161799179845331107"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_u8",
-    "hash": "11837744337220533109413713715514285037"
+    "hash": "161826768988739874616847001547576078030"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shl_usize",
-    "hash": "864557628653698813113521344400510984167"
+    "hash": "15802612868932521715425074614467106239"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i128",
-    "hash": "173818362017632185451460595662633984656"
+    "hash": "56075537140702143111707294896304206526"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i16",
-    "hash": "5200261361814415823285668822916347326"
+    "hash": "50141855081288800175616535445391715721"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i32",
-    "hash": "620357452829611802514461438333603766803"
+    "hash": "112005351312926100871225631021904796206"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i64",
-    "hash": "906698639802172375413475337653390308113"
+    "hash": "51044092430462539511019274434642397090"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_i8",
-    "hash": "62085936530038912439427412643619960148"
+    "hash": "83676608362567567896840210612731659188"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_isize",
-    "hash": "380984251563493647316593266211807286354"
+    "hash": "33285410351229324262572316007475913386"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u128",
-    "hash": "40163674990049989317479389687622790657"
+    "hash": "17102167891828213005432191165783539702"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u16",
-    "hash": "926902178425755096415702446890175213354"
+    "hash": "175205519590150987186500876090169072387"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u32",
-    "hash": "13245944577964542386680779331048797442"
+    "hash": "101725624277884246734637766575774587772"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u64",
-    "hash": "1119011750916484234213701536125658310943"
+    "hash": "38574545195994965073828693117216512537"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_u8",
-    "hash": "72025485340112840216032276476095375336"
+    "hash": "11501172996550724381923517564431320492"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_shr_usize",
-    "hash": "12830372244145678881656180054611698849"
+    "hash": "1220350965462862334936560843198554765"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i128",
-    "hash": "997495286932748723015367246098436168838"
+    "hash": "15661733668056662697879643813940425946"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i16",
-    "hash": "433579036773151637617251397718191472994"
+    "hash": "79069296674750979983536088144962550807"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i32",
-    "hash": "6218254432116676014777687830241390746"
+    "hash": "1343776545600935849113571546718272635600"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i64",
-    "hash": "56766550051106056523022955140889142363"
+    "hash": "1793383479287264573411447327679782260784"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_i8",
-    "hash": "179768235135932966307085773462330601480"
+    "hash": "744255408706100368316655043775792094824"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_isize",
-    "hash": "156236746725080190393886819001348922557"
+    "hash": "722190847034914777111862276935748077088"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u128",
-    "hash": "126358604668963378512074268101315521808"
+    "hash": "99251608325879286446892061833741379090"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u16",
-    "hash": "17829158232833270880838378421706420082"
+    "hash": "140209811954626366314873662605736231329"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u32",
-    "hash": "7840254206304867086193735156615167081"
+    "hash": "20406708838384393278573529601480800573"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u64",
-    "hash": "922027693234233903220882374001745577"
+    "hash": "98399071874282285238680318179210988155"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_u8",
-    "hash": "9190182936490854723060582928396211227"
+    "hash": "12363779816884001937302513559058965584"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_unchecked_sub_usize",
-    "hash": "14900079129916834897547582967888715558"
+    "hash": "1597878910533096408314295105970152316309"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i128",
-    "hash": "163905743074246763003081779152158428196"
+    "hash": "291770625548891802312036118488487737806"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i16",
-    "hash": "166117821613177295249643325491475810962"
+    "hash": "796046107288115407710411382406332182461"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i32",
-    "hash": "606631281348003327411167055238475545103"
+    "hash": "160724595098070243818371734809327314205"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i64",
-    "hash": "1649652616229135673217797458848320050477"
+    "hash": "1183050073542647139417135983135443288549"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_i8",
-    "hash": "174240888478006126793927810018725545821"
+    "hash": "589064955558552596816426659742629147323"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_isize",
-    "hash": "108858793842611213181389648118155045231"
+    "hash": "147883250817865286274506805453381697578"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u128",
-    "hash": "176307721224129773547873211542893623928"
+    "hash": "152175983159793938622099356494349715483"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u16",
-    "hash": "1814501156679227602010759610558929102226"
+    "hash": "135031922537543658856856453724735907445"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u32",
-    "hash": "141540853946179869275689912917388699725"
+    "hash": "860644457052785433216289491924276940132"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u64",
-    "hash": "25208251457935250498880796196354940620"
+    "hash": "1254969146998978004111906339476421320990"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_u8",
-    "hash": "96335570293831535814462038442648955736"
+    "hash": "665002851525094953713880803929540086950"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shl_usize",
-    "hash": "21428347190932051063206881635457924000"
+    "hash": "1507214355554830747315061708678188416319"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i128",
-    "hash": "1660603540427905272214908671928964514784"
+    "hash": "58960001368002692057703816013096625520"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i16",
-    "hash": "1398115521861912169116835342872464910231"
+    "hash": "169860511738603974479890648747705775087"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i32",
-    "hash": "62015263569223281236953346704742732694"
+    "hash": "1181897753367418400918126677090764543207"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i64",
-    "hash": "181943994971741449842646270402023626432"
+    "hash": "18292700657620554299702320975636703531"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_i8",
-    "hash": "114241434323583883816315073205367459711"
+    "hash": "44394187250689369145888942848145883071"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_isize",
-    "hash": "32507398557777333152511136389539566365"
+    "hash": "847910514765788008516952794162664083288"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u128",
-    "hash": "1719585067799424107517563635092904268701"
+    "hash": "204637962994250387311162431976073540535"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u16",
-    "hash": "1121811557254221748512196453219622201152"
+    "hash": "1463680007244058972910391829916043253047"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u32",
-    "hash": "153153909918833406741076139070773333930"
+    "hash": "828500877657173471011347920534509775313"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u64",
-    "hash": "126135795132087687828521208785405403789"
+    "hash": "140727148594991800939139522075932578007"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_u8",
-    "hash": "1809137496327017738410051520152087475745"
+    "hash": "1807803657704834837712980372993461351657"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::checked_wrapping_shr_usize",
-    "hash": "71962498628975341342522853599387533458"
+    "hash": "307639422562486222815427675628741435058"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_edge_neg",
-    "hash": "181028627897073060205562212240246609369"
+    "hash": "733483128992203573811349661401873164531"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_edge_pos",
-    "hash": "90564796992807741216514298942216248607"
+    "hash": "1646611039044622108912715269796509117544"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_large_neg",
-    "hash": "1178884306892636538816185549293126688138"
+    "hash": "47948165602340441234242918943600433045"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_large_pos",
-    "hash": "634562276727068660016030116426699955094"
+    "hash": "121724881926455918987488858668725653265"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i128_small",
-    "hash": "1754400765320494769915871750915272792660"
+    "hash": "51825711364671454006635959386503080011"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_edge_neg",
-    "hash": "88721800021910781748261693495513882106"
+    "hash": "821054039508505409117381486996388544317"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_edge_pos",
-    "hash": "177136490273364937464667540781870492149"
+    "hash": "4987615825332353055098735419323298107"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_large_neg",
-    "hash": "1789228387515935376014623022293187081628"
+    "hash": "45334897280937202805833457717076686239"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_large_pos",
-    "hash": "159007315204723416596339248315860926486"
+    "hash": "275320056442928788367002140976877859"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i32_small",
-    "hash": "1691617297211389100110345169579456743516"
+    "hash": "123727308858597111618064317424149186684"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_edge_neg",
-    "hash": "44575141401344217714243047119617592240"
+    "hash": "17416554860753083991098846876662533302"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_edge_pos",
-    "hash": "91124527090015212246046164618731181423"
+    "hash": "179367510777195083419808533001597276832"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_large_neg",
-    "hash": "472915196007257210812864355961737605541"
+    "hash": "67571053480756536126931535797288104836"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_large_pos",
-    "hash": "585703463520876223116427844160337253747"
+    "hash": "1579608339928725331313607553569843492018"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_i64_small",
-    "hash": "14801253290943900366128891287508098601"
+    "hash": "99923852101650002733351137108294650604"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_edge_neg",
-    "hash": "209962094439989699214074681567636389220"
+    "hash": "41795348871453971473513185627809110155"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_edge_pos",
-    "hash": "42938962094926901471426033679886550855"
+    "hash": "1192996701334529366413269442256741211900"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_large_neg",
-    "hash": "676160450159951055224526363026397983"
+    "hash": "328086369763562153716839943300740900733"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_large_pos",
-    "hash": "561210702612501728913533135990538025866"
+    "hash": "28826166932437098464879480946243399780"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_isize_small",
-    "hash": "125875074041845656618776397708476168504"
+    "hash": "1841656020665546093813117190082667121106"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u128_edge",
-    "hash": "1200915612411021894816766821042939506882"
+    "hash": "178773728087264777023704633492806996053"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u128_large",
-    "hash": "98497934617570775036463983993753102228"
+    "hash": "1441273291239288240317499922030371307676"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u128_small",
-    "hash": "1244022527117567168017647527463412320302"
+    "hash": "129887996626158186945101773713168875503"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u32_edge",
-    "hash": "3884002936295768704602664430489303290"
+    "hash": "1574759844985881208615856467258328065674"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u32_large",
-    "hash": "80664823815821781165918499663937068776"
+    "hash": "46342281599269840038522698536670101327"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u32_small",
-    "hash": "15833245755650818592438632780370917970"
+    "hash": "12414035624332303707435666225615879148"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u64_edge",
-    "hash": "1811235923209422316010501832586199508285"
+    "hash": "18101713586988318774349239061897775433"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u64_large",
-    "hash": "184204516272526672915700590612056236840"
+    "hash": "142813824249079413891123085800477317467"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_u64_small",
-    "hash": "7017747722996444193266469555937018512"
+    "hash": "1762818972982369980813818296160828840061"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_usize_edge",
-    "hash": "51017123691936637189460005465894826292"
+    "hash": "9412589549068802717605923784944996017"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_usize_large",
-    "hash": "68447599651681355112069600132405107537"
+    "hash": "67664687108034576133628049324915134504"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::unchecked_mul_usize_small",
-    "hash": "16017432234036677608650065958024043992"
+    "hash": "1477831419004945322717519845194733673140"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u16_large",
-    "hash": "52661343262781590767691498984147775102"
+    "hash": "50068605144568914433934545903642756744"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u16_mid_edge",
-    "hash": "120665964001343227044199005357765682480"
+    "hash": "98492860636491075564140208850058056095"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u16_small",
-    "hash": "148206783586962667812751408533000425768"
+    "hash": "103374553300674810197153430454733509894"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u32_large",
-    "hash": "1617538316488461132116815318090266740646"
+    "hash": "251530385105120101914530088484864406771"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u32_mid_edge",
-    "hash": "54117699716891695188019537006871189258"
+    "hash": "115833906427772198341326892416864012683"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u32_small",
-    "hash": "109552123566196504381418384779378218422"
+    "hash": "1440287539449244552412004359381825043729"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u64_large",
-    "hash": "128804927339672601745390628831931191478"
+    "hash": "113398313014780273651209470183644678774"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u64_mid_edge",
-    "hash": "44642181510217098278703826082786802296"
+    "hash": "834410229287065825810339209139561780208"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u64_small",
-    "hash": "1373397704607730042210011199034834277694"
+    "hash": "336829030257804530812555155089460812645"
   },
   {
     "file": "core/src/num/mod.rs",
     "func": "num::verify::widening_mul_u8",
-    "hash": "969726315231982244111001762348180540520"
+    "hash": "959263565493464236811407511942375624205"
   },
   {
     "file": "core/src/num/niche_types.rs",
@@ -21796,572 +21796,572 @@
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_edge_neg",
-    "hash": "1350954067009605647517304967874444315200"
+    "hash": "126572793536358400019218629183701727927"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_edge_pos",
-    "hash": "821079974239472848813390198456140512526"
+    "hash": "617152071739997730714832266048864152196"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_large_neg",
-    "hash": "1331169959360005897717937909889823126399"
+    "hash": "704748448655807552717769005428419601573"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_large_pos",
-    "hash": "5427161078347573529442678979205270010"
+    "hash": "92277720174285082725156688912912126737"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i128_small",
-    "hash": "54075949015745521431025894055876620359"
+    "hash": "108176305069058275692667682465754456323"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_edge_neg",
-    "hash": "69547579302224818798990089875839095649"
+    "hash": "1461070617189157915613615872352069367060"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_edge_pos",
-    "hash": "116860872666182731556887621523252528425"
+    "hash": "1601299044791821897814374118106569033877"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_large_neg",
-    "hash": "603258445035072655410160366751647842016"
+    "hash": "1596908716003316406631802725969931013"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_large_pos",
-    "hash": "97657254800942132368633156622708559125"
+    "hash": "121276882178520233097968780928995728841"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i32_small",
-    "hash": "47895841336973867095709096090728525747"
+    "hash": "31833373228380865315903831266610214925"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_edge_neg",
-    "hash": "328925778130286881817728294671966576"
+    "hash": "85823485034441710989014628044021459486"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_edge_pos",
-    "hash": "356246848510348848411458863579405386066"
+    "hash": "166550564275675197026790305540979740786"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_large_neg",
-    "hash": "1614572249627657434611221907902610339415"
+    "hash": "327901659613034652513665598284695758896"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_large_pos",
-    "hash": "1183839190922589559212689910659774511006"
+    "hash": "1380825610344678785012080380502518213022"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_i64_small",
-    "hash": "166496139797835000483207362115872787888"
+    "hash": "685016366446277010516992771972832618646"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_edge_neg",
-    "hash": "50769394231845448891613623037117688816"
+    "hash": "19980427794151860184731835472423081487"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_edge_pos",
-    "hash": "126424965318127359166305227084244956704"
+    "hash": "101436316626006148022177233618847696542"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_large_neg",
-    "hash": "1134912025711687114918353452394662781479"
+    "hash": "166250470237382669692132937381019748823"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_large_pos",
-    "hash": "83542034851892431072428885042846916833"
+    "hash": "1772588611697117897412715865787409827890"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_isize_small",
-    "hash": "1362279185159837897017257448221240767377"
+    "hash": "639116529229422822811475098480299763444"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u128_edge",
-    "hash": "900673762467540125516417236160418981184"
+    "hash": "61168995301618123754567642490735366239"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u128_large",
-    "hash": "412112989576125776810996455877757780652"
+    "hash": "112952566492483858838634345755624760616"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u128_small",
-    "hash": "788351824859520995914671530639060037774"
+    "hash": "1519964195343615618010736892424085798859"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u32_edge",
-    "hash": "146624649357762962949324252775425554884"
+    "hash": "159487785064608153229138797105090897539"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u32_large",
-    "hash": "181225162059182766541530555644444346311"
+    "hash": "1143699339291646571613815460692899519375"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u32_small",
-    "hash": "93031915036229791089613860563284128816"
+    "hash": "26223064567492145357322101272651782808"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u64_edge",
-    "hash": "175933572343254428407977735170683856120"
+    "hash": "97678371302315629375030598889507837339"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u64_large",
-    "hash": "541551602129878394410276815110642298146"
+    "hash": "108959077315092336286853079520427189059"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_u64_small",
-    "hash": "178979525440224735676421275699047740346"
+    "hash": "70177827549721850489952549761567362824"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_usize_edge",
-    "hash": "5589282360428875754285944419233750608"
+    "hash": "67268602030065140479105180656400331057"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_usize_large",
-    "hash": "403085430226758524914029130865904750460"
+    "hash": "365034312439451527915486963416187506191"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::check_mul_usize_small",
-    "hash": "1716814606849695420714384414650362457282"
+    "hash": "8653486808193501437469764754577587877"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_128",
-    "hash": "93703547081561170416454620886126796235"
+    "hash": "148827628993622428037983243069587473278"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_16",
-    "hash": "123344103509599540442311968629930726306"
+    "hash": "1033369380621472120517067278467459242156"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_32",
-    "hash": "148770954170871136034828279495189165005"
+    "hash": "1240451548243773341015864219946584576351"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_64",
-    "hash": "93154856975983741245105565295569747231"
+    "hash": "1152855587663765360810494232739092875384"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_i8",
-    "hash": "1333894560838712118317964640214647774937"
+    "hash": "1588971185174003914613680862082031755129"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_isize",
-    "hash": "468650370462332952113176431786491811495"
+    "hash": "55874472397056396349911388959153266720"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u128",
-    "hash": "165042360902948802153874056886638234188"
+    "hash": "116886748051959823708577380828969143484"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u16",
-    "hash": "1463620064932788598116251137361366309971"
+    "hash": "1258676861928892533510350395489504380252"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u32",
-    "hash": "4905819915468732525616698018301012660"
+    "hash": "1762146383009082999017067639265957444227"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u64",
-    "hash": "255662359416667329017166319385072947421"
+    "hash": "1416292783755576593416521939285071313242"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_u8",
-    "hash": "1458300693283128348116113920851531683683"
+    "hash": "19598661848323572313870618746243516038"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_for_usize",
-    "hash": "29450036314912462939620196311946707262"
+    "hash": "85184058513992240001968145105781025119"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_128",
-    "hash": "156718071009335255736046900612345617375"
+    "hash": "1071273289518460988315606908391941573309"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_16",
-    "hash": "564443458170849765613143197215699072892"
+    "hash": "806214682809580249814233692663246638991"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_32",
-    "hash": "12022051867484936212961144523756267650"
+    "hash": "1413867615654356819513202394661631875654"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_64",
-    "hash": "161577732571473163629044092186295118911"
+    "hash": "157651531916639452149198597179486494592"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_i8",
-    "hash": "148613928287448639187328615253307708692"
+    "hash": "1360269077762570390315361633620274033505"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_isize",
-    "hash": "127723862426250906742535460070834797727"
+    "hash": "1820032885601911880916357674684660463665"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u128",
-    "hash": "1417644278807031499469260523203498749"
+    "hash": "24843930075952661510550849333537225"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u16",
-    "hash": "678119320457297862111714912565448822747"
+    "hash": "62560979100836699844011304375225026795"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u32",
-    "hash": "50648294182048318641780486478443258186"
+    "hash": "156855911831732783399118586235009662476"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u64",
-    "hash": "82794497349078554456591483166829338074"
+    "hash": "75149804409756581833716332101361873"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_u8",
-    "hash": "10737208447664048987261958690251210605"
+    "hash": "171130382060420492758419850466734550207"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_clamp_panic_for_usize",
-    "hash": "97053545153964482032675896643828554741"
+    "hash": "1265427547096133333412165861730323277437"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i128",
-    "hash": "171602560502813700918541631830610901910"
+    "hash": "1142190084957549322016821841248653949565"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i16",
-    "hash": "709841195968631465111645189713636405120"
+    "hash": "1351996178002149021967629992628631852"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i32",
-    "hash": "876165373641999284813584835101943932573"
+    "hash": "366488170376604632217901966363000030292"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i64",
-    "hash": "179048859016107488845645093824519383109"
+    "hash": "694473826870531435716969018660428392413"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_i8",
-    "hash": "48454321201879367509137379907559104893"
+    "hash": "1458143571361305462613119623973060571581"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_isize",
-    "hash": "58970843558256445613125646072095163242"
+    "hash": "134795168582998640116726225514319457256"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u128",
-    "hash": "1620792998246326460518352796310350345470"
+    "hash": "107906159493707829148008339860219047015"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u16",
-    "hash": "963130695582906220614128067839225404218"
+    "hash": "1116044549999028858212171070422562368877"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u32",
-    "hash": "76405854881770126747866801063147677780"
+    "hash": "165833707814918794307530798797250027753"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u64",
-    "hash": "1192836152912340199729513595150993442"
+    "hash": "112143737582213996239182831328173823712"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_u8",
-    "hash": "138742408411770792412940459591925718458"
+    "hash": "97244155574088017189292497322963056843"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_cmp_for_usize",
-    "hash": "102292901466821942735010997332886363913"
+    "hash": "75773609675560790301519188078393582058"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i128",
-    "hash": "111895509296480139584431442350385690551"
+    "hash": "125100165903453613723624293687099466866"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i16",
-    "hash": "1314926580729558330715654979605831926684"
+    "hash": "956425013463182958914445965777864294819"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i32",
-    "hash": "34713624473996998410648814942171696786"
+    "hash": "875785127692585433417666585604318171914"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i64",
-    "hash": "114829921325802499247597591242406265748"
+    "hash": "101112735023125182828083437479258953162"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_i8",
-    "hash": "1134724542287344373816561742445974394034"
+    "hash": "433159241283405752714917389395904245345"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_isize",
-    "hash": "43173692857136623626793739017857958740"
+    "hash": "142153200590953289686011202219604109582"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u128",
-    "hash": "1797843702538038564811457596358500581897"
+    "hash": "1465544347262659686817430655948364568979"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u16",
-    "hash": "170478216540836815309756193264938605497"
+    "hash": "978701429429958124610550223224255037156"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u32",
-    "hash": "244189639995031240112363087964612982489"
+    "hash": "108523388519138631772544677158247080502"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u64",
-    "hash": "24064828247112562185009267445263760684"
+    "hash": "109993947215179179612783338614841588208"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_u8",
-    "hash": "11921740825991565228375103332060215069"
+    "hash": "389471774718321328118283170389221621291"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_max_for_usize",
-    "hash": "13471894792879500992963849969586223816"
+    "hash": "1237821082295203048113601427434151949017"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i128",
-    "hash": "158364411273152863937463428313326900515"
+    "hash": "467114298025684440110647745719967486253"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i16",
-    "hash": "136827000357795164725426242920105835197"
+    "hash": "810166223417308658613148128368555965084"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i32",
-    "hash": "518595974904743187011802887721782409378"
+    "hash": "433896238705981500413766902439739385883"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i64",
-    "hash": "565177157498069140211221763833905624456"
+    "hash": "1130007588884761194515280262759336947495"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_i8",
-    "hash": "128561647959480434092886125645748639572"
+    "hash": "313382336979393079115949474262324141454"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_isize",
-    "hash": "143035899639135214992391414528033905631"
+    "hash": "841649463175008620513088696965136933460"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u128",
-    "hash": "121273281285295588152508760555133088106"
+    "hash": "1274710458107499084017728309538213211176"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u16",
-    "hash": "166457411783348146346994375797733636130"
+    "hash": "36118681092228264461782820900702565210"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u32",
-    "hash": "174667946499198254527144666079156543828"
+    "hash": "259267171635009254414191881059146437764"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u64",
-    "hash": "56228065763088115331930725407075142094"
+    "hash": "88366255159477156945329911588193680148"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_u8",
-    "hash": "124799195535724833384912094574249608865"
+    "hash": "31126541783676949423561256904696637496"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_min_for_usize",
-    "hash": "554098070407523095016840191500154881777"
+    "hash": "1701239896403110668713102698816011169367"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_i16",
-    "hash": "989784028223651178017670382041086109547"
+    "hash": "10181687469926978084284913614101041021"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_i8",
-    "hash": "830636895734763671214460520518412267655"
+    "hash": "1495378042250256632410279754473748418603"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_u16",
-    "hash": "3246857731262710648680268843223213850"
+    "hash": "692268469113344924815698081271285271187"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_mul_for_u8",
-    "hash": "115045582071978069653185272721079780899"
+    "hash": "57953653706289436234834051140338909995"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_128",
-    "hash": "111823965925400256346673723375611418773"
+    "hash": "445853215792059395110251101186523986208"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_16",
-    "hash": "57817106200364795716687389429490421916"
+    "hash": "56546286116300241018661663726763427987"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_32",
-    "hash": "1444563538815844291912900556631268340711"
+    "hash": "138807076179372949102243520434197802875"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_64",
-    "hash": "145696145489837912322598565253019362335"
+    "hash": "178872807692031589952638315495526503594"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_i8",
-    "hash": "758970127450832711712980906665861905583"
+    "hash": "159344654434324176047190481520393620520"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_isize",
-    "hash": "1032334883430711099318357368064015120102"
+    "hash": "55058942940701148416499963893142888573"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u128",
-    "hash": "114227113218568552775771536086325516343"
+    "hash": "46786509084595455829297256196323367521"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u16",
-    "hash": "800783131654730056115273772208589968495"
+    "hash": "552141313641700394413466234730798541138"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u32",
-    "hash": "440650114246587385039294480306892909"
+    "hash": "872194708805187081116117231978692974050"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u64",
-    "hash": "525424813797222241510418586376615607577"
+    "hash": "35379678474858636555394827343526638476"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_u8",
-    "hash": "1589700077731176770815132359667464801930"
+    "hash": "150881200035106929856032592087661076134"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_new_unchecked_for_usize",
-    "hash": "776696460693720054913802362790795303606"
+    "hash": "73737342874226011418240508903573582600"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u128",
-    "hash": "8322738316348135993914219719954651675"
+    "hash": "7350962699169980749108932519733899743"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u16",
-    "hash": "1702852809589886706811527962565532591120"
+    "hash": "102001836482366565771352898561365646772"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u32",
-    "hash": "1836922876913974174416783553164007606877"
+    "hash": "84067376623469444111881105737898593750"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u64",
-    "hash": "295912849927524569414851088417845368699"
+    "hash": "703022352900920811310850089457477412485"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_u8",
-    "hash": "107909910375087589373592168030557191319"
+    "hash": "2431053769179215447755123439908122219"
   },
   {
     "file": "core/src/num/nonzero.rs",
     "func": "num::nonzero::verify::nonzero_check_unchecked_add_for_usize",
-    "hash": "654795364473028349312566988002281319005"
+    "hash": "1730505042061272679015339707434431364041"
   },
   {
     "file": "core/src/num/overflow_panic.rs",
@@ -31421,227 +31421,227 @@
   {
     "file": "core/src/option.rs",
     "func": "option::verify::verify_as_slice",
-    "hash": "12590488003543174799032829518901954477"
+    "hash": "30623443313714622491198686362172983418"
   },
   {
     "file": "core/src/panic.rs",
     "func": "char::methods::encode_utf16_raw::do_panic",
-    "hash": "159375648412719567188404552784823910522"
+    "hash": "72285810534221413553557916636646788719"
   },
   {
     "file": "core/src/panic.rs",
     "func": "char::methods::encode_utf8_raw::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f128::<impl f128>::clamp::do_panic",
-    "hash": "50807735889621473026858823970825922467"
+    "hash": "1020313098020682086813525449733387508679"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f16::<impl f16>::clamp::do_panic",
-    "hash": "80863658359543196131499440355492894153"
+    "hash": "45365173242766850069784469000113513917"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f32::<impl f32>::clamp::do_panic",
-    "hash": "40152032105393575334041670605428032388"
+    "hash": "1645263290791078191515586862813480023162"
   },
   {
     "file": "core/src/panic.rs",
     "func": "f64::<impl f64>::clamp::do_panic",
-    "hash": "1471803332684985989614176870595548450117"
+    "hash": "139095771090594133195310116661061414295"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Assume::panic_cold_explicit",
-    "hash": "1789421038053706123710098356680448714467"
+    "hash": "1506070533374096704814809185562537688310"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Call::panic_cold_explicit",
-    "hash": "295371150684177085715081702501752032999"
+    "hash": "1408509860728327854813604341673682330237"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::CastPtrToPtr::panic_cold_explicit",
-    "hash": "73965070712856596836659199303475017123"
+    "hash": "742034857866235252890557226018016225"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::CastTransmute::panic_cold_explicit",
-    "hash": "378090514985406829710584467808735149809"
+    "hash": "7339847188062706127315228104164504393"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Checked::panic_cold_explicit",
-    "hash": "128333664918770274261688271437565845126"
+    "hash": "199595456589912283717119169739543279589"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::CopyForDeref::panic_cold_explicit",
-    "hash": "609013470521849315718255485813152183234"
+    "hash": "16341918568529364625569996928746873855"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Deinit::panic_cold_explicit",
-    "hash": "938266443487077680616217634212307852190"
+    "hash": "1785894418650424903312553870546663027229"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Discriminant::panic_cold_explicit",
-    "hash": "137467938365592260787386096045701623459"
+    "hash": "81775534530354112179176337429753666459"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Drop::panic_cold_explicit",
-    "hash": "257090290858865617710102565418972576465"
+    "hash": "746894880889946677716721807334842959746"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Field::panic_cold_explicit",
-    "hash": "92123714177881913146242159589196169699"
+    "hash": "1352686515516519169015975493904529932948"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Goto::panic_cold_explicit",
-    "hash": "22175953128656401297064148711324782239"
+    "hash": "110580338041328369781090380259251041043"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Len::panic_cold_explicit",
-    "hash": "142105944693957838316714814489638057672"
+    "hash": "67888286006198805673134511088851130781"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Move::panic_cold_explicit",
-    "hash": "162200283992099129796115303197233248390"
+    "hash": "116872287033605475914577365623793020996"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Offset::panic_cold_explicit",
-    "hash": "54669212364655385098584674346110640579"
+    "hash": "27433262809085370077456906019314442711"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::PtrMetadata::panic_cold_explicit",
-    "hash": "1732213299668300100016463945423008504618"
+    "hash": "640508737116014266214915361687054852237"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Retag::panic_cold_explicit",
-    "hash": "81683014888037235312929999747273983636"
+    "hash": "44196892434186067144751017255323691562"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Return::panic_cold_explicit",
-    "hash": "182523880797771197678575232574645162553"
+    "hash": "1714561766591072987917816672675188169767"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::ReturnTo::panic_cold_explicit",
-    "hash": "11055829247994603801577073293495183146"
+    "hash": "110028352069935417698345215215892531421"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::SetDiscriminant::panic_cold_explicit",
-    "hash": "1437804766786886914716964473913122252335"
+    "hash": "6882202771299132285026028051294774747"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Static::panic_cold_explicit",
-    "hash": "132282081316497259936789638503357535133"
+    "hash": "53909762353665015863351408718183585641"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::StaticMut::panic_cold_explicit",
-    "hash": "102168648871423887676573611284817397588"
+    "hash": "40158843098427337614883186002032292478"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::StorageDead::panic_cold_explicit",
-    "hash": "61898601481286946277560821448816298933"
+    "hash": "155440065820628926766575326473112163534"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::StorageLive::panic_cold_explicit",
-    "hash": "531133218987953098411257973601662260294"
+    "hash": "13116672398544422041899866916247458343"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::TailCall::panic_cold_explicit",
-    "hash": "1390938607515588769214155221053412363837"
+    "hash": "509007597409936015910660996704624363310"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Unreachable::panic_cold_explicit",
-    "hash": "17776026680420953293605614192341237686"
+    "hash": "140879367068072058054130032519836693740"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindCleanup::panic_cold_explicit",
-    "hash": "105298623447639116667200042160659264771"
+    "hash": "416918189149504071416765804788610114263"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindContinue::panic_cold_explicit",
-    "hash": "170155754333316407057806419910809023230"
+    "hash": "79608751687191560358775722279105186137"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindResume::panic_cold_explicit",
-    "hash": "376070249658287840016726757098145634780"
+    "hash": "199598609119397467513821283132744601752"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindTerminate::panic_cold_explicit",
-    "hash": "140667877420609903763612146134059076493"
+    "hash": "170041468465096593219413700318026119921"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::UnwindUnreachable::panic_cold_explicit",
-    "hash": "38393966172403297278872444492342160729"
+    "hash": "66427127608056022851739916628221250547"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::Variant::panic_cold_explicit",
-    "hash": "1006711043700819926215509686585437110462"
+    "hash": "176587880980367410773945757592236123649"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::__debuginfo::panic_cold_explicit",
-    "hash": "112398654373845065568746064311615959684"
+    "hash": "94982048625337666317982282310540275109"
   },
   {
     "file": "core/src/panic.rs",
     "func": "intrinsics::mir::__internal_make_place::panic_cold_explicit",
-    "hash": "1330778076631843542615879765226573522070"
+    "hash": "1513064912916396068515466653650527505112"
   },
   {
     "file": "core/src/panic.rs",
     "func": "num::from_ascii_radix_panic::do_panic",
-    "hash": "149310366229237893685348743334776059449"
+    "hash": "31929417444213691761029989375105527760"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic",
-    "hash": "1072304849003159545015693768884188491165"
+    "hash": "166743082214890768219807743374638619288"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::index::slice_end_index_len_fail::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::index::slice_index_order_fail::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic.rs",
     "func": "slice::index::slice_start_index_len_fail::do_panic",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/panic/location.rs",
@@ -31651,7 +31651,7 @@
   {
     "file": "core/src/panicking.rs",
     "func": "panicking::panic_bounds_check",
-    "hash": "7830816113357828502135153638694178379"
+    "hash": "728911593736298613413879175387058038540"
   },
   {
     "file": "core/src/panicking.rs",
@@ -31771,7 +31771,7 @@
   {
     "file": "core/src/panicking.rs",
     "func": "panicking::panic_explicit",
-    "hash": "1035356066328463027311434339410608402400"
+    "hash": "954011670273584559413724775235663875825"
   },
   {
     "file": "core/src/panicking.rs",
@@ -31781,7 +31781,7 @@
   {
     "file": "core/src/panicking.rs",
     "func": "panicking::panic_misaligned_pointer_dereference",
-    "hash": "65985693830680293206686160255696941099"
+    "hash": "47382073969818256606302523105374584012"
   },
   {
     "file": "core/src/panicking.rs",
@@ -31926,1357 +31926,1357 @@
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i128",
-    "hash": "1675705772848578006012122842517236949438"
+    "hash": "60858223530108041165382953724370511678"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i16",
-    "hash": "158019816037067336052060524014389705044"
+    "hash": "1700594662779370165710997422476225882343"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i32",
-    "hash": "175622485947600819306850155388232188452"
+    "hash": "1582268101519906451912333594027823404987"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i64",
-    "hash": "1535601636895935336517432153270259880211"
+    "hash": "1530151676285471606917784762602662921937"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_i8",
-    "hash": "1326421231673630846511186048968762563034"
+    "hash": "5331966539103015199427715264974376575"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_isize",
-    "hash": "98268662194605619319264586816774107506"
+    "hash": "100479855850961491065885317426128135712"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i128",
-    "hash": "1288464093744360586917437556604803731794"
+    "hash": "911749843056547691014421567799287347362"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i16",
-    "hash": "1065614515751518032618116125308197312999"
+    "hash": "1326985231377037481512096818320511151032"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i32",
-    "hash": "1475271473206254815418139518127611254139"
+    "hash": "142749506251787481472065680235390414388"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i64",
-    "hash": "11780758094000997453755757787824158319"
+    "hash": "111249837707824545957034908715536218904"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_i8",
-    "hash": "1088879519007081508411056833457883347112"
+    "hash": "1648825481873716646615010022527157036005"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_isize",
-    "hash": "97446613950649675423128484265760192374"
+    "hash": "157234193152601134732596554879293127470"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_1",
-    "hash": "31831563380506493298518152828194622840"
+    "hash": "77563719578222075998953677232495168109"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_2",
-    "hash": "798942511580911814714232623324299276295"
+    "hash": "84231358747275479802311825873780952263"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_3",
-    "hash": "654896720285272890716242512526168963212"
+    "hash": "89321674429661413872996681185676466430"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_tuple_4",
-    "hash": "146812293645287162917849522425499570085"
+    "hash": "1341971715727661064011211781537992334521"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u128",
-    "hash": "116649844444831082649672303746280858974"
+    "hash": "77382190606528931345412534385254317167"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u16",
-    "hash": "1415334025285463115514711125358401010831"
+    "hash": "507437000842772472217887909195719347285"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u32",
-    "hash": "829922200088720480618407605432995096153"
+    "hash": "51730753738409967919086110292066789013"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u64",
-    "hash": "1344479149315698220910380289392101731816"
+    "hash": "167497376656540354922877995537748996078"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_u8",
-    "hash": "512435068594202981210189991312296084467"
+    "hash": "15931814740699644328547247307671858149"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_slice_usize",
-    "hash": "88034442136784715753415482033134537694"
+    "hash": "151050995820701234382234671723830366177"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_1",
-    "hash": "665710712657287981311149793860063170697"
+    "hash": "121759491499969142105324580910721384423"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_2",
-    "hash": "14788332205287806624165356299335259237"
+    "hash": "1112506924183269669612628605903843260608"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_3",
-    "hash": "88880446153189492243710736877055795336"
+    "hash": "3243218657587253501689045316239093562"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_tuple_4",
-    "hash": "831372783451512859816414343573620430786"
+    "hash": "594570578185067340117368375157296478429"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u128",
-    "hash": "698277290155717208781013276270694779"
+    "hash": "170001868107598165034020918386023004859"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u16",
-    "hash": "1833842786489157868310248451321103580471"
+    "hash": "170643026358802232048433720691888991614"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u32",
-    "hash": "1609675285421099079317331884296123990318"
+    "hash": "1487985062332698951913045619143734639384"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u64",
-    "hash": "1662797914628800144615579834711429194648"
+    "hash": "11691222712691410362929927353146781066"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_u8",
-    "hash": "790088443678981285717442013285497577086"
+    "hash": "1697463570029668961810860823629955150449"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_unit",
-    "hash": "1401007401102257300316537842469832927174"
+    "hash": "176720649170840493764138047418834677612"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_add_usize",
-    "hash": "1798573077240762536713390140088504274596"
+    "hash": "1542148791568968585716339548091419356903"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_dyn",
-    "hash": "79761632330825712301934196451561294376"
+    "hash": "1780201231807408733117667568540184151781"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i128",
-    "hash": "1078263186806924628710316170638792003298"
+    "hash": "1543346732854776912812428776625228854264"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i128_slice",
-    "hash": "1019481656079838767414261407433444457277"
+    "hash": "132012397416362308712590838754686302702"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i16",
-    "hash": "1508464630561425882413581394789221770694"
+    "hash": "424370766340670561618406829996047044269"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i16_slice",
-    "hash": "115306421891758824994435506718793699826"
+    "hash": "171357506014746520769527867030185336508"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i32",
-    "hash": "64573943806622376555518346088736492051"
+    "hash": "72421349288104198459522967807234036814"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i32_slice",
-    "hash": "179671283709616507237189850734661000688"
+    "hash": "248861842452637352210104103915777815238"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i64",
-    "hash": "1455080676235601625012841677101482569780"
+    "hash": "1147486888178754201116329520501271936138"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i64_slice",
-    "hash": "137410277259891236314809702825594861656"
+    "hash": "19951687458320497684172429937017536281"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i8",
-    "hash": "166498650700478157781319064338239039600"
+    "hash": "887288045858584317914995258581540179575"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_i8_slice",
-    "hash": "1552950265331809409114529939810725630899"
+    "hash": "272744950132597254911360020743809864118"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_isize",
-    "hash": "108914495536680298917298348089638193467"
+    "hash": "99122289237441761267611851478378944644"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_isize_slice",
-    "hash": "882997220283147291114322805008018110107"
+    "hash": "68834488028471120272320701181374031263"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_1",
-    "hash": "621834688544712464533363748914816689"
+    "hash": "72849725960850029756714174308581867033"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_2",
-    "hash": "868423451879432281811008128101122828173"
+    "hash": "42566001926501421519983798935769122393"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_3",
-    "hash": "126235737103951137988853591215446631316"
+    "hash": "452891248071879725411213937392287759683"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_tuple_4",
-    "hash": "5986215934792710317207018615617405899"
+    "hash": "160133261048311428005394393869453396585"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u128",
-    "hash": "429747602224698080512293036533128972362"
+    "hash": "86684378560462401881052008726440830451"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u128_slice",
-    "hash": "79017586312499993776523324185025657189"
+    "hash": "1091999322440121821311751918017766506537"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u16",
-    "hash": "78238390672365434597873610003242068813"
+    "hash": "100902534974805568571800676326961628913"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u16_slice",
-    "hash": "669305334046988472214124455716867740742"
+    "hash": "1735027461068621184418160305871302214690"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u32",
-    "hash": "687919097717870300710899732458696960105"
+    "hash": "1645329164305644888112230893808947986"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u32_slice",
-    "hash": "722380556302857156615849650782698653401"
+    "hash": "23425179039299441535661160535752733447"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u64",
-    "hash": "1079942161950497456811775505511965186080"
+    "hash": "566545122637606111916843730057753339205"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u64_slice",
-    "hash": "14183821838572736251755376811339774391"
+    "hash": "1438400072150383099015379081523232338839"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u8",
-    "hash": "1739260375824962430317405337740660977696"
+    "hash": "799223897673115665316354021158070546960"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_u8_slice",
-    "hash": "1814666946233095251615373594359471233251"
+    "hash": "23324201006595292533174832926971631763"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_unit",
-    "hash": "38515986439544837923572248300193269726"
+    "hash": "44114477907647897972858815262310458055"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_usize",
-    "hash": "46542658444842084054840590461983606619"
+    "hash": "182864633573887237715754065931537836783"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_add_usize_slice",
-    "hash": "1295391538573182368418093677420380882387"
+    "hash": "236472749687946268311385032823888332941"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_cast_unit",
-    "hash": "1047383007193929699311682981357278609930"
+    "hash": "68114178015446238968348476424768499083"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_dyn",
-    "hash": "1008233644147352524312260245725571746044"
+    "hash": "64684734920831411282730928544649991911"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_dyn",
-    "hash": "289580119021279912416450780334189701292"
+    "hash": "1124452668317072695210550794823973934462"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_fixed_offset",
-    "hash": "35212817648223289761482256676121656325"
+    "hash": "1309406905859399879214131897351420987476"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i128",
-    "hash": "74654854567413375287251934100872097197"
+    "hash": "23116773570954884885341464717039870409"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i128_arr",
-    "hash": "87267168993771030810820591921430534504"
+    "hash": "1396645968274699898512364061126156110667"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i128_slice",
-    "hash": "179687424450291177726900577464191461412"
+    "hash": "35613058035615018728601918553568490492"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i16",
-    "hash": "21185782532481910712564080151844107912"
+    "hash": "8253084154241523438675389720908703349"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i16_arr",
-    "hash": "98573560498905638484042032460506496817"
+    "hash": "3137308913633839143876393403627062627"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i16_slice",
-    "hash": "43685657259451647315810057190860822861"
+    "hash": "71386591587124280261093988783255615940"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i32",
-    "hash": "51740290118865502613542678101889122609"
+    "hash": "1092122742428271631017013905340255873563"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i32_arr",
-    "hash": "536115960201607606713577918516730672288"
+    "hash": "159555922340426364018108387956641347962"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i32_slice",
-    "hash": "659136438267344261415681456956317291523"
+    "hash": "40133619235364598899197011405688126466"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i64",
-    "hash": "1219344560402077156813108040887062706472"
+    "hash": "160177163503939286011386120757655700729"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i64_arr",
-    "hash": "130665130894017309231070956181545627930"
+    "hash": "1830397428240347997117576936057076085993"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i64_slice",
-    "hash": "281215302440365460012049833284565118215"
+    "hash": "1264915220574990044710117491719103932466"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i8",
-    "hash": "1341180107210783982613637232558144151226"
+    "hash": "113642004154439751937158508459289017092"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i8_arr",
-    "hash": "80458894332632495961491854629354698741"
+    "hash": "870931739691936156314874304431103688892"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_i8_slice",
-    "hash": "598967865190244095716864531129479545169"
+    "hash": "1445322861380947419411210559529086632990"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_isize",
-    "hash": "342033566847217272460692502014948166"
+    "hash": "376106286448650826011478940444084820451"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_isize_arr",
-    "hash": "990734353379656860818013238126538014684"
+    "hash": "438336769525675828717713692484869328983"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_isize_slice",
-    "hash": "65681938942466744867871772972622955468"
+    "hash": "593389438977863623318445941714127257495"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_1",
-    "hash": "19139401910267346127811120295531135332"
+    "hash": "1143332942015344547713406317151206422043"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_1_arr",
-    "hash": "1320867064749074359714985182305243797627"
+    "hash": "154458954424250650245090080116564205975"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_2",
-    "hash": "80683965295780001581016194279684856194"
+    "hash": "685710497040508708414863458092070840983"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_2_arr",
-    "hash": "5889664753945953613427851572555379808"
+    "hash": "156573650084038038082376411534416695005"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_3",
-    "hash": "583833227024408096316623133715837083885"
+    "hash": "46641355979915589108320492439890914954"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_3_arr",
-    "hash": "73624341087623857392122789520343523565"
+    "hash": "1426877732365177052710200246567677526323"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_4",
-    "hash": "598442334794389501813450340439641927979"
+    "hash": "71365759431641990793369852389015687690"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_tuple_4_arr",
-    "hash": "616770451975320295814059298429579879037"
+    "hash": "869805857737615859411012015690873458863"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u128",
-    "hash": "138338376326138499212897027212461880560"
+    "hash": "161509731004469493357091358910159669537"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u128_arr",
-    "hash": "94349057099750275639707135499879467350"
+    "hash": "767156721878879206356713798281727780"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u128_slice",
-    "hash": "1188332589982159247515492276691538905706"
+    "hash": "154247496924798991636696080739304929834"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u16",
-    "hash": "87830105271067518101647786869539025173"
+    "hash": "94100600798694583116617339900629916210"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u16_arr",
-    "hash": "374461324399075728417233025639937309989"
+    "hash": "100935500677866942857325463282048306394"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u16_slice",
-    "hash": "112427217039767335567579840068196601498"
+    "hash": "139815517706237190276117683876921593990"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u32",
-    "hash": "21273389758772047928011304444624671097"
+    "hash": "16348480229302742718756201885290291697"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u32_arr",
-    "hash": "97410155648642854595097731219694990509"
+    "hash": "1574461712456706128711239743299975614932"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u32_slice",
-    "hash": "76000447706575158025967254412658606649"
+    "hash": "90174721923693289624151675107749455207"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u64",
-    "hash": "16508880365925511856157193153203508732"
+    "hash": "748541701818152516710590830364041880711"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u64_arr",
-    "hash": "708431291951265881569127386509168499"
+    "hash": "71136287099781648713453277419047958985"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u64_slice",
-    "hash": "33359008310300659128035841845078510224"
+    "hash": "176673816624700950286115243668379898926"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u8",
-    "hash": "56993902104751495977109429732412798850"
+    "hash": "58294556438688452323570231687344157658"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u8_arr",
-    "hash": "37361769259474275582553314820945748310"
+    "hash": "17098551446732662878178792026480129357"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_u8_slice",
-    "hash": "80818347659445675219912046401639601048"
+    "hash": "10305660181398399625540712354046459705"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_unit",
-    "hash": "1417971053370825704212047619502559597002"
+    "hash": "10090816483824009571626631271945438326"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_usize",
-    "hash": "1327853728464915162411494575886608773782"
+    "hash": "126833283541367083352356579740277719501"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_usize_arr",
-    "hash": "341464485672486093116750437984660470588"
+    "hash": "389262848541777494413551381828979140213"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_from_usize_slice",
-    "hash": "35062883797703853847316594100877442888"
+    "hash": "7711333462077729392958530554587406531"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i128",
-    "hash": "451895114652309469315948818781560206099"
+    "hash": "164403283934624981233214523100047021208"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i128_slice",
-    "hash": "2557599467702423959621538119868131239"
+    "hash": "460619193316654237114823687445647214421"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i16",
-    "hash": "9938220754346994975136538227000480389"
+    "hash": "50018336614034480293351279767041268865"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i16_slice",
-    "hash": "107056356979673444556449971108343986532"
+    "hash": "1842238213503626794018080695557995881255"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i32",
-    "hash": "142935136103748045208028011565931976153"
+    "hash": "8282259866361304858208843399231271275"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i32_slice",
-    "hash": "1148554035384277595010258202263414558811"
+    "hash": "8848390093042735116116360264890908652"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i64",
-    "hash": "1348395943137395944412376972511731000248"
+    "hash": "310555797639214418318002419877635594812"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i64_slice",
-    "hash": "115938835546675496937172903229170943275"
+    "hash": "138318366059517004523335024115852160536"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i8",
-    "hash": "1568674383346685148611950215320619469622"
+    "hash": "12265986759610681379662326721738698818"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_i8_slice",
-    "hash": "1305885116912999876912630522627935775"
+    "hash": "60531043796741172715426399816419465075"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_isize",
-    "hash": "81433089637092787014616810431987785744"
+    "hash": "556144776216280440017596805544177123734"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_isize_slice",
-    "hash": "47729387727170309063558702806298440215"
+    "hash": "1172723334404222332413376659160342800175"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_1",
-    "hash": "42712194188520431586707711448309151490"
+    "hash": "8834181101754870321654076350345846257"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_2",
-    "hash": "113291205129780090705070574087903435759"
+    "hash": "165185913945608124083029610514826190263"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_3",
-    "hash": "6428028018296655794355191156503563160"
+    "hash": "1084397283305033126185265358298210990"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_tuple_4",
-    "hash": "14920577636067050782290711998797814014"
+    "hash": "12045614411895583767866000521178305915"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u128",
-    "hash": "511440286209044155915145310481585129580"
+    "hash": "21284489962333748604423364409652295073"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u128_slice",
-    "hash": "78543572495541892365354839775190273786"
+    "hash": "85855428887748186936389178537848610577"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u16",
-    "hash": "102991877399622504414381474406613261689"
+    "hash": "90171841417812934318961552590186314007"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u16_slice",
-    "hash": "1119149407151896458510454036727287755430"
+    "hash": "1620603028079807836716891639751486159652"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u32",
-    "hash": "103632180471615403127179279644695401"
+    "hash": "130109495817176595106520067056477064035"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u32_slice",
-    "hash": "26041931951136025246387510049486069889"
+    "hash": "39236970320722419298442150176143746"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u64",
-    "hash": "834820166650836811317352124897614556761"
+    "hash": "1687260658808925589111398757107456575159"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u64_slice",
-    "hash": "111708122987495936759434394764267897058"
+    "hash": "14361207061781990175496130207101891511"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u8",
-    "hash": "1194098582749068184218070753333157670617"
+    "hash": "11031285797781391853823488494155690122"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_u8_slice",
-    "hash": "117971258771325561183046212204339337200"
+    "hash": "158800882340301497427817000481314540079"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_unit",
-    "hash": "126874029539991483693640238971011346920"
+    "hash": "136337743180868214718117768876095456085"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_unit_invalid_count",
-    "hash": "159128080768811755148486848261949120722"
+    "hash": "141097209605609755431724933214126626835"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_usize",
-    "hash": "73327354559361693642280825646559213492"
+    "hash": "46299565563072724572193226011275551612"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_offset_usize_slice",
-    "hash": "28143271605856875725664022099342681297"
+    "hash": "94789239343485082438148012143662091522"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_dyn",
-    "hash": "1812994354060132743615719395965604750088"
+    "hash": "1626995826193404953013122887118167554833"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i128",
-    "hash": "1121480458840785407712615131746880925644"
+    "hash": "413051490592170675613275038323720055056"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i128_slice",
-    "hash": "574206817935040407810323164890562882208"
+    "hash": "1454571748056056243910662376034836443450"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i16",
-    "hash": "201287070311259175417227135976243384398"
+    "hash": "163284620777495987125702646726795363910"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i16_slice",
-    "hash": "1806319481580721108581480019015017139"
+    "hash": "792984682473527778411528926290954629471"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i32",
-    "hash": "11121767801645073845453624627504137917"
+    "hash": "1120554874859575922911663038879435588761"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i32_slice",
-    "hash": "13654725482620480279483163045786777390"
+    "hash": "1587959036882938376016065280412377680446"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i64",
-    "hash": "1648161563700071369111400858462580063364"
+    "hash": "136605759072929530307168425309869092779"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i64_slice",
-    "hash": "1651378816575645003910461559804988270417"
+    "hash": "1583507444926715812718132612011335582779"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i8",
-    "hash": "1450896249803630297414020987967480667032"
+    "hash": "99174944652758210251935721806980960537"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_i8_slice",
-    "hash": "84980218599433640571997866192663855208"
+    "hash": "1340644958589426856715886172417863171117"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_isize",
-    "hash": "97419650160701479116703899483809354699"
+    "hash": "115827513914791228724233722849702404134"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_isize_slice",
-    "hash": "39569547492285158695760695059960843238"
+    "hash": "84281292207670495615752780868050359336"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_1",
-    "hash": "175669555708694925617334113410889842806"
+    "hash": "529158419265158644315042796482893349106"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_2",
-    "hash": "182071469560089583552434494777531802895"
+    "hash": "1704553040599643431315670977889802881294"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_3",
-    "hash": "299965681416033649311173985863701360607"
+    "hash": "1136679286398730462511827503960163585890"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_tuple_4",
-    "hash": "1283888510658721288912800611339613813035"
+    "hash": "158860487433421637314463752536315587436"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u128",
-    "hash": "13125639273314167214693555138627448871"
+    "hash": "275921801992549314311993508962901925664"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u128_slice",
-    "hash": "1376682593246683294516879016125372429759"
+    "hash": "146452391179489655910752825705807150627"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u16",
-    "hash": "1138152128352006496713774639672476749836"
+    "hash": "161573396601560368077899615293233072380"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u16_slice",
-    "hash": "181721726149665544009618344111707432944"
+    "hash": "110652873058106374916833234868377387367"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u32",
-    "hash": "9218849613565215527327272268984375975"
+    "hash": "645798319254540151117950992006588095954"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u32_slice",
-    "hash": "111680522428090080095390397353062337580"
+    "hash": "165505259933721890391265740730907410086"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u64",
-    "hash": "10573026302503300923585216842138088984"
+    "hash": "1722024686963515707210649284449162261515"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u64_slice",
-    "hash": "26693568884845139693752924999924265925"
+    "hash": "53965863801406444139691707257082670072"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u8",
-    "hash": "570947863903416492110361515458418761953"
+    "hash": "109777281422297354653703453065284802969"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_u8_slice",
-    "hash": "1557981753444780104115658949803965243792"
+    "hash": "13069463362136787157592795159058464921"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_unit",
-    "hash": "6087126018391411602801695102913782302"
+    "hash": "131616326176797115122147197959092463656"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_usize",
-    "hash": "80092237702771395517878274762057902280"
+    "hash": "109659824592201626407026520798065290787"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_byte_sub_usize_slice",
-    "hash": "1174837468976277915614383804345590439399"
+    "hash": "893785166472521153115273900461091310315"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i128",
-    "hash": "472219666716204953118329882794579196780"
+    "hash": "1437850998366812597712493670884014335487"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i128_arr",
-    "hash": "288377658155836914914614654264596699249"
+    "hash": "98192996814307625891608956456267508467"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i16",
-    "hash": "118498202001543917367169914997867023152"
+    "hash": "104515085715011320065415481399407747265"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i16_arr",
-    "hash": "150270248427846618741624843579827331624"
+    "hash": "877108355045505242116955618327268552416"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i32",
-    "hash": "25153902227134409912252073956710760190"
+    "hash": "2512504928801610786625111735702583198"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i32_arr",
-    "hash": "439996988580530741714853752197143724976"
+    "hash": "97910416353960023539508368640576793780"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i64",
-    "hash": "8374888333889680531387692054454282345"
+    "hash": "469411172217937826217845851265195892252"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i64_arr",
-    "hash": "8347506717841862874266106746727971825"
+    "hash": "63324902774967402256786598701027415858"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i8",
-    "hash": "569519914456023945811266067636775543166"
+    "hash": "406546662405406181312541917630724655179"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_i8_arr",
-    "hash": "94636851797734253139437969894032125575"
+    "hash": "43261119243112205568801815664895881067"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_isize",
-    "hash": "208344316486867282511030592441986247317"
+    "hash": "75260241161240470814911453331948565208"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_isize_arr",
-    "hash": "866586616819744548418410839748151247035"
+    "hash": "64571548560819449917985590011865217952"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_1",
-    "hash": "1362756556694918791014122709441933145854"
+    "hash": "176784038219161327723181485602217688653"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_1_arr",
-    "hash": "10080428147009318347865968312800991547"
+    "hash": "838530231319277928814834112763624074635"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_2",
-    "hash": "175098307539381993548565678140050927970"
+    "hash": "103523956108807879964608692191528129700"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_2_arr",
-    "hash": "385705521841403352515529554018548571364"
+    "hash": "79706343261875245468196147286074734610"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_3",
-    "hash": "177377161871871659313023914441286361409"
+    "hash": "109027822570856603566601100604712954507"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_3_arr",
-    "hash": "202164090399252924913033418523223377344"
+    "hash": "1733083991802640733110689278216871349785"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_4",
-    "hash": "1510508234434818609116155858111384073518"
+    "hash": "175152637975535883818324558173525666431"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_tuple_4_arr",
-    "hash": "577591262279765943516814488502268118099"
+    "hash": "567970039843195995511459312066410099827"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u128",
-    "hash": "62156059734923927397555768726309116934"
+    "hash": "87057421084040114833144126618581435127"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u128_arr",
-    "hash": "1842595737264081260117514996267120754714"
+    "hash": "14746448396065016759153901361109537383"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u16",
-    "hash": "100905623595191210074323490041450509984"
+    "hash": "162684892327153937055457502531700522117"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u16_arr",
-    "hash": "19283529930768770484793617112355605781"
+    "hash": "176654090469178257518103908751229912539"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u32",
-    "hash": "90639154274991633227965670424369105951"
+    "hash": "175937908891157490083542712275985536049"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u32_arr",
-    "hash": "130690225653150376614772921571547860226"
+    "hash": "72217174540538308295852138249863549284"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u64",
-    "hash": "546748148048224515112215182823478823287"
+    "hash": "6324486854523244696160832314053035240"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u64_arr",
-    "hash": "1667617807485727194818288866328527317250"
+    "hash": "117455081622708917807358425328661760105"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u8",
-    "hash": "120780894567022577695058926754439910306"
+    "hash": "110833847472057472994061891753049311472"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_u8_arr",
-    "hash": "522806875194353642416716135090805828016"
+    "hash": "1117910412059884627312601761226398308279"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_unit",
-    "hash": "719824541380511394311810273535856086446"
+    "hash": "1746885794916172025514248005589568700518"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_usize",
-    "hash": "956781494720496291314324687505454249879"
+    "hash": "143537263553009158959882184670384122192"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_from_usize_arr",
-    "hash": "84430369208869625762243513625787882360"
+    "hash": "163879690693067488547853575872911961762"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i128",
-    "hash": "122004476253990483317416928985731644632"
+    "hash": "1750527981242507078710985512948241249487"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i16",
-    "hash": "11965354067041791201118007911009050654"
+    "hash": "119144638013715850025740121730615485987"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i32",
-    "hash": "57543717407503070910423424914316229629"
+    "hash": "1539669213611342558315432840220082663598"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i64",
-    "hash": "920066735690559450616587922608245144356"
+    "hash": "518997772468700682312143033999346780600"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_i8",
-    "hash": "1531979543669462096015358431510531007338"
+    "hash": "59271252744212637632907255923361208046"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_isize",
-    "hash": "1043419738490289675014864404629455113886"
+    "hash": "6361497774529477561023648807569534303"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i128",
-    "hash": "178038112329690445505076567563347164179"
+    "hash": "1666643398880310900010024216849441223156"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i16",
-    "hash": "925506715150229543417849720419285772114"
+    "hash": "158828635034733745811073971754690595082"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i32",
-    "hash": "27992325736726713338629862547889741364"
+    "hash": "1007654829118360798810765486359956736874"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i64",
-    "hash": "1208999982444379166815531478849461196755"
+    "hash": "119106625052967492728950497316547346267"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_i8",
-    "hash": "59934114324912149562198614999319370442"
+    "hash": "865470280654489946916198624398613077685"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_isize",
-    "hash": "90586864661989260053028127418085094082"
+    "hash": "1501592901520183396851108108054346303"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_1",
-    "hash": "110928183313520005612702371755217019394"
+    "hash": "99582751613571698413435829424655939704"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_2",
-    "hash": "65065107191958147571741411883045026850"
+    "hash": "1005582644702551253515551925501620900212"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_3",
-    "hash": "45311939867936492197227095831494760717"
+    "hash": "1475671936023102861213555931870454810614"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_tuple_4",
-    "hash": "101117009675522693451636842050511067880"
+    "hash": "8675589154535740815532430673651217730"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u128",
-    "hash": "171194023872495346305876108595793779421"
+    "hash": "1490299186760241627115170488806169327649"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u16",
-    "hash": "49269745719928883676241945905604922941"
+    "hash": "268427809540739878113639616934620050547"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u32",
-    "hash": "746492192624084253614391160893970276636"
+    "hash": "956555378289247584311859503997052275935"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u64",
-    "hash": "161452662729691991552889790747474201542"
+    "hash": "9532856893165980675707998720778269145"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_u8",
-    "hash": "1791262004604193815517265490629921333067"
+    "hash": "1427873646098768785616724469234712403073"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_slice_usize",
-    "hash": "185877031120637136214670619395408055748"
+    "hash": "20230027330766022886559680701513749255"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_1",
-    "hash": "177661163162752846014405259603061588740"
+    "hash": "587976968072122502210777705878449023007"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_2",
-    "hash": "64033545580824589782840264936655174741"
+    "hash": "54400943963624751707643341163408096467"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_3",
-    "hash": "186911077219001242912956587424386802574"
+    "hash": "1841782170479504082610226103771571862908"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_tuple_4",
-    "hash": "17637395960335649463547779001484635729"
+    "hash": "3893868398317680470658608038358943589"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u128",
-    "hash": "117973746778909006672923085132004800692"
+    "hash": "19078229677276319486168513978384105919"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u16",
-    "hash": "732749291300133548316988329538448518154"
+    "hash": "1277740768450182653918050340454324492123"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u32",
-    "hash": "1098491752663744127611424150510284683861"
+    "hash": "1367695589514563734315421004730068954241"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u64",
-    "hash": "98849152767190181314004881076560335840"
+    "hash": "92287708792845714523595211073177056988"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_u8",
-    "hash": "979038893475871840518377559335748203908"
+    "hash": "1306943541994335093410060093392184598770"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_unit",
-    "hash": "15698210495126260452647604312001687176"
+    "hash": "683800591672017374515153092319383761782"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_offset_usize",
-    "hash": "1830002907016331594011674226636805373440"
+    "hash": "945134435774068472112242202094810397626"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i128",
-    "hash": "49254660711153849433185836093167493674"
+    "hash": "64970701707556018186137413589242763782"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i16",
-    "hash": "14988882972424978645556622177077564817"
+    "hash": "928716145195139971012220985040172712868"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i32",
-    "hash": "580861804768852435718145419362815744413"
+    "hash": "179212760192176579031921043792363489678"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i64",
-    "hash": "208051860861712264111006533068113882099"
+    "hash": "1290567948950226846317894208943429569949"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_i8",
-    "hash": "172206705828268718629282443645494307656"
+    "hash": "817918246180111547610402478801706734275"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_isize",
-    "hash": "238439586507323491715212087047454002092"
+    "hash": "209821932946902901917205749001679534526"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i128",
-    "hash": "2104053532182841641105060350359732680"
+    "hash": "62431613292860005109640168446751786920"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i16",
-    "hash": "233749521958306698115140418229144076542"
+    "hash": "889721553524316978314193163324513240438"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i32",
-    "hash": "24314431646321856196793420899932372158"
+    "hash": "1330307712698804280712939151122542716129"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i64",
-    "hash": "1620411869365577892018193087498294181804"
+    "hash": "123130757228560573715222085887756750933"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_i8",
-    "hash": "1269956253029455997423517128216531541"
+    "hash": "429158520220108561918027385948699117986"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_isize",
-    "hash": "1133558984324236120611606783801881223982"
+    "hash": "67335231625590530194987768026024090411"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_1",
-    "hash": "171053748437195686815972006832337630147"
+    "hash": "1706558125675512610916368111344652161078"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_2",
-    "hash": "173626677153391551802069498018276031910"
+    "hash": "3204711849912592633535116455555778419"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_3",
-    "hash": "106627616189233343392128468998482391722"
+    "hash": "1351253823026856387713712764200568725055"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_tuple_4",
-    "hash": "1598518960662702764814685770303878296305"
+    "hash": "78957158461245734297794105073557208919"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u128",
-    "hash": "1076511468184034720116326563211838137974"
+    "hash": "1101556762099782431118348502028576815205"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u16",
-    "hash": "105078473831761913514855291186971095412"
+    "hash": "987146268447762393017713117417935477342"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u32",
-    "hash": "234838166953896927615744143125906396780"
+    "hash": "4262415564093585172426311049147657211"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u64",
-    "hash": "58448523359073680032312582944904227333"
+    "hash": "903950039837668673515985567820568279558"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_u8",
-    "hash": "91751971442353936486773990741041069827"
+    "hash": "522115948517064748013521995510428903283"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_slice_usize",
-    "hash": "77266605695682358929644834629705565644"
+    "hash": "85597461673088689211894875470429992581"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_1",
-    "hash": "119674128215927276946207078874725618757"
+    "hash": "1641662756362859944514766965614968862976"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_2",
-    "hash": "121660820807266003396776614592508016785"
+    "hash": "556825650589376353817712829370144619044"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_3",
-    "hash": "1309772320460063487813911355070237778542"
+    "hash": "1316795999130236992718305460424125898663"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_tuple_4",
-    "hash": "42716025420146425142163403698165794364"
+    "hash": "4002509576834855086548224379654209457"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u128",
-    "hash": "1521843207198973116516050521621873811369"
+    "hash": "45681924968481936811777837701238915048"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u16",
-    "hash": "14758845796115916773391688849440754283"
+    "hash": "1050807993326796068817649764266859832266"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u32",
-    "hash": "117202759263659309931602787879770322809"
+    "hash": "186510571757235907814036891776729063575"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u64",
-    "hash": "135739319989353689438885740126854031276"
+    "hash": "63355644152291227594811164026422755977"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_u8",
-    "hash": "1333281973101712998212614646973439045348"
+    "hash": "19633126472895621559055555103656236149"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_unit",
-    "hash": "171653299350641130317143143511196658390"
+    "hash": "63732522620500339159579557680326216017"
   },
   {
     "file": "core/src/ptr/const_ptr.rs",
     "func": "ptr::const_ptr::verify::check_const_sub_usize",
-    "hash": "759582235954607046515644544027258869504"
+    "hash": "134955529402641917304597117243300514615"
   },
   {
     "file": "core/src/ptr/mod.rs",
@@ -33298,1917 +33298,1917 @@
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_4096",
-    "hash": "90580971551785484262903858766032665283"
+    "hash": "27210167019335885145126709725503461580"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_5",
-    "hash": "1716409006842852835512687451507775196626"
+    "hash": "118639409502828256631365001682399913376"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u128",
-    "hash": "65387033735383670537678689671927865951"
+    "hash": "448658740373620053517009358012158424236"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u16",
-    "hash": "1027278213332400092314212141461060313473"
+    "hash": "14262417160000836994397441868687009562"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u32",
-    "hash": "1038703713919702057916097470002928117221"
+    "hash": "115198702321938779319658820017072441352"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u64",
-    "hash": "1746441396084642892017626416337083184944"
+    "hash": "62996711778246971314336706121145762885"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_u8",
-    "hash": "696153836315223482517525328932886681728"
+    "hash": "18214484434072388762867970799719987843"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_align_offset_zst",
-    "hash": "192401122231118509618270768714800638863"
+    "hash": "27293493752970312534739509639834365672"
   },
   {
     "file": "core/src/ptr/mod.rs",
     "func": "ptr::verify::check_read_u128",
-    "hash": "985543799374433816413372072181637283900"
+    "hash": "41017799793716564823708299119812729220"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i128",
-    "hash": "117834836575589103349607342957345363250"
+    "hash": "1092328107318589713315215439982757469438"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i16",
-    "hash": "174084438623062774661296301400592742054"
+    "hash": "132679317788737105359067741545663126670"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i32",
-    "hash": "117277318419166798898367408354748571317"
+    "hash": "12002823718736893016602510381270613547"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i64",
-    "hash": "36490625346505404474696449921723109368"
+    "hash": "687660885033898283511790638772128834719"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_i8",
-    "hash": "171629084390931774793617845913565950559"
+    "hash": "2946401450121008356593267731512074413"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_isize",
-    "hash": "49131374700181315018264021891047116120"
+    "hash": "15656459630214173187499554190758097133"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i128",
-    "hash": "1239441682663062626211646013130298593327"
+    "hash": "129326657858099733041692928663237737798"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i16",
-    "hash": "89893151827804664279487863485438387982"
+    "hash": "87136810932111239536897985904686665948"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i32",
-    "hash": "10865926068954529999206920703095481600"
+    "hash": "133920717003817186872378402868880194680"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i64",
-    "hash": "1525407528789745582612973850166795190294"
+    "hash": "362514198787586023512201700093342718438"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_i8",
-    "hash": "54761887413533017366101730613649697723"
+    "hash": "975901305855187770314196179616018722318"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_isize",
-    "hash": "1517394310388826587416073311009200824226"
+    "hash": "314939679113719007817419464436803768857"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_1",
-    "hash": "82985991324477583929655100866087983486"
+    "hash": "961891772753272164712781970598828212000"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_2",
-    "hash": "162726851305841783985815239903377592783"
+    "hash": "36577919485404247554741479807703084575"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_3",
-    "hash": "1060170079602788975512730501105841841946"
+    "hash": "1109857783056848673117595641448856915972"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_tuple_4",
-    "hash": "1566672658616445213110182683726000250276"
+    "hash": "1219555435910688070313609530564791596842"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u128",
-    "hash": "122504711331920169022878569374230046708"
+    "hash": "1228270509384227103413065447637928928442"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u16",
-    "hash": "204685388669080082211781423177989343881"
+    "hash": "1044060362314478823010589030915875420611"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u32",
-    "hash": "761705436142542646918240820588354223800"
+    "hash": "3137723825901976909553331763727199535"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u64",
-    "hash": "28866300148657568316239240023706418652"
+    "hash": "118456111872325916773211502211752389588"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_u8",
-    "hash": "83903325607289626412664917484877494073"
+    "hash": "619057555595036643117510477168458260631"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_slice_usize",
-    "hash": "138821919149553380603070120029940879240"
+    "hash": "915909779621102734214437492298768412027"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_1",
-    "hash": "1042589576211222071516026521952960442698"
+    "hash": "1704633372390547588317516911311573213832"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_2",
-    "hash": "2372336022457717091540624865944728339"
+    "hash": "95099189832357658066153512696484589019"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_3",
-    "hash": "181403813975887663219040672972319518404"
+    "hash": "40104805873228075212947983793283133978"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_tuple_4",
-    "hash": "937724437268103989313298553889229388635"
+    "hash": "1433017281997360095510848528232615862363"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u128",
-    "hash": "1667501585244324986715104119530067448183"
+    "hash": "1509028426371248804110326995520843142903"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u16",
-    "hash": "748643156528898692914738512517163523524"
+    "hash": "107698783833583302627700243672105969225"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u32",
-    "hash": "809970372559516043718379171401672962500"
+    "hash": "1043375095402232003913262453366574169142"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_u64",
-    "hash": "1311664334953043018144313503347055456"
+    "hash": "1517480877337586552215357359370433637083"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_unit",
-    "hash": "138227945904891724291488211928650706705"
+    "hash": "1169118382758069657914493187408276011603"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_add_usize",
-    "hash": "66430204223624441854749663637696829447"
+    "hash": "1633193950926913141317059915075527012264"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_dyn",
-    "hash": "7803749238591855475726324941793228533"
+    "hash": "33644326858376294599414844248407311578"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i128",
-    "hash": "7959971405020777058054615018877122657"
+    "hash": "553749931800084187810410956881843653048"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i128_slice",
-    "hash": "523978279720973640816643526986968441579"
+    "hash": "156709675836867096314763743669015649376"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i16",
-    "hash": "93375526010341226914610724740735332956"
+    "hash": "126991876012935866928941901679953975286"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i16_slice",
-    "hash": "1292860274323687841615329432082662308509"
+    "hash": "83035750116784736447597136626600397668"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i32",
-    "hash": "1429956675008049258417449592744460081672"
+    "hash": "68945032074119594021806211677647304435"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i32_slice",
-    "hash": "9913455033853243523982905164526070510"
+    "hash": "1482319397526960590310118462174035975152"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i64",
-    "hash": "21294506692910796966235151371761458975"
+    "hash": "1313412821230813709610447312687364151455"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i64_slice",
-    "hash": "333279542896813285113439173234883439626"
+    "hash": "12527410345013991918921149743876132966"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i8",
-    "hash": "1775443931642475301617659063588079174267"
+    "hash": "180535814676790268710709294758474149801"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_i8_slice",
-    "hash": "1130887348509768030415626921220741576153"
+    "hash": "136553433470734213846187936300268959603"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_isize",
-    "hash": "64671752130018187199115081215770826518"
+    "hash": "133869558897277811513384172302846686980"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_isize_slice",
-    "hash": "430000569675276231917395314037697915947"
+    "hash": "145611731341323054923574599536545801886"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_1",
-    "hash": "31450904619616326959750500829271166125"
+    "hash": "1126864421819433023416590870260860426508"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_2",
-    "hash": "134858451431796254812487051016806619293"
+    "hash": "640038229976308588716859323478038563813"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_3",
-    "hash": "1017055626959845577311911143730839206511"
+    "hash": "133316388441112562613721696948788182582"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_tuple_4",
-    "hash": "1607290822605224042715978907090601569728"
+    "hash": "16360431835182626351077311320716792035"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u128",
-    "hash": "376280426045472480017461796399163654441"
+    "hash": "1846461453155705499483088735002710961"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u128_slice",
-    "hash": "142904147110440140382371508210584710250"
+    "hash": "12919948715888755654003773996066082169"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u16",
-    "hash": "189306332556682082313810488315456031822"
+    "hash": "1563804127774067158715370171125999654731"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u16_slice",
-    "hash": "443334778298374210612780126360521930261"
+    "hash": "142186458445319615918853857663170536350"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u32",
-    "hash": "166683938939168448823723813880479002474"
+    "hash": "488903940943785014014909800688570702771"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u32_slice",
-    "hash": "1141109251371258719518150901468110049893"
+    "hash": "523719750247674573716756083305369684102"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u64",
-    "hash": "953108137971526991316970136591365453289"
+    "hash": "1208526509658323825572486734485265328"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u64_slice",
-    "hash": "60101527556627396089972012388302351098"
+    "hash": "258977265444447680518328616662913869862"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u8",
-    "hash": "783392222791828678717886677497209191088"
+    "hash": "45906627679052990812223475143960040222"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_u8_slice",
-    "hash": "339919658640172275518069446552849815766"
+    "hash": "944906917096743308718411926111846286015"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_unit",
-    "hash": "104268905733119846525120193697400299738"
+    "hash": "1207300024410842280217524321813629389570"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_usize",
-    "hash": "12763337541174542385663017195468360618"
+    "hash": "155011682756778884712754229304721564840"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_add_usize_slice",
-    "hash": "926660397466653154117171879137181941792"
+    "hash": "157111091647613146868926855852633376572"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_cast_unit",
-    "hash": "72679433664304965910037016317421381802"
+    "hash": "28478568544649681599836889796705183089"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_dyn",
-    "hash": "40109375984461863131946764651169832155"
+    "hash": "1835058917417551263010754329110216464106"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_dyn",
-    "hash": "121346300789475636561207885541643122662"
+    "hash": "4906062050927098689917698203352900675"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_fixed_offset",
-    "hash": "86042762092653700713576906930935038082"
+    "hash": "1551630612805190232010147968108927369606"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i128",
-    "hash": "53248487735086434711357569095973294968"
+    "hash": "773810933942820959314835887217808837426"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i128_arr",
-    "hash": "49008075453693233352988149037724470064"
+    "hash": "125063428547612043689309526511430138039"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i128_slice",
-    "hash": "136895748299023794666709439541180895217"
+    "hash": "80223564512711038294317750865998730182"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i16",
-    "hash": "119446623548266856707244925103191928788"
+    "hash": "1457955831293470741216170682454339668830"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i16_arr",
-    "hash": "894507300465843276214180381811796603239"
+    "hash": "596590458125162300311553079272015797676"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i16_slice",
-    "hash": "1197639240487100715015218095983614466634"
+    "hash": "1272487943177778607017165711260323282087"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i32",
-    "hash": "102555548327468646971306992801013232392"
+    "hash": "906765415368293307816308137356490893356"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i32_arr",
-    "hash": "1122545148513966440713074632776670784953"
+    "hash": "28950829728835720316628604590829414402"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i32_slice",
-    "hash": "17591358447729644713322981758042862485"
+    "hash": "66161310415961208032023596242747228601"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i64",
-    "hash": "1739311261132231535154594698936762515"
+    "hash": "593087626995658673211682002602489979201"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i64_arr",
-    "hash": "3791104449404982339109291074276444393"
+    "hash": "1460726440485716476813667388363860990388"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i64_slice",
-    "hash": "934510236137214110418142349091641346800"
+    "hash": "48381501621481187017900992593974890691"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i8",
-    "hash": "52556049259833840612525568879412974393"
+    "hash": "180591460056434020778345262995057190833"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i8_arr",
-    "hash": "50388699140277276392040260327835305022"
+    "hash": "649228195785470731517733531884611284298"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_i8_slice",
-    "hash": "665023023313478959611365238578652252479"
+    "hash": "1083742636386536370917275455363967945875"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_isize",
-    "hash": "113328196949881191836255687627553712354"
+    "hash": "108499785470531989162275671783251699314"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_isize_arr",
-    "hash": "162835621402383805116664775077224111768"
+    "hash": "1230094214205434849711184149018189314054"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_isize_slice",
-    "hash": "80417396837266613167033338875329914220"
+    "hash": "47955991063541865231508319219645985205"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_1",
-    "hash": "87574890931237950617753701139683137158"
+    "hash": "117813417602418952688806188019676385725"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_1_arr",
-    "hash": "67130541617817303044604626871381974563"
+    "hash": "132640293410324597588002821909435561320"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_2",
-    "hash": "124848756233338661115317919016791591894"
+    "hash": "1116251429364132508418373479365929917559"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_2_arr",
-    "hash": "148371786174045930272564359394642540455"
+    "hash": "554577578789205438611043453099967299968"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_3",
-    "hash": "76978277129044061639218017540571271039"
+    "hash": "105986825419462071646303644009878133905"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_3_arr",
-    "hash": "84782725157261381336347655037473532124"
+    "hash": "103243424484260032659235256203355038019"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_4",
-    "hash": "793557815986676956014572936229372059636"
+    "hash": "163883526145883047593380605546680146410"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_tuple_4_arr",
-    "hash": "1543516562768406995111271452320850582192"
+    "hash": "352006421110553064813003216492333656870"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u128",
-    "hash": "1372051797861326714663754467307104999"
+    "hash": "135619572731870267993027842624065766237"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u128_arr",
-    "hash": "6927362728319685519823952981896420177"
+    "hash": "1691232697121156622917895783751255301461"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u128_slice",
-    "hash": "177806543362526129619800873540376030947"
+    "hash": "176676570853450642283393797865118495208"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u16",
-    "hash": "92827774699949403698686861968249620927"
+    "hash": "1087076667242374655517327469520461870431"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u16_arr",
-    "hash": "44591165107676435659598892535891939492"
+    "hash": "448684070389875908210952198320177559940"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u16_slice",
-    "hash": "1703279426144374087415520094247924957829"
+    "hash": "566546874377286997716926219085016929696"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u32",
-    "hash": "36439214747960939826232859219629655478"
+    "hash": "1026560116735330114318236597746252203872"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u32_arr",
-    "hash": "184281469519399659792401799740020358484"
+    "hash": "92099506293022408252816003983231775844"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u32_slice",
-    "hash": "180289699031288650374491836304570662236"
+    "hash": "1308169265360620359711264606404317766323"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u64",
-    "hash": "724795515084080854016773156646655367464"
+    "hash": "58310225020683835655557336817624774758"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u64_arr",
-    "hash": "934426316301556350918382064150158837335"
+    "hash": "1333986093766900210810718495950299311174"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u64_slice",
-    "hash": "176154456308286077597393735356557289102"
+    "hash": "18023445917333222800361905004951951554"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u8",
-    "hash": "157494340762137603393295061976345970388"
+    "hash": "112352224093955504716941066644030021469"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u8_arr",
-    "hash": "5568289483562380903331917751499994900"
+    "hash": "125212181432941857658782468278419647390"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_u8_slice",
-    "hash": "1463089805995044200917743169769473892255"
+    "hash": "1030962623015336635010665022901837103494"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_unit",
-    "hash": "102432282612520547583200950098303684487"
+    "hash": "56741440795001704683005549319303930732"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_usize",
-    "hash": "62710078182043370114913883805769982215"
+    "hash": "1473629308985840539817680236216656267722"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_usize_arr",
-    "hash": "216164551535881389015727265480956737900"
+    "hash": "137458818875369985209052947247905862112"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_from_usize_slice",
-    "hash": "6080792642595631748650954982055379796"
+    "hash": "96015555635929856182068620297039687276"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i128",
-    "hash": "454131717359372835811693493765943701931"
+    "hash": "1910330331926052916828389682967832380"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i128_slice",
-    "hash": "114684554212813750583127302168618931167"
+    "hash": "129031611576925560251966061767479696531"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i16",
-    "hash": "127341729045954790715457672629503672817"
+    "hash": "155782980783901851581441734508951074734"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i16_slice",
-    "hash": "8736554062049458499914036613142431838"
+    "hash": "228793104886810141113999610691937853151"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i32",
-    "hash": "450498847782472301710583156506992649767"
+    "hash": "21663825259583796899009136752067207193"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i32_slice",
-    "hash": "1309697691443808238714693776794607164687"
+    "hash": "46074851496994633232952085978508747390"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i64",
-    "hash": "21927460298032175147643728055614374783"
+    "hash": "820142145608203744615249611030587596989"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i64_slice",
-    "hash": "581648473891084257511531235591359881754"
+    "hash": "52337851546867762196619885992909618052"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i8",
-    "hash": "95758815325064901038058854643170093415"
+    "hash": "433846513877232044912834959351008426376"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_i8_slice",
-    "hash": "1357485938052032401910181783362239229998"
+    "hash": "1636771846880150689311892342491634384682"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_isize",
-    "hash": "6575241154557537694412693981599880274"
+    "hash": "13480201492507363951190825856854697380"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_isize_slice",
-    "hash": "98343184570553121091313744070836329764"
+    "hash": "1702985597226491730555608818970817197"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_1",
-    "hash": "24620011161540116398919672931937637529"
+    "hash": "2329751326812624158999165343367774491"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_2",
-    "hash": "43942161010382635279009669348680678166"
+    "hash": "941058816964801151417261630491075883498"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_3",
-    "hash": "672246196723218528914702736793713075658"
+    "hash": "65943116074395230139049357317079071934"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_tuple_4",
-    "hash": "1502924923678749485910362119972055496469"
+    "hash": "1576704497289968190415915609754627248157"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u128",
-    "hash": "105639172785129663804219869990989668410"
+    "hash": "32177357125168474802807922652531491385"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u128_slice",
-    "hash": "29084144641832115058777247363945394591"
+    "hash": "131075692591483309242295552546326448701"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u16",
-    "hash": "135452323624709616413124417796549578018"
+    "hash": "142950817786484130608710475451369688314"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u16_slice",
-    "hash": "18779809690410943413589593046653088128"
+    "hash": "4749325290539070450833041482529914994"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u32",
-    "hash": "1741344153480102745212932670127002312776"
+    "hash": "926827913134031611217076026170267660805"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u32_slice",
-    "hash": "157784278016234339086795023402810522877"
+    "hash": "114790759205998243913762138274317811631"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u64",
-    "hash": "12325661335996963207053572713933332229"
+    "hash": "646997786206240982916235780542756061768"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u64_slice",
-    "hash": "130887298470579432411135356026019851331"
+    "hash": "1398703184371098096316343772329021451218"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u8",
-    "hash": "78594647127364731372032063570121040429"
+    "hash": "1509342001293340141817698622083449497718"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_u8_slice",
-    "hash": "104196611985598767873124401960092430022"
+    "hash": "150790693171954153687493086528819773691"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_unit",
-    "hash": "56422243238568459396939997079496025912"
+    "hash": "1723629025495896085912811545360423108134"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_unit_invalid_count",
-    "hash": "329818862583333159216745648847028231354"
+    "hash": "199393505885455949367757821260279202"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_usize",
-    "hash": "444049558116081275212661906629890657973"
+    "hash": "1825310201233115310111507980843608481139"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_offset_usize_slice",
-    "hash": "1515561819749321575013507412201550578746"
+    "hash": "1020803234580360337212713001547399844561"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_dyn",
-    "hash": "62163144194216857402720029388064333408"
+    "hash": "685499241201413299014279389924740293593"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i128",
-    "hash": "335866384141074556510768482553929118587"
+    "hash": "83604550640178848089956772279027965848"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i128_slice",
-    "hash": "1272709509453437402413655174223862784601"
+    "hash": "1165224262270679206717335208861136059655"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i16",
-    "hash": "1834737111203416726312344928493007125532"
+    "hash": "108463181042920253316360602960857423922"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i16_slice",
-    "hash": "1157450651537014636110210569142402638734"
+    "hash": "81595698048129681949411320313068702877"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i32",
-    "hash": "86185297137116787126546325256588841560"
+    "hash": "143974620856651237477985265226193924775"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i32_slice",
-    "hash": "142382702112499467506449811647263392064"
+    "hash": "66817998669704091141599728397343326930"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i64",
-    "hash": "152690289695794186975008903113650483445"
+    "hash": "11449230639520295205570285654377029269"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i64_slice",
-    "hash": "108879466860163261081788904314322777513"
+    "hash": "91562201282436633541462256845460852585"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i8",
-    "hash": "130400700939603778815419371270293866497"
+    "hash": "155588123127870753703576965879687464415"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_i8_slice",
-    "hash": "1388766461772571065212565705961371868772"
+    "hash": "79245413885804041948254209423716335976"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_isize",
-    "hash": "83795140216574369704707694915005872251"
+    "hash": "1340648806503170068318164292662838149392"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_isize_slice",
-    "hash": "805419656682353809314950803784257463712"
+    "hash": "63756406089363154914337182629998304028"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_1",
-    "hash": "1661692600724467351010522731220070637198"
+    "hash": "107834115247428803878992653933478160694"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_2",
-    "hash": "179785851543915821742506699667089309540"
+    "hash": "1154007723717721260817132116036508418656"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_3",
-    "hash": "1784875982872086567211575071731553797748"
+    "hash": "169955309878546801391529479940081275896"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_tuple_4",
-    "hash": "17754108342010230412920869484544326530"
+    "hash": "1457426870049344943118049717761291888213"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u128",
-    "hash": "122359974852417625328824796914879049414"
+    "hash": "72121784230212368089810156915195956082"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u128_slice",
-    "hash": "807129096864775184410741761507488487631"
+    "hash": "5341746813015391941791096873640329252"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u16",
-    "hash": "1803989804728501715211530540489200940576"
+    "hash": "156008023474602482086828738113289952993"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u16_slice",
-    "hash": "42967478929081058393263715837834891844"
+    "hash": "26229656160457705094742015135488887690"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u32",
-    "hash": "175697470240320147214313845433282838374"
+    "hash": "549541522723793237917475515325557797030"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u32_slice",
-    "hash": "181593430042015998773394229276948461919"
+    "hash": "81682673775017842135820659741987199599"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u64",
-    "hash": "657394553962587845912613405109275179027"
+    "hash": "98270155466324263413192210241768655573"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u64_slice",
-    "hash": "93546504414135550416319293771510446731"
+    "hash": "63944416734581842110500530764467277455"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u8",
-    "hash": "18804186772860826068890466451219588102"
+    "hash": "744029502985405753911884368139070963937"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_u8_slice",
-    "hash": "17495571747323468616923393770914744523"
+    "hash": "581615646397329590913586718629668549085"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_unit",
-    "hash": "657092135948639082412761214202685750597"
+    "hash": "989434848373370956713437013889901852484"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_usize",
-    "hash": "54182611523797391643286971384532957395"
+    "hash": "161979279841183529427197669781397380404"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_byte_sub_usize_slice",
-    "hash": "2413643927284753662169917047484514505"
+    "hash": "167113946419389663476318225502277710308"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i128",
-    "hash": "88877851959119872683325496227993798334"
+    "hash": "696330027754939415610973163619045301856"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i128_array",
-    "hash": "78844825596471269886641008542805107885"
+    "hash": "320046556803928865415240636144773120077"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i16",
-    "hash": "481032140060310773713474973687865728740"
+    "hash": "150606427166329197797895759708103637254"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i16_array",
-    "hash": "698578439128549941016722498924209206265"
+    "hash": "20397655445667446785771780278628742492"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i32",
-    "hash": "585758978641009299417863445189723379255"
+    "hash": "65856155161561582171095734428860020503"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i32_array",
-    "hash": "1302787617493865871511277635616361084436"
+    "hash": "30079548507387035617337894992899228944"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i64",
-    "hash": "1714994365811903060517270279872026419846"
+    "hash": "23540607517088129467122533754865787245"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i64_array",
-    "hash": "176494832326003514501548294724549063666"
+    "hash": "63055882321720892384647439101507307499"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i8",
-    "hash": "146895324508417870971865801588979059768"
+    "hash": "137907942831238196613889307241347315989"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_i8_array",
-    "hash": "857849120599855269514941424056884585183"
+    "hash": "1563695798627120356610677362867898119808"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_isize",
-    "hash": "68306791852743917296077456685335864782"
+    "hash": "771834964383278062313076878891557114524"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_isize_array",
-    "hash": "45607934530354105315410050186369032403"
+    "hash": "22210192262208719015301226477131810739"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_1",
-    "hash": "77720282134694234297263165939769047365"
+    "hash": "100131432203728521725087474597045316748"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_1_array",
-    "hash": "668262908442825412312275248984583861278"
+    "hash": "267886848787388445217033830866192295424"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_2",
-    "hash": "62489879601054675855858870882349270772"
+    "hash": "81362249798990447267426899046078815531"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_2_array",
-    "hash": "237706028039931232613898826959332314562"
+    "hash": "6939101351419100211851390575594450982"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_3",
-    "hash": "934493123050304370912019451717172864966"
+    "hash": "84995588211998038412858284209320709609"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_3_array",
-    "hash": "115735363330376889943330801591689117096"
+    "hash": "1156158038373211064912532679233850792198"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_4",
-    "hash": "137502461968767924231169231791461375274"
+    "hash": "121988653635646154485197541456002255483"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_tuple_4_array",
-    "hash": "33710139911346370571154067611413434055"
+    "hash": "1408107114683912708417045376472953107633"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u128",
-    "hash": "229346494923256319817305675350834296821"
+    "hash": "138758222218124490928363292866016394059"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u128_array",
-    "hash": "70936551213287971763712925279344262257"
+    "hash": "12284458368572986965809734534483035892"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u16",
-    "hash": "78950729562529615622768970282430817318"
+    "hash": "25681143599162751987519049878934121912"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u16_array",
-    "hash": "705486316655619288014403321880647104715"
+    "hash": "38041309770090316718574509880847518222"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u32",
-    "hash": "765393315126086176611441037139591534266"
+    "hash": "7174848411798694731859142735107059733"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u32_array",
-    "hash": "1074690491714079624215851346142255997292"
+    "hash": "13906670009720986705907170232984858699"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u64",
-    "hash": "10392892426136338104990723193413363238"
+    "hash": "144038172703939731065440722233071241084"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u64_array",
-    "hash": "160788960388425286248683034632333253648"
+    "hash": "28161698278387946905387260813669003135"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u8",
-    "hash": "144132621553293764617067815214068604299"
+    "hash": "9450172207666873852812715370360718465"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_u8_array",
-    "hash": "1824781798770686997606129081765319192"
+    "hash": "1160234633774975056014082442722115523905"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_unit",
-    "hash": "389435815582681361218120354073453159932"
+    "hash": "937138538081775379910592330601517320431"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_usize",
-    "hash": "1696963768541727100918115778766531982274"
+    "hash": "155850881876130710638577990712673459632"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_from_usize_array",
-    "hash": "130921406778700730231927693270944881243"
+    "hash": "49995078997867405197939686001821891290"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i128",
-    "hash": "34176213537842957814439550225174964302"
+    "hash": "342297942028408888614426175389179468375"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i16",
-    "hash": "198423755668160197411632055481549512953"
+    "hash": "131170885190113449154612935636619492156"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i32",
-    "hash": "155675214849733935707950547923039337069"
+    "hash": "151234693796664654109208671075843736025"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i64",
-    "hash": "31936714096094526515740399568581821119"
+    "hash": "44987024146370819526821790460913703318"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_i8",
-    "hash": "63031679161014359132993224700757945165"
+    "hash": "143036525782206426462550036788768746085"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_isize",
-    "hash": "10511275438415517086807574380262679421"
+    "hash": "23588512857460175112975557656485165236"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i128",
-    "hash": "157652756192003225366566707289406449167"
+    "hash": "1829644626460140164712446958817622255190"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i16",
-    "hash": "949427345742438400418120822823440110332"
+    "hash": "161165455145932633312171030194730753563"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i32",
-    "hash": "110839555540109883581248127228736085051"
+    "hash": "38146875261490773272460783063837140559"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i64",
-    "hash": "32227542606150810685806035679235357426"
+    "hash": "144247344730558130672417280294647136993"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_i8",
-    "hash": "540095076610041761916169922480133347802"
+    "hash": "666257739913538417514440259874473640717"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_isize",
-    "hash": "1518868431082337523015255103141803595491"
+    "hash": "942132168032893925810502590614237644270"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_1",
-    "hash": "16724054122296093606124649726759586979"
+    "hash": "33031491353698206727018722972964413146"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_2",
-    "hash": "41629929209814401876386847388370543162"
+    "hash": "641747281272355769714405609866831979408"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_3",
-    "hash": "161202864113092848123709346586611639219"
+    "hash": "561676556624499788311616801984046741952"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_tuple_4",
-    "hash": "41327381205890663224526759226402389713"
+    "hash": "100772350851368504809679870021583735591"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u128",
-    "hash": "119989811314778445052828940373004436468"
+    "hash": "841590687930190866710615284243430953440"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u16",
-    "hash": "1266004043685367220712988147043930065995"
+    "hash": "478941332451605578211236748745517833810"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u32",
-    "hash": "137454801878025648914651963543523785654"
+    "hash": "332898925731662075315036006947789339179"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u64",
-    "hash": "141540139310910335517336662841698981491"
+    "hash": "65533855003569914921311214969805518014"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_u8",
-    "hash": "357865219362546065514013606194565609150"
+    "hash": "1544286333619572567814652059518607937057"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_slice_usize",
-    "hash": "40387199117608303189208154010921805259"
+    "hash": "360851794473655393510973221611910750737"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_1",
-    "hash": "10529911052758982216247476843061773865"
+    "hash": "43335879533910215869965959583301153136"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_2",
-    "hash": "157287007359659382254551602317722049895"
+    "hash": "112317403894261351334569252659277526505"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_3",
-    "hash": "35726856699162475134144920114343932998"
+    "hash": "241883408283601034214594377984433021616"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_tuple_4",
-    "hash": "182439896619015366513152599822641379750"
+    "hash": "7008214705175512396151918896898952314"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u128",
-    "hash": "6442793723563713828955550294309758797"
+    "hash": "564697472954438498040905650870305465"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u16",
-    "hash": "1160367840163600043115073922749875484407"
+    "hash": "1284034644309072776513543653864590702721"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u32",
-    "hash": "1162130782304978194813981706431862336590"
+    "hash": "1038019907179383920910767445894761965860"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_u64",
-    "hash": "573177967650711070716906444976510692110"
+    "hash": "601534251925469966017230420898098136817"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_unit",
-    "hash": "188868274262120573712869464707927741472"
+    "hash": "1343499633561958719216312093127935499377"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_offset_usize",
-    "hash": "818701120752323608618061751262758239071"
+    "hash": "1311633000986359466510844268511730382407"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i128",
-    "hash": "341627976428751505217108013742730714171"
+    "hash": "53515973524772126099809813663984316182"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i16",
-    "hash": "145958809671978417741796555322743872781"
+    "hash": "102731795500303462884662222854933067687"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i32",
-    "hash": "92437944048307452085859428575062584497"
+    "hash": "1047904007183775896917977155463355742015"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i64",
-    "hash": "15938229365298027913493691509589598681"
+    "hash": "6078851829207035068012998111768316169"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_i8",
-    "hash": "1746796774868030296214109603810663411253"
+    "hash": "154614750220985907048027616304357126952"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_isize",
-    "hash": "913178227069576976513501173723279644587"
+    "hash": "96117709829946262573914095391152566019"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i128",
-    "hash": "180101527294625984148758618638639746835"
+    "hash": "871304017093762009018116702986368762378"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i16",
-    "hash": "127080766779991542712704050872249092329"
+    "hash": "1246520703659192194915786681091136905211"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i32",
-    "hash": "879368742341422893418254324789155947037"
+    "hash": "323568299347352418212714880423520279779"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i64",
-    "hash": "3644772464759090577658637723771986821"
+    "hash": "81195297590536281096553452827892190225"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_i8",
-    "hash": "8588818133964134668070416555090580328"
+    "hash": "27567117371593721988910965939891564342"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_isize",
-    "hash": "41930633413595137895387460614146574914"
+    "hash": "37538580242024948001760762929801132953"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_1",
-    "hash": "781441124919869554416502189132605279844"
+    "hash": "1036849070921420154425286441590850762"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_2",
-    "hash": "61132976871941369104591310354676192835"
+    "hash": "76524844457558993275757415700711152381"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_3",
-    "hash": "92710387544780106501133015214626088140"
+    "hash": "132245124082063489842699929864920591991"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_tuple_4",
-    "hash": "96302013474733976217822527100873564280"
+    "hash": "246824732937089328118210926653494998810"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u128",
-    "hash": "81622547885180210229772679766098623960"
+    "hash": "22256670217093282455593958890864417657"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u16",
-    "hash": "19944365617265444641235592071625836321"
+    "hash": "155568371230529961942778040329780186932"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u32",
-    "hash": "16915764259506228428020641737851528130"
+    "hash": "1810142310043796914211793807887989025773"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u64",
-    "hash": "1694174951488200727670769355079432817"
+    "hash": "949557835961934931111658023066847504564"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_u8",
-    "hash": "1736751304106843223716931371578427299615"
+    "hash": "459647931013415320816189434738065836126"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_slice_usize",
-    "hash": "1632063388415339290211855231845129212627"
+    "hash": "621497648495597624313404973672577869674"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_1",
-    "hash": "68779461610473718578176483796119262064"
+    "hash": "121069607916912823268076390633255771343"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_2",
-    "hash": "1567955632154993140914762349094981139635"
+    "hash": "147885621044826007742982464454731519290"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_3",
-    "hash": "1801224950679635015517885629536356276538"
+    "hash": "11388766935340300958722031783404127462"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_tuple_4",
-    "hash": "1263671002415910184812995388235590456204"
+    "hash": "86474300757032917911193537949585957096"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u128",
-    "hash": "98676360285596856122893252365742821878"
+    "hash": "17225502781240651991333716840023576463"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u16",
-    "hash": "632503239863003576011089365060925551304"
+    "hash": "183920116284916685544544522612898172481"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u32",
-    "hash": "12624980082881436920571132781402339701"
+    "hash": "924897042041410971413047136540409708212"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_u64",
-    "hash": "81956476375626376201529993607137271305"
+    "hash": "122075905858217951714800812011605116990"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_unit",
-    "hash": "982021487992632128389586496515652292"
+    "hash": "121050462169381801815491316251320942315"
   },
   {
     "file": "core/src/ptr/mut_ptr.rs",
     "func": "ptr::mut_ptr::verify::check_mut_sub_usize",
-    "hash": "1812235887773585394216190575095297600349"
+    "hash": "161953534078468840428887386176312359328"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_add_dangling_proof",
-    "hash": "1747298681486910475816726743755067658898"
+    "hash": "17444228336824189752462070142785648621"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_add_proof",
-    "hash": "1579887565423392023912766034399471615858"
+    "hash": "688322228492094239816178455094697432491"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_offset_from_dangling_proof",
-    "hash": "348717468479167218713843361344884722064"
+    "hash": "19580315731511462611427111561444119966"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_offset_from_proof",
-    "hash": "1098922922670129613214590088607032461213"
+    "hash": "1649526097990842950717454622885167174503"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_byte_offset_proof",
-    "hash": "1603514863278245643415125165189311626919"
+    "hash": "1143363275365724994317774081066302298418"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_add",
-    "hash": "107157012980315669817514695998874878698"
+    "hash": "16290436647856014989817137363585617253"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_addr",
-    "hash": "73749130171920277746895880475102142147"
+    "hash": "130100253621390112181785825687195458913"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_align_offset",
-    "hash": "9718814348386585608996232064151130741"
+    "hash": "899711308647752674210289638917477681096"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_align_offset_negative",
-    "hash": "40761669962769985826884235235170685339"
+    "hash": "9462321022686435794067035520796360821"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_mut",
-    "hash": "61832168037305662226151216037272025262"
+    "hash": "13813496740395743749445444418474008631"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_mut_ptr",
-    "hash": "45158695316660810675881326582926885559"
+    "hash": "857360611764458586316400947437482018742"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_non_null_ptr",
-    "hash": "1430875310159020512510747736760781895804"
+    "hash": "10371168902957988945924414347535950406"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_ptr",
-    "hash": "54303012363649167618320663668216943270"
+    "hash": "406211520990736106713608909895640994528"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_ref",
-    "hash": "70471356695599362813179690735992408029"
+    "hash": "619531733527696458413551874090283331066"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_mut",
-    "hash": "1747131982949722268314734395930541090813"
+    "hash": "1652300581698948207218103258133122044626"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_ref",
-    "hash": "40778229744204218142977567990097323398"
+    "hash": "110928428641917351463649959873205781374"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_slice",
-    "hash": "6155879628434304465225367274103505255"
+    "hash": "777032401298734572013591599564925974407"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_as_uninit_slice_mut",
-    "hash": "1526326320573611530510845467282402783903"
+    "hash": "152269218973942662159375054821869651851"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_byte_sub",
-    "hash": "51935963327726248642342784902589865795"
+    "hash": "462026359248805334511098533231595459357"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_cast",
-    "hash": "342796496168384324312428470851097519583"
+    "hash": "66796354811321158495112179015015031606"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_from",
-    "hash": "1044284009250301634515113316838429765962"
+    "hash": "54733754020344580596252035163308027248"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_from_nonoverlapping",
-    "hash": "251463311196613623611201956951013921811"
+    "hash": "149353816556169971149326628926616715752"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_to",
-    "hash": "372285907565593037710677712597518060347"
+    "hash": "1655044573647971024013783701378533294810"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_copy_to_nonoverlapping",
-    "hash": "1600953319613678393114813525235320289637"
+    "hash": "79797449618343173524788375028097738719"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_drop_in_place",
-    "hash": "833119382969450938414885940204520736379"
+    "hash": "132526314002287367942726372009918337399"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_from_raw_part_trait",
-    "hash": "720928737188636636814545206971351089656"
+    "hash": "62719145474213895231309511448133981929"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_get_unchecked_mut",
-    "hash": "117486130024486173049454652198656781666"
+    "hash": "106963626207943753082859438296894253071"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_is_aligned_to",
-    "hash": "119866710655772248174294157214312042051"
+    "hash": "51915470283033776771254875377328973860"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_is_aligned_to_no_power_two",
-    "hash": "177665352612592310238447279524841092379"
+    "hash": "1193426965199182770513267545627407449155"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_is_empty",
-    "hash": "64992349610206906493972609669430293672"
+    "hash": "650993329988601024316868010019321568689"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_len",
-    "hash": "57244469530576191003984485934283563932"
+    "hash": "587575833008383151814788621552248117934"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_map_addr",
-    "hash": "122402408817049489017569871722363203417"
+    "hash": "53223000933562797711415405765070791107"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_new",
-    "hash": "13499313909562794569050386619764562768"
+    "hash": "17521120372762346568515825715402127334"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_new_unchecked",
-    "hash": "64184252177853553687165725130196342524"
+    "hash": "908166559499485195815456486536707007835"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_offset",
-    "hash": "1430799571502227858214068548952047478138"
+    "hash": "1764019790125179662215336128208067258029"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_offset_from",
-    "hash": "692636254821948565615536593488076397385"
+    "hash": "95324036043828150932077367757957872696"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_read",
-    "hash": "851755023256382660111384685700353402341"
+    "hash": "115000884303785821355970415659381405684"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_read_unaligned",
-    "hash": "166297787229119087874584936186230752436"
+    "hash": "725090587249524681813448623708682126364"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_read_volatile",
-    "hash": "854490041449606109115330206530653654003"
+    "hash": "1599875538626405725311715573862035875608"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_replace",
-    "hash": "12181502269707053472181624239566552065"
+    "hash": "144112023863817061998145523039525579167"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_slice_from_raw_parts",
-    "hash": "134779604878960724428885797167447727063"
+    "hash": "74565718190414701195564310526915324843"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_sub",
-    "hash": "107511771081490894503899211715429222877"
+    "hash": "1157769923303971431911864449214761345412"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_sub_ptr",
-    "hash": "1679634702483926906113785645270600412418"
+    "hash": "103963999094906981114552715994221120536"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_swap",
-    "hash": "1584325256965804149516102277019228176548"
+    "hash": "627299795047352134412446865530311703884"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_to_raw_parts",
-    "hash": "333386655064828718114345860663805163521"
+    "hash": "115538306409906544082055894187275012032"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_with_addr",
-    "hash": "1260418369259312175413835785129909860466"
+    "hash": "127140607740334852803137579698959963243"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i128",
-    "hash": "32134058635352782931866765010946807685"
+    "hash": "91575577108022156916268791278579950556"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i16",
-    "hash": "296859307844560924116780550673909048904"
+    "hash": "103568027113157008827999270500042765037"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i32",
-    "hash": "57071385859858181898463833311451810780"
+    "hash": "20661108709668732256293801414653003764"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i64",
-    "hash": "1254583894498796787934402120685081129"
+    "hash": "293901113092381325210927600960169238794"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_i8",
-    "hash": "1376397961654530514710188956824610611921"
+    "hash": "153061836221569423856873460427559615720"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_isize",
-    "hash": "1026068410662060630313772539566432512952"
+    "hash": "180448014908894164434758409061384629888"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u128",
-    "hash": "17932086107077254426181753444098387203"
+    "hash": "21805169767628883947481310890595666888"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u16",
-    "hash": "8422488275800112025831466780014806728"
+    "hash": "82443077272052247846951813109381783468"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u32",
-    "hash": "9139453833036456836350178314384186960"
+    "hash": "507432105738532318512436752528878551826"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u64",
-    "hash": "638268871256266049313305943232860351226"
+    "hash": "1431237536933348024511746759760755141"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_u8",
-    "hash": "348611778153520057114744393324966825616"
+    "hash": "1079952583824377863215712760609827153860"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_unit",
-    "hash": "67091213483378712634923995303548131700"
+    "hash": "49519980084043249510379016134201604358"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_bytes_usize",
-    "hash": "59268293925322015822070410127716314099"
+    "hash": "28260867926805741748709533083639929975"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i128",
-    "hash": "180467279781298655727177085399030198562"
+    "hash": "627497896926534675911786564102703592370"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i16",
-    "hash": "1430476498542536689214724281062428978806"
+    "hash": "510685557569134157413474083430223772366"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i32",
-    "hash": "1332871670278172055918013401422897437373"
+    "hash": "160688257063881335105110729760506197269"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i64",
-    "hash": "59535126947856545917815076042086058939"
+    "hash": "89188822709348200109568438550846431327"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_i8",
-    "hash": "138830679896852037269858826665506679596"
+    "hash": "90854812953061008936232673928105088144"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_isize",
-    "hash": "10328200052592827512867520615350185469"
+    "hash": "873687152640555328014131108511130757201"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u128",
-    "hash": "1268682461100987917957169479927943402"
+    "hash": "1247573117722118737217428406871960870474"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u16",
-    "hash": "166237685685537748367906308768232129843"
+    "hash": "8882961879931188168043518158103491452"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u32",
-    "hash": "78225775701922819363925440995856837037"
+    "hash": "178637850681288067503018430366170158444"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u64",
-    "hash": "62621594732464581416564918563724275442"
+    "hash": "115186980366116065665164491637128764872"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_u8",
-    "hash": "170557890060617080135350622761273930062"
+    "hash": "1630010274961526850411528747005978082826"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i128",
-    "hash": "95982496510494095811360893493241944512"
+    "hash": "11954152142164409841190183283971885701"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i16",
-    "hash": "1329541734850133912814961814113369895703"
+    "hash": "871085769247702071017079140238082168775"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i32",
-    "hash": "5003943964297149222709546678963714000"
+    "hash": "153060554615101494609090688107958964838"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i64",
-    "hash": "166843234667500978567563125999510491671"
+    "hash": "1700984225148229216217459680770160883687"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_i8",
-    "hash": "621682731602593580016321504711699906354"
+    "hash": "181053913874059441179839838122752939112"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_isize",
-    "hash": "129615871933134743014745173520838036829"
+    "hash": "240150359145394492513370403914282032158"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u128",
-    "hash": "868448858850195715412134944073697606388"
+    "hash": "1827406137713049807614524741067234695419"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u16",
-    "hash": "652370322423207672414287470446105805855"
+    "hash": "138015948936209957227410876136437988497"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u32",
-    "hash": "575246318325320249512530746546845860814"
+    "hash": "1075625232786893911210704714514917782996"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u64",
-    "hash": "58040466875078911655341618928082059622"
+    "hash": "41108727694476257369757419566782510827"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_u8",
-    "hash": "26673647802629224667168836089929973138"
+    "hash": "1834696523156267051818164975869941263709"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_unit",
-    "hash": "141753337997269697372751668072179365752"
+    "hash": "382239763175345238114199938498740380176"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unaligned_usize",
-    "hash": "42673777719291574245463675027090948832"
+    "hash": "11511995503683118213179084667509984973"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_unit",
-    "hash": "689324134787994935411326758909638214250"
+    "hash": "685693598824122000317563499524932000839"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_usize",
-    "hash": "177914902475674915364731627082095414526"
+    "hash": "577171121015011454511277102605466952275"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i128",
-    "hash": "174775390741014390053405165315561568388"
+    "hash": "1722435117845618230213492687996994847938"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i16",
-    "hash": "142048866353554846294577566982689378227"
+    "hash": "335028472216190024715413638883930445334"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i32",
-    "hash": "364541460912482096511935142866566376635"
+    "hash": "6082716670180213963510436597096387100"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i64",
-    "hash": "35220241851420753863538125456005285252"
+    "hash": "896212000170520464816349637334191859368"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_i8",
-    "hash": "1810558908056158921011800822272515584988"
+    "hash": "163755686889880640232021432650944323562"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_isize",
-    "hash": "43258784523514452412395693425572446803"
+    "hash": "1517395270487077959115712092473454002747"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u128",
-    "hash": "1833114452296479351113560235388169590691"
+    "hash": "303008628392884888415706272720131993870"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u16",
-    "hash": "27919533875916407864293660286152662452"
+    "hash": "50652784218102479368028266008966530396"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u32",
-    "hash": "707277323632466299412010852321864874537"
+    "hash": "63391428371796542075402026246876572896"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u64",
-    "hash": "1790507493767768924411798306207647705741"
+    "hash": "52992264035800884721141461565176709179"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_u8",
-    "hash": "1367128918803930320516622420299129366868"
+    "hash": "117386878272532511233336338922894740991"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_unit",
-    "hash": "462689983539327928214161524900208112210"
+    "hash": "22907383900765150436307750156242526689"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_check_write_volatile_usize",
-    "hash": "11851342108536372684371000905120299841"
+    "hash": "392753272968129194311093433146012854075"
   },
   {
     "file": "core/src/ptr/non_null.rs",
     "func": "ptr::non_null::verify::non_null_slice_is_aligned_check",
-    "hash": "40633048495016183856590486397510222258"
+    "hash": "1499524989893243890014154430666720704943"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_mut",
-    "hash": "117777470482487681418711445947373028094"
+    "hash": "249237478728842833512931658291975139572"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_non_null_ptr",
-    "hash": "41546644467610812826556990811979766638"
+    "hash": "341214187713778708014448450233072314022"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_ptr",
-    "hash": "105716617228133269097545665373400629820"
+    "hash": "627543795123301268410300122295889486491"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_as_ref",
-    "hash": "127164979549636140754680316738684717863"
+    "hash": "78429416892213296752188951542999756445"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_cast",
-    "hash": "376399865093847840911486449165911927626"
+    "hash": "160066752515252673613075721758359155604"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_new",
-    "hash": "1811613836314477174014808888154227993594"
+    "hash": "536549931544590665715591448789303473354"
   },
   {
     "file": "core/src/ptr/unique.rs",
     "func": "ptr::unique::verify::check_new_unchecked",
-    "hash": "775688553481186341716842585442130327801"
+    "hash": "11792335716319747321464545802227063805"
   },
   {
     "file": "core/src/slice/ascii.rs",
@@ -35228,12 +35228,12 @@
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::into_slice_range",
-    "hash": "78298200851685132247937481372256502560"
+    "hash": "1771666983195198680614983471265562396840"
   },
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::slice_end_index_len_fail",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/slice/index.rs",
@@ -35243,12 +35243,12 @@
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::slice_index_order_fail",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/slice/index.rs",
     "func": "slice::index::slice_start_index_len_fail",
-    "hash": "44711849404336985174606327610078404504"
+    "hash": "8122113097909839353660388256140577054"
   },
   {
     "file": "core/src/slice/index.rs",
@@ -35258,362 +35258,362 @@
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_advance_back_by",
-    "hash": "139960570267927240949348611761291084600"
+    "hash": "861193825345109948813089720648972906787"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_advance_by",
-    "hash": "1309057817691988006314702262891804976375"
+    "hash": "1670778179932011792813442940843828855245"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_as_ref",
-    "hash": "926682556241345506312163051434323132390"
+    "hash": "9959386809164438754797650497697958472"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_as_slice",
-    "hash": "1457065977724398083810289303087822832423"
+    "hash": "607366646519643514715930887699507572765"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_clone",
-    "hash": "1801947897244010041016543399008262150851"
+    "hash": "1160937473463700776216317998509853696780"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_count",
-    "hash": "1591515875709101590312754828776990510810"
+    "hash": "182686006598902093643207213533348293157"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_default",
-    "hash": "999083644885064169115198293980768460653"
+    "hash": "689024262283676454414806378541386781005"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_is_empty",
-    "hash": "6152498103849136889231032234458312146"
+    "hash": "139415941370266500607062419504683539775"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_len",
-    "hash": "39436383385921255449727394145828152670"
+    "hash": "77724262875764785311901059060696383431"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_new_iter",
-    "hash": "717135312299404984711624214677278132006"
+    "hash": "1106710886555791049713863830344245152268"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_next",
-    "hash": "4681238577650917222198948418260165679"
+    "hash": "1691512815652815021212302328761377296155"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_next_back",
-    "hash": "48781245646140790805774892762785351587"
+    "hash": "9986036763406714986274905766326357648"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_next_back_unchecked",
-    "hash": "15484039302876695458294835233151522666"
+    "hash": "181362399571023939208041318317975875458"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_nth",
-    "hash": "383362540475024558213313487005848360199"
+    "hash": "121448260041314614938788524596520728159"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_nth_back",
-    "hash": "115696503967776524089359898980160257142"
+    "hash": "1408277060550888397813794247984973571811"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_post_inc_start",
-    "hash": "1177562694201273835618163304661684189682"
+    "hash": "1579413168559714474012705852940355797207"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_pre_dec_end",
-    "hash": "61650113099800051494069438331221682505"
+    "hash": "14239161467851783514822119025666694103"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_char::check_size_hint",
-    "hash": "50662908790258032158359469751450748909"
+    "hash": "171216423171719021369467889126263287165"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_advance_back_by",
-    "hash": "40133445456369299273071626533770585779"
+    "hash": "1049285573602063975816299047434095817555"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_advance_by",
-    "hash": "651601209045912102715255523964833114571"
+    "hash": "437002137551840210015902403996207033731"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_as_ref",
-    "hash": "21909695368713357817695612970568892482"
+    "hash": "117572879190878403071879571059698923651"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_as_slice",
-    "hash": "528855900097586767710511857051576579181"
+    "hash": "980826399823350586512484238862321607659"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_clone",
-    "hash": "9846246607643053052789514921044984464"
+    "hash": "67093496659591607741578583704856335341"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_count",
-    "hash": "1653045920412370033015300333939554489388"
+    "hash": "105402093155095829192918972706724925533"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_default",
-    "hash": "1075998351906562772214479322133016367350"
+    "hash": "112298455367248753925305453929243918302"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_is_empty",
-    "hash": "102410585837662610115950926803305843021"
+    "hash": "1185895448689024974015149068870592553029"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_len",
-    "hash": "95715431604472015283308187542587460840"
+    "hash": "28939706369634289165941647701748045538"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_new_iter",
-    "hash": "1285913759582449692515380058014953662571"
+    "hash": "1087450656947339622912765726781414566543"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_next",
-    "hash": "84957580405337021201365146694210507223"
+    "hash": "37313375997344997746498023848647067728"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_next_back",
-    "hash": "85482122169895572032068531101973228073"
+    "hash": "236664686667593662110365496336110526255"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_next_back_unchecked",
-    "hash": "167466966316312125512869932547839091433"
+    "hash": "1444489025968958098510295303769005401376"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_nth",
-    "hash": "1545202723736073001917396090090063670479"
+    "hash": "325039137557135876910179121162131639917"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_nth_back",
-    "hash": "15637158173136528171813495242114393286"
+    "hash": "154424749971734828318751321680996551460"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_post_inc_start",
-    "hash": "112747279063842800792257971646037800721"
+    "hash": "1616096750031092521610002185566130323499"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_pre_dec_end",
-    "hash": "1366170040786291903816059907629628071342"
+    "hash": "2672411955581529994740371058722054295"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_tup::check_size_hint",
-    "hash": "1088443821154933739617417714295520323034"
+    "hash": "9699979090301776414276302173311815806"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_advance_back_by",
-    "hash": "1192930982506545955415193187031921424780"
+    "hash": "702932305369103779817545920429915750735"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_advance_by",
-    "hash": "130067916773912073253886266873492517556"
+    "hash": "169664169634698344735561345216925582327"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_as_ref",
-    "hash": "150589989357585482237959232499075949290"
+    "hash": "144168449965293851717297037097010227984"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_as_slice",
-    "hash": "92599835409257960659625250199070740313"
+    "hash": "101420683250954631914211182879830547253"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_clone",
-    "hash": "1634310256637752416313360944456084972461"
+    "hash": "411129120005459309014805765740285704614"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_count",
-    "hash": "381309416641930447611150968155017654670"
+    "hash": "1673756569186294725167491445006872017"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_default",
-    "hash": "128779033045629232487927283503240826997"
+    "hash": "920793844495442519116442691044500546405"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_is_empty",
-    "hash": "97888119244611737003840594663805266788"
+    "hash": "1031106772079892408611873317942952288342"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_len",
-    "hash": "687367853629764229016655893279991307868"
+    "hash": "100700875500503558915463314157098448882"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_new_iter",
-    "hash": "54041149948734222331988398625368841087"
+    "hash": "26090114237370722466708667347746968499"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_next",
-    "hash": "15591669200241625746387550828422683912"
+    "hash": "3272200516801177579860716317359749912"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_next_back",
-    "hash": "995890544020765136617119862460993837548"
+    "hash": "144970422038065862193607669127509861875"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_next_back_unchecked",
-    "hash": "14927074434639219618962930259053910399"
+    "hash": "175668192865300339488956421570897967378"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_nth",
-    "hash": "1331049345454030817616498914778015109179"
+    "hash": "95261538399817912371018138249387025081"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_nth_back",
-    "hash": "1203911415862282050914618578822457764875"
+    "hash": "482996177165052312810211115389576048710"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_post_inc_start",
-    "hash": "43437479158756851533311982826149103324"
+    "hash": "14442271044432101054230574576855060467"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_pre_dec_end",
-    "hash": "117350661952814726778298880806192145512"
+    "hash": "701201682874368826814637929995934274484"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_u8::check_size_hint",
-    "hash": "1452105519273497474711829791337138400260"
+    "hash": "1986195812432982307292979577292384340"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_advance_back_by",
-    "hash": "1319450465175723836714042634788934357650"
+    "hash": "59289172209692140598859425130274691571"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_advance_by",
-    "hash": "38748746669302612081496362059625460674"
+    "hash": "250751627071467107910051017301624274108"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_as_ref",
-    "hash": "1646840197862046133916036597784351519646"
+    "hash": "321753956908508752018055215308702696394"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_as_slice",
-    "hash": "54568006866825903489764784701601980103"
+    "hash": "166658351717011667126562228530403172939"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_clone",
-    "hash": "291579395175806939216167472074302694966"
+    "hash": "1143834142215882653916994141189293130237"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_count",
-    "hash": "112326932004283389794052149170527957029"
+    "hash": "976329539027784433516201922970075153385"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_default",
-    "hash": "15810731937134161356285501472461242442"
+    "hash": "137570939972685296873655141484901584115"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_is_empty",
-    "hash": "932691234413829325112747602551700290377"
+    "hash": "52895370479884907428549925094184928388"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_len",
-    "hash": "67515536971943221611815665861176245040"
+    "hash": "69433295534060245163690722234188956908"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_new_iter",
-    "hash": "1107343495967724937810712244816181142863"
+    "hash": "1363526272758237287610468468160399725276"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_next",
-    "hash": "137024524549345782609646547294141104007"
+    "hash": "714695668838906455815869473572060304162"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_next_back",
-    "hash": "377559293388697150516857112865751977461"
+    "hash": "163339030084672594421668058425984523499"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_next_back_unchecked",
-    "hash": "533750375490703866517399809458989611606"
+    "hash": "127686565998432334901061870083221359013"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_nth",
-    "hash": "4840223071120913377508715957732269887"
+    "hash": "957056633302437535015239756775690006328"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_nth_back",
-    "hash": "952746216976093671410410461366422685604"
+    "hash": "992938715268404881713353799456534831407"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_post_inc_start",
-    "hash": "147949041401349756155676307937369275603"
+    "hash": "34937320527431234211610005773948152242"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_pre_dec_end",
-    "hash": "164834321415149450095472617281390396901"
+    "hash": "125505802153987241316572113726374312358"
   },
   {
     "file": "core/src/slice/iter.rs",
     "func": "slice::iter::verify::verify_unit::check_size_hint",
-    "hash": "45193465255649134785767519228476047437"
+    "hash": "356765650748154173312519680647704146175"
   },
   {
     "file": "core/src/slice/memchr.rs",
@@ -35628,7 +35628,7 @@
   {
     "file": "core/src/slice/mod.rs",
     "func": "slice::<impl [T]>::copy_from_slice::len_mismatch_fail",
-    "hash": "488069662088004350112809738995584756183"
+    "hash": "403467134703471832816686528817990508081"
   },
   {
     "file": "core/src/slice/sort/shared/smallsort.rs",
@@ -35733,12 +35733,12 @@
   {
     "file": "core/src/str/pattern.rs",
     "func": "str::pattern::verify::check_small_slice_eq",
-    "hash": "135563978378385492726666353229377330358"
+    "hash": "845149562119932975814861053783379673808"
   },
   {
     "file": "core/src/str/pattern.rs",
     "func": "str::pattern::verify::check_small_slice_eq_empty",
-    "hash": "102185519891892527487327436954428029777"
+    "hash": "33048801839369517641966645982641812300"
   },
   {
     "file": "core/src/str/traits.rs",
@@ -35773,7 +35773,7 @@
   {
     "file": "core/src/str/validations.rs",
     "func": "str::validations::verify::check_run_utf8_validation",
-    "hash": "131730157332688882848860392945491271156"
+    "hash": "1123572387366226396713103407163803214385"
   },
   {
     "file": "core/src/sync/atomic.rs",
@@ -35953,12 +35953,12 @@
   {
     "file": "core/src/task/wake.rs",
     "func": "task::wake::LocalWaker::noop",
-    "hash": "123723638901198696813404341783633870945"
+    "hash": "472764338886095420117228579050597462206"
   },
   {
     "file": "core/src/task/wake.rs",
     "func": "task::wake::Waker::noop",
-    "hash": "1743661486992008159612291404162607195897"
+    "hash": "127674890129135189316270498950318572654"
   },
   {
     "file": "core/src/time.rs",
@@ -35968,52 +35968,52 @@
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Add>::add",
-    "hash": "109742324320271269815219537898058338298"
+    "hash": "158701123428408317577826621080364987225"
   },
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Div<u32>>::div",
-    "hash": "403531840734294633314980331633988740429"
+    "hash": "600791011295372228187675651585982260"
   },
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Mul<u32>>::mul",
-    "hash": "1576331431798425232510190777423442331905"
+    "hash": "27293571358936313059362992893665172166"
   },
   {
     "file": "core/src/time.rs",
     "func": "<time::Duration as ops::arith::Sub>::sub",
-    "hash": "161313175365211766514626638849314671494"
+    "hash": "164576193882935509069664220587060101994"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::<impl ops::arith::Mul<time::Duration> for u32>::mul",
-    "hash": "917258847654041938512616888458549365289"
+    "hash": "17556818814875381251599312119355152158"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::abs_diff",
-    "hash": "1190008920955027549414558268300920333450"
+    "hash": "26869045586565505132860040768134625332"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_add",
-    "hash": "19569297159615508031460179401882422644"
+    "hash": "14110580735580096177824659522826889201"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_div",
-    "hash": "334853331962763434511377330919294441838"
+    "hash": "1674337126137678817717862049789526749597"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_mul",
-    "hash": "1270957039126496278514773072002857684554"
+    "hash": "337837089598643960014907234987613046925"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::checked_sub",
-    "hash": "122792719157580155476280973011202309986"
+    "hash": "70865920824769009197052802876233687335"
   },
   {
     "file": "core/src/time.rs",
@@ -36028,12 +36028,12 @@
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::div_f32",
-    "hash": "86647618178726140729405028356674242646"
+    "hash": "991611201474977183716339654034856696260"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::div_f64",
-    "hash": "45140018449145166078195067686606542123"
+    "hash": "521199485861330628012445971557357911846"
   },
   {
     "file": "core/src/time.rs",
@@ -36073,12 +36073,12 @@
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::from_secs_f32",
-    "hash": "755374780160847799017297064596369900573"
+    "hash": "79953099556852880634104146821471070147"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::from_secs_f64",
-    "hash": "157098851599913139475304395198967799945"
+    "hash": "99203238549934975001889106857293051325"
   },
   {
     "file": "core/src/time.rs",
@@ -36088,167 +36088,167 @@
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::mul_f32",
-    "hash": "75587386486920788356952843106278193889"
+    "hash": "633296327890070211511164033577046143021"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::mul_f64",
-    "hash": "501462466641100985316509253437372271713"
+    "hash": "64855093171223787853089307102977884588"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::new",
-    "hash": "5314983784721758121573985092525882477"
+    "hash": "560522362222698302817024915517888048336"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::saturating_add",
-    "hash": "1029381576398734859717662111519589594169"
+    "hash": "1547215013632414454413365255356869872002"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::saturating_mul",
-    "hash": "353792515781400462011652680312911991039"
+    "hash": "71591559019619054646505433053580302677"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::saturating_sub",
-    "hash": "955154698754365405413054881827955123528"
+    "hash": "962111426188525602715302185202801398846"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::try_from_secs_f32",
-    "hash": "386430803346235433011304754245099095304"
+    "hash": "1582323221010237901714486768599657871333"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::Duration::try_from_secs_f64",
-    "hash": "14064064061827562397635626926479232189"
+    "hash": "18512181781032176776757738709236962485"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_micros",
-    "hash": "143953371308447061659784409087493907282"
+    "hash": "149093069380090186064889193936681303234"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_micros_panics",
-    "hash": "9197717600921742818967999055434397761"
+    "hash": "49891574261553285984430708039934748357"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_millis",
-    "hash": "99392989396211020877677722409414049596"
+    "hash": "13786368735983730972471376445803054052"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_millis_panics",
-    "hash": "1593278298721129871617653804794223874262"
+    "hash": "62619583459878820716346327000009655763"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_nanos",
-    "hash": "1806822829692306929717239395562314381902"
+    "hash": "68819276793716182326503000090355799216"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_nanos_panics",
-    "hash": "134604422389350977679384184753437665474"
+    "hash": "542845243352908423117324499414075789715"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_secs",
-    "hash": "373619136652708307018265044138944864523"
+    "hash": "5124225600452617824401242139010956964"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_as_secs_panics",
-    "hash": "56474447501295750765405004511393428398"
+    "hash": "152243306181619088014145311057851070885"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_add",
-    "hash": "11447966089483765022807339094687920146"
+    "hash": "854180375907274312913263058568331260770"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_add_panics",
-    "hash": "644645159158315310614394451212035857170"
+    "hash": "714539158972310775713321826258624352287"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_div",
-    "hash": "53602273988008304331556382325686351072"
+    "hash": "12863549432509954683707449835503794134"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_div_panics",
-    "hash": "175652462245910622887369578424722772339"
+    "hash": "78722486372969621035259149031912550398"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_mul",
-    "hash": "137256341125787148005413434917162888699"
+    "hash": "342740270554854368616262675168036682043"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_mul_panics",
-    "hash": "37145406260111199889768642749294627695"
+    "hash": "53356829868975264417640421784527349419"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_sub",
-    "hash": "107644569654009206394816251043042500694"
+    "hash": "32660496354749046278117605202571355710"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_checked_sub_panics",
-    "hash": "66129356364066244212301479442248630176"
+    "hash": "66745367161425907209301882029246274821"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_new",
-    "hash": "16125700201101227386931667241377527911"
+    "hash": "89999717233790311152470293408479500196"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_new_panics",
-    "hash": "4195069762151724680317974427567166315"
+    "hash": "92204770616426725348141117855773055190"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_micros",
-    "hash": "70444258993380352033891107648014694533"
+    "hash": "124542813381046865364324865071312233462"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_micros_panics",
-    "hash": "595907716407018342613999463254189158545"
+    "hash": "13699179572696318451943951031996287658"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_millis",
-    "hash": "648131215881160634713073108173378238934"
+    "hash": "25365135789972253982668083183709491160"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_millis_panics",
-    "hash": "1529855138608294633216544210767884400444"
+    "hash": "53271462925618174268302956934064433274"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_nanos",
-    "hash": "164594633053227258477594578482098098154"
+    "hash": "975607428530403251816816470521958393925"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::duration_subsec_nanos_panics",
-    "hash": "129736479618869443411201141038012545220"
+    "hash": "943327031114386412717270220480752432841"
   },
   {
     "file": "core/src/time.rs",
     "func": "time::duration_verify::safe_duration",
-    "hash": "12880020053050264589197180469100900669"
+    "hash": "33189514496080489196197566224046525581"
   },
   {
     "file": "core/src/ub_checks.rs",
@@ -37715,7 +37715,7 @@
   {
     "file": "core/src/unicode/printable.rs",
     "func": "unicode::printable::is_printable",
-    "hash": "640233528153813131516715235621471926179"
+    "hash": "50462956522701923657823589723870492229"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
@@ -37730,42 +37730,42 @@
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::alphabetic::lookup",
-    "hash": "114458833989842083205671944971070948398"
+    "hash": "1329015468907602524117083160396805892343"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::case_ignorable::lookup",
-    "hash": "53200597786092391798658450461828367879"
+    "hash": "365548638339558431716578712691189055424"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::cased::lookup",
-    "hash": "432350275258755412415097868397067490816"
+    "hash": "1133486143322644225915808852324512329988"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::cc::lookup",
-    "hash": "1358015945398825292616134865526974975293"
+    "hash": "179845081358912699686376826600196648065"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::conversions::to_lower",
-    "hash": "154059837774755195014293174670994181866"
+    "hash": "622117423559617959813585461945945237420"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::conversions::to_upper",
-    "hash": "173512665571503271513550006003881530964"
+    "hash": "874420712690310273518316387036755391415"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::grapheme_extend::lookup",
-    "hash": "43050873062878551877287422371794203678"
+    "hash": "1780284020915414009117013684329460414574"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::grapheme_extend::lookup_slow",
-    "hash": "115802730984523368611435159107397426916"
+    "hash": "33585099156603560377688831177654593693"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",
@@ -37775,7 +37775,7 @@
   {
     "file": "core/src/unicode/unicode_data.rs",
     "func": "unicode::unicode_data::n::lookup",
-    "hash": "389801549401587616013799007575789122504"
+    "hash": "440816291901984389416241033179272663674"
   },
   {
     "file": "core/src/unicode/unicode_data.rs",


### PR DESCRIPTION
This PR updates submodules, rust toolchain, and test snapshots:
* kani: b64e59de6 -> 12386811f
* verify-rust-std: e021729236f -> a914785e79c0
* rust toolchain: nightly-2025-06-17 -> nightly-2025-07-02